### PR TITLE
Added deprecation warning for 'blazorwasm-empty' template

### DIFF
--- a/application-types/elsa-studio.md
+++ b/application-types/elsa-studio.md
@@ -19,6 +19,14 @@ To setup Elsa Studio, we'll go through the following steps:
     ```bash
     dotnet new blazorwasm-empty -n "ElsaStudioBlazorWasm"
     ```
+    {% hint style="warning" %}
+    **Deprecation warning**
+
+    The `blazorwasm-empty` template is [dicontinued since .NET 8.0](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates).
+    If you are using .NET 8.0+, you can just use `blazorwasm` instead of `blazorwasm-empty`.
+    {% endhint %}
+
+    
 2.  **Add Elsa Studio Packages**
 
     Navigate to the root directory of your project and integrate the following Elsa Studio packages:


### PR DESCRIPTION
The `blazorwasm-empty` template is [dicontinued since .NET 8.0](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates).
For .NET 8.0+, just use `blazorwasm` instead of `blazorwasm-empty`.

Should this be shown as a warning, or should I just edit the recommended command in the first place? To make it more beginner-friendly (who might be new to .NET, and use 8.0+).