### PR TITLE
Added `MainLayout.razor.css` as item to remove

### DIFF
--- a/application-types/elsa-studio.md
+++ b/application-types/elsa-studio.md
@@ -91,6 +91,7 @@ To setup Elsa Studio, we'll go through the following steps:
     * Pages
     * App.razor
     * MainLayout.razor
+    * MainLayout.razor.css
     * \_Imports.razor
 5.  **Generate appsettings.json**
 


### PR DESCRIPTION
If not removed, it could cause error:

Layout\MainLayout.razor.css : error BLAZOR102: The scoped css file 'Layout\MainLayout.razor.css' was defined but no associated razor component or view was found for it.

![image](https://github.com/user-attachments/assets/ec6fed26-846c-4f05-8e2a-63bfeb0b247f)
