### PR TITLE
Update elsa-server-+-studio-wasm.md

### DIFF
--- a/application-types/elsa-server-+-studio-wasm.md
+++ b/application-types/elsa-server-+-studio-wasm.md
@@ -32,7 +32,7 @@ dotnet new web -n "ElsaServer"
 dotnet sln add ElsaServer/ElsaServer.csproj
 
 # Create the client project
-dotnet new blazorwasm-empty -n "ElsaStudio"
+dotnet new blazorwasm -n "ElsaStudio"
 
 # Add the client project to the solution
 dotnet sln add ElsaStudio/ElsaStudio.csproj


### PR DESCRIPTION
Replaced deprecated 'blazorwasm-empty' template with 'blazorwasm' as the former is no longer available in recent .NET SDK versions.