### PR TITLE
Update docker.md - fix docker run image

### DIFF
--- a/getting-started/containers/docker.md
+++ b/getting-started/containers/docker.md
@@ -14,7 +14,7 @@ This image hosts an ASP.NET Core application that runs both as an Elsa Server as
 
 ```bash
 docker pull elsaworkflows/elsa-server-and-studio-v3-3-0-preview:latest
-docker run -t -i -e ASPNETCORE_ENVIRONMENT='Development' -e HTTP_PORTS=8080 -e HTTP__BASEURL=http://localhost:13000 -p 13000:8080 elsaworkflows/elsa-server-and-studio-v3:latest
+docker run -t -i -e ASPNETCORE_ENVIRONMENT='Development' -e HTTP_PORTS=8080 -e HTTP__BASEURL=http://localhost:13000 -p 13000:8080 elsaworkflows/elsa-server-and-studio-v3-3-0-preview:latest
 ```
 
 When the container has started, open a web browser and navigate to [http://localhost:13000](http://localhost:13000/). On the login screen, enter the following credentials:
@@ -30,7 +30,7 @@ This image hosts an ASP.NET Core application that runs as an Elsa Server. To run
 
 ```bash
 docker pull elsaworkflows/elsa-server-v3-3-0-preview:latest
-docker run -t -i -e ASPNETCORE_ENVIRONMENT=Development -e HTTP_PORTS=8080 -e HTTP__BASEURL=http://localhost:13000 -p 13000:8080 elsaworkflows/elsa-server-v3:latest
+docker run -t -i -e ASPNETCORE_ENVIRONMENT=Development -e HTTP_PORTS=8080 -e HTTP__BASEURL=http://localhost:13000 -p 13000:8080 elsaworkflows/elsa-server-v3-3-0-preview:latest
 ```
 
 When the container has started, open a web browser and navigate to [http://localhost:13000](http://localhost:13000/).
@@ -43,7 +43,7 @@ This image hosts an ASP.NET Core application that runs Elsa Studio. To run the c
 
 ```bash
 docker pull elsaworkflows/elsa-studio-v3-3-0-preview:latest
-docker run -t -i -e ASPNETCORE_ENVIRONMENT='Development' -e HTTP_PORTS=8080 -e ELSASERVER__URL=http://localhost:13000/elsa/api -p 14000:8080 elsaworkflows/elsa-studio-v3:latest
+docker run -t -i -e ASPNETCORE_ENVIRONMENT='Development' -e HTTP_PORTS=8080 -e ELSASERVER__URL=http://localhost:13000/elsa/api -p 14000:8080 elsaworkflows/elsa-studio-v3-3-0-preview:latest
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
It's not clear why we do a pull of one image, then run a different image.

It results in two images being downloaded:

```shell
❯ docker pull elsaworkflows/elsa-server-and-studio-v3-3-0-preview:latest
latest: Pulling from elsaworkflows/elsa-server-and-studio-v3-3-0-preview
d51c377d94da: Pull complete 
570895edc796: Pull complete 
...

❯ docker run -t -i -e ASPNETCORE_ENVIRONMENT='Development' -e HTTP_PORTS=8080 -e HTTP__BASEURL=http://localhost:13000 -p 13000:8080 elsaworkflows/elsa-server-and-studio-v3:latest
Unable to find image 'elsaworkflows/elsa-server-and-studio-v3:latest' locally
latest: Pulling from elsaworkflows/elsa-server-and-studio-v3
ea235d1ccf77: Pull complete 
7247c1ec1d56: Pull complete
...
```

The change I propose aligns with the images used in the [docker-compose docs](https://docs.elsaworkflows.io/getting-started/containers/docker-compose/elsa-server-+-studio).