### PR TITLE
Added `Elsa.Studio.Models` directive

### DIFF
--- a/application-types/elsa-studio.md
+++ b/application-types/elsa-studio.md
@@ -42,6 +42,7 @@ To setup Elsa Studio, we'll go through the following steps:
     using Elsa.Studio.Shell.Extensions;
     using Elsa.Studio.Workflows.Extensions;
     using Elsa.Studio.Contracts;
+    using Elsa.Studio.Models;
     using Elsa.Studio.Core.BlazorWasm.Extensions;
     using Elsa.Studio.Extensions;
     using Elsa.Studio.Login.BlazorWasm.Extensions;


### PR DESCRIPTION
If not added, it would show error:

~\ElsaStudioBlazorWasm\Program.cs(24,28): error CS0246: The type or namespace name 'BackendApiConfig' could not be found (are you missing a using directive or an assembly reference?)

The build failed. Fix the build errors and run again.

![image](https://github.com/user-attachments/assets/bcc7a748-5301-4d1a-9519-f209bd271882)
