### PR TITLE
Fix command syntax for adding JavaScript package

### DIFF
--- a/expressions/javascript.md
+++ b/expressions/javascript.md
@@ -13,7 +13,7 @@ When creating workflows, you'll often need to write dynamic expressions. This pa
 The JavaScript Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.JavaScript
+dotnet add package Elsa.JavaScript
 ```
 
 You can enable the feature as follows:


### PR DESCRIPTION
This is not valid syntax for adding a package to a dotnet project.  This is an easy fix.