### PR TITLE
Add Elsa.Identity package to Elsa Studio setup

### DIFF
--- a/application-types/elsa-studio.md
+++ b/application-types/elsa-studio.md
@@ -38,6 +38,7 @@ If you are using .NET 8.0+, you can just use `blazorwasm` instead of `blazorwasm
     dotnet add package Elsa.Studio
     dotnet add package Elsa.Studio.Core.BlazorWasm
     dotnet add package Elsa.Studio.Login.BlazorWasm
+    dotnet add package Elsa.Identity
     dotnet add package Elsa.Api.Client
     ```
 3.  **Modify Program.cs**


### PR DESCRIPTION
The main program in step 3 uses `builder.Services.UseElsaIdentity()`, which lives in `Elsa.Identity` and doesn't seem to be a dependency of any of the other packages.