### PR TITLE
Update docs for Elsa 3.6.0 package renames

### DIFF
--- a/application-types/elsa-server-+-studio-wasm.md
+++ b/application-types/elsa-server-+-studio-wasm.md
@@ -54,15 +54,15 @@ In this chapter, we will setup the host, which will host both the Elsa Server en
 
     ```bash
     dotnet add package Elsa
-    dotnet add package Elsa.EntityFrameworkCore
-    dotnet add package Elsa.EntityFrameworkCore.Sqlite
+    dotnet add package Elsa.Persistence.EFCore
+    dotnet add package Elsa.Persistence.EFCore.Sqlite
     dotnet add package Elsa.Http
     dotnet add package Elsa.Identity
     dotnet add package Elsa.Scheduling
     dotnet add package Elsa.Workflows.Api
-    dotnet add package Elsa.CSharp
-    dotnet add package Elsa.JavaScript
-    dotnet add package Elsa.Liquid
+    dotnet add package Elsa.Expressions.CSharp
+    dotnet add package Elsa.Expressions.JavaScript
+    dotnet add package Elsa.Expressions.Liquid
     dotnet add package Microsoft.AspNetCore.Components.WebAssembly.Server
     ```
 2.  **Update Program.cs**
@@ -72,9 +72,9 @@ In this chapter, we will setup the host, which will host both the Elsa Server en
     **Program.cs**
 
     ```csharp
-    using Elsa.EntityFrameworkCore.Extensions;
-    using Elsa.EntityFrameworkCore.Modules.Management;
-    using Elsa.EntityFrameworkCore.Modules.Runtime;
+    using Elsa.Persistence.EFCore.Extensions;
+    using Elsa.Persistence.EFCore.Modules.Management;
+    using Elsa.Persistence.EFCore.Modules.Runtime;
     using Elsa.Extensions;
     using Microsoft.AspNetCore.Mvc;
 

--- a/application-types/elsa-server.md
+++ b/application-types/elsa-server.md
@@ -32,16 +32,16 @@ The following is a step-by-step guide to setting up a new ASP.NET Core Web Appli
 
     ```bash
     dotnet add package Elsa
-    dotnet add package Elsa.EntityFrameworkCore
-    dotnet add package Elsa.EntityFrameworkCore.Sqlite
+    dotnet add package Elsa.Persistence.EFCore
+    dotnet add package Elsa.Persistence.EFCore.Sqlite
     dotnet add package Elsa.Http
     dotnet add package Elsa.Identity
     dotnet add package Elsa.Scheduling
     dotnet add package Elsa.Workflows.Api
-    dotnet add package Elsa.CSharp
+    dotnet add package Elsa.Expressions.CSharp
     dotnet add package Elsa.Http
-    dotnet add package Elsa.JavaScript
-    dotnet add package Elsa.Liquid
+    dotnet add package Elsa.Expressions.JavaScript
+    dotnet add package Elsa.Expressions.Liquid
     ```
 4.  We need to add some code to make our server work. Open the `Program.cs` file in your project and replace its contents with the code provided below. This code does a lot of things like setting up database connections, enabling user authentication, and preparing the server to handle workflows.
 
@@ -49,9 +49,9 @@ The following is a step-by-step guide to setting up a new ASP.NET Core Web Appli
     **Program.cs**
 
     ```csharp
-    using Elsa.EntityFrameworkCore.Extensions;
-    using Elsa.EntityFrameworkCore.Modules.Management;
-    using Elsa.EntityFrameworkCore.Modules.Runtime;
+    using Elsa.Persistence.EFCore.Extensions;
+    using Elsa.Persistence.EFCore.Modules.Management;
+    using Elsa.Persistence.EFCore.Modules.Runtime;
     using Elsa.Extensions;
 
     var builder = WebApplication.CreateBuilder(args);

--- a/docs/meta/core-concepts.md
+++ b/docs/meta/core-concepts.md
@@ -211,7 +211,7 @@ Based on the namespace structure, Elsa Core is organized into several layers:
 - Import/export functionality
 - API endpoints
 
-### Persistence (`Elsa.EntityFrameworkCore`, `Elsa.MongoDb`, etc.)
+### Persistence (`Elsa.Persistence.EFCore`, `Elsa.MongoDb`, etc.)
 - Storage abstractions and implementations
 - Entity Framework Core providers
 - MongoDB providers

--- a/expressions/c.md
+++ b/expressions/c.md
@@ -13,7 +13,7 @@ When creating workflows, you'll often need to write dynamic expressions. This pa
 The C# Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.CSharp
+dotnet package add Elsa.Expressions.CSharp
 ```
 
 You can enable the feature as follows:

--- a/expressions/c.md
+++ b/expressions/c.md
@@ -13,7 +13,7 @@ When creating workflows, you'll often need to write dynamic expressions. This pa
 The C# Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.Expressions.CSharp
+dotnet add package Elsa.Expressions.CSharp
 ```
 
 You can enable the feature as follows:

--- a/expressions/javascript.md
+++ b/expressions/javascript.md
@@ -13,7 +13,7 @@ When creating workflows, you'll often need to write dynamic expressions. This pa
 The JavaScript Expressions feature is provided by the following package:
 
 ```bash
-dotnet add package Elsa.JavaScript
+dotnet add package Elsa.Expressions.JavaScript
 ```
 
 You can enable the feature as follows:

--- a/expressions/liquid.md
+++ b/expressions/liquid.md
@@ -11,7 +11,7 @@ Elsa uses the [Fluid library](https://github.com/sebastienros/fluid) to implemen
 The Liquid Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.Liquid
+dotnet package add Elsa.Expressions.Liquid
 ```
 
 You can enable the feature as follows:

--- a/expressions/liquid.md
+++ b/expressions/liquid.md
@@ -11,7 +11,7 @@ Elsa uses the [Fluid library](https://github.com/sebastienros/fluid) to implemen
 The Liquid Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.Expressions.Liquid
+dotnet add package Elsa.Expressions.Liquid
 ```
 
 You can enable the feature as follows:

--- a/expressions/python.md
+++ b/expressions/python.md
@@ -108,7 +108,7 @@ Refer to the [Pythonnet GitHub project](https://github.com/pythonnet/pythonnet) 
 The Python Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.Python
+dotnet package add Elsa.Expressions.Python
 ```
 
 You can enable the feature as follows:

--- a/expressions/python.md
+++ b/expressions/python.md
@@ -108,7 +108,7 @@ Refer to the [Pythonnet GitHub project](https://github.com/pythonnet/pythonnet) 
 The Python Expressions feature is provided by the following package:
 
 ```bash
-dotnet package add Elsa.Expressions.Python
+dotnet add package Elsa.Expressions.Python
 ```
 
 You can enable the feature as follows:

--- a/extensibility/custom-activities.md
+++ b/extensibility/custom-activities.md
@@ -286,7 +286,7 @@ In this scenario, we use a simple C# delegate expression to dynamically determin
 Alternatively, other installed expression provider syntaxes, such as JavaScript, can be used:
 
 ```csharp
-using Elsa.JavaScript.Models;
+using Elsa.Expressions.JavaScript.Models;
 using Elsa.Workflows;
 using Elsa.Workflows.Contracts;
 
@@ -1306,7 +1306,7 @@ builder.Services.AddScoped<IPaymentService, PaymentService>();
 Here's a complete example showing activity registration in `Program.cs`:
 
 ```csharp
-using Elsa.EntityFrameworkCore.Extensions;
+using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/getting-started/database-configuration.md
+++ b/getting-started/database-configuration.md
@@ -32,7 +32,7 @@ By default, Elsa uses SQLite for development scenarios. For production deploymen
 
 ```bash
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Elsa.EntityFrameworkCore.SqlServer
+dotnet add package Elsa.Persistence.EFCore.SqlServer
 ```
 
 2. **Replace `UseSqlite()` with `UseSqlServer()`** in your `Program.cs`:
@@ -68,7 +68,7 @@ For more detailed information about persistence strategies, connection pooling, 
 
 ```bash
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Elsa.EntityFrameworkCore.SqlServer
+dotnet add package Elsa.Persistence.EFCore.SqlServer
 ```
 
 ### 2. Configure Services
@@ -104,7 +104,7 @@ Add to `appsettings.json`:
 
 ```bash
 dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
-dotnet add package Elsa.EntityFrameworkCore.PostgreSQL
+dotnet add package Elsa.Persistence.EFCore.PostgreSql
 ```
 
 ### 2. Configure Services

--- a/guides/architecture/README.md
+++ b/guides/architecture/README.md
@@ -245,12 +245,12 @@ Elsa Workflows v3
 | **Elsa.Workflows.Core**      | Core workflow engine, activities, and abstractions          |
 | **Elsa.Workflows.Runtime**   | Runtime services for execution, persistence, and management |
 | **Elsa**                     | Meta-package that includes commonly needed packages         |
-| **Elsa.EntityFrameworkCore** | EF Core persistence providers                               |
+| **Elsa.Persistence.EFCore** | EF Core persistence providers                               |
 | **Elsa.Http**                | HTTP activities and triggers                                |
 | **Elsa.MassTransit**         | Message bus integration                                     |
-| **Elsa.JavaScript**          | JavaScript expression evaluator                             |
-| **Elsa.CSharp**              | C# expression evaluator                                     |
-| **Elsa.Liquid**              | Liquid template expression evaluator                        |
+| **Elsa.Expressions.JavaScript**          | JavaScript expression evaluator                             |
+| **Elsa.Expressions.CSharp**              | C# expression evaluator                                     |
+| **Elsa.Expressions.Liquid**              | Liquid template expression evaluator                        |
 | **Elsa.Alterations**         | Workflow alteration and migration support                   |
 
 ## Typical Workflow Execution Flow

--- a/guides/architecture/README.md
+++ b/guides/architecture/README.md
@@ -240,18 +240,18 @@ Elsa Workflows v3
 
 ## Key Packages and Their Roles
 
-| Package                      | Purpose                                                     |
-| ---------------------------- | ----------------------------------------------------------- |
-| **Elsa.Workflows.Core**      | Core workflow engine, activities, and abstractions          |
-| **Elsa.Workflows.Runtime**   | Runtime services for execution, persistence, and management |
-| **Elsa**                     | Meta-package that includes commonly needed packages         |
-| **Elsa.Persistence.EFCore** | EF Core persistence providers                               |
-| **Elsa.Http**                | HTTP activities and triggers                                |
-| **Elsa.MassTransit**         | Message bus integration                                     |
-| **Elsa.Expressions.JavaScript**          | JavaScript expression evaluator                             |
-| **Elsa.Expressions.CSharp**              | C# expression evaluator                                     |
-| **Elsa.Expressions.Liquid**              | Liquid template expression evaluator                        |
-| **Elsa.Alterations**         | Workflow alteration and migration support                   |
+| Package                         | Purpose                                                     |
+| ------------------------------- | ----------------------------------------------------------- |
+| **Elsa.Workflows.Core**         | Core workflow engine, activities, and abstractions          |
+| **Elsa.Workflows.Runtime**      | Runtime services for execution, persistence, and management |
+| **Elsa**                        | Meta-package that includes commonly needed packages         |
+| **Elsa.Persistence.EFCore**     | EF Core persistence providers                               |
+| **Elsa.Http**                   | HTTP activities and triggers                                |
+| **Elsa.MassTransit**            | Message bus integration                                     |
+| **Elsa.Expressions.JavaScript** | JavaScript expression evaluator                             |
+| **Elsa.Expressions.CSharp**     | C# expression evaluator                                     |
+| **Elsa.Expressions.Liquid**     | Liquid template expression evaluator                        |
+| **Elsa.Alterations**            | Workflow alteration and migration support                   |
 
 ## Typical Workflow Execution Flow
 

--- a/guides/deployment/kubernetes.md
+++ b/guides/deployment/kubernetes.md
@@ -307,9 +307,9 @@ spec:
 If you're building a custom Elsa Server image, configure PostgreSQL persistence in `Program.cs`:
 
 ```csharp
-using Elsa.EntityFrameworkCore.Extensions;
-using Elsa.EntityFrameworkCore.Modules.Management;
-using Elsa.EntityFrameworkCore.Modules.Runtime;
+using Elsa.Persistence.EFCore.Extensions;
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Persistence.EFCore.Modules.Runtime;
 using Elsa.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -554,7 +554,7 @@ kubectl logs -l app=elsa-server --tail=100
 3. Check that the PostgreSQL package is included in your Docker image:
    ```dockerfile
    # In Dockerfile
-   RUN dotnet add package Elsa.EntityFrameworkCore.PostgreSql
+   RUN dotnet add package Elsa.Persistence.EFCore.PostgreSql
    ```
 
 ### Problem: Connection Refused or Timeout

--- a/guides/external-application-interaction.md
+++ b/guides/external-application-interaction.md
@@ -433,8 +433,8 @@ dotnet add package Microsoft.EntityFrameworkCore
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 dotnet add package Microsoft.EntityFrameworkCore.Design
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite.Design
-dotnet add package Elsa.EntityFrameworkCore
-dotnet add package Elsa.EntityFrameworkCore.Sqlite
+dotnet add package Elsa.Persistence.EFCore
+dotnet add package Elsa.Persistence.EFCore.Sqlite
 ```
 {% endstep %}
 

--- a/guides/integration/blazor-dashboard.md
+++ b/guides/integration/blazor-dashboard.md
@@ -100,7 +100,7 @@ dotnet add package Microsoft.AspNetCore.Components.Web
 dotnet add package Elsa
 dotnet add package Elsa.Workflows.Runtime
 dotnet add package Elsa.Workflows.Api
-dotnet add package Elsa.EntityFrameworkCore.PostgreSql  # or your chosen provider
+dotnet add package Elsa.Persistence.EFCore.PostgreSql  # or your chosen provider
 
 # Add Elsa Studio packages
 dotnet add package Elsa.Studio

--- a/guides/migration-v2-to-v3.md
+++ b/guides/migration-v2-to-v3.md
@@ -104,12 +104,12 @@ Use this checklist to track your migration progress:
 <PackageReference Include="Elsa.Workflows.Core" Version="3.x.x" />
 <PackageReference Include="Elsa.Workflows.Management" Version="3.x.x" />
 <PackageReference Include="Elsa.Workflows.Runtime" Version="3.x.x" />
-<PackageReference Include="Elsa.EntityFrameworkCore.SqlServer" Version="3.x.x" />
+<PackageReference Include="Elsa.Persistence.EFCore.SqlServer" Version="3.x.x" />
 ```
 
 **Key Changes:**
 - Consolidated packages: The `Elsa` meta-package includes `Elsa.Api.Common`, `Elsa.Mediator`, `Elsa.Workflows.Core`, `Elsa.Workflows.Management`, and `Elsa.Workflows.Runtime`
-- Persistence packages renamed: `Elsa.Persistence.*` → `Elsa.EntityFrameworkCore.*`
+- Persistence packages renamed: `Elsa.Persistence.*` → `Elsa.Persistence.EFCore.*`
 - .NET 8+ required (no longer supports .NET Standard 2.0)
 
 ### Namespace Changes
@@ -942,10 +942,10 @@ builder.Services.AddElsa(elsa =>
 
 | Provider | V2 Package | V3 Package |
 |----------|-----------|-----------|
-| SQL Server | `Elsa.Persistence.EntityFramework.SqlServer` | `Elsa.EntityFrameworkCore.SqlServer` |
-| PostgreSQL | `Elsa.Persistence.EntityFramework.PostgreSql` | `Elsa.EntityFrameworkCore.PostgreSql` |
-| MySQL | `Elsa.Persistence.EntityFramework.MySql` | `Elsa.EntityFrameworkCore.MySql` |
-| SQLite | `Elsa.Persistence.EntityFramework.Sqlite` | `Elsa.EntityFrameworkCore.Sqlite` |
+| SQL Server | `Elsa.Persistence.EntityFramework.SqlServer` | `Elsa.Persistence.EFCore.SqlServer` |
+| PostgreSQL | `Elsa.Persistence.EntityFramework.PostgreSql` | `Elsa.Persistence.EFCore.PostgreSql` |
+| MySQL | `Elsa.Persistence.EntityFramework.MySql` | `Elsa.Persistence.EFCore.MySql` |
+| SQLite | `Elsa.Persistence.EntityFramework.Sqlite` | `Elsa.Persistence.EFCore.Sqlite` |
 | MongoDB | `Elsa.Persistence.MongoDb` | `Elsa.MongoDb` |
 
 ## Background Job Scheduler
@@ -1186,7 +1186,7 @@ protected override void Execute(ActivityExecutionContext context)
 ```xml
 <!-- All packages should be version 3.x -->
 <PackageReference Include="Elsa" Version="3.5.1" />
-<PackageReference Include="Elsa.EntityFrameworkCore.SqlServer" Version="3.5.1" />
+<PackageReference Include="Elsa.Persistence.EFCore.SqlServer" Version="3.5.1" />
 ```
 
 ### 10. Trigger Activity Implementation

--- a/guides/migration-v2-to-v3.md
+++ b/guides/migration-v2-to-v3.md
@@ -109,7 +109,7 @@ Use this checklist to track your migration progress:
 
 **Key Changes:**
 - Consolidated packages: The `Elsa` meta-package includes `Elsa.Api.Common`, `Elsa.Mediator`, `Elsa.Workflows.Core`, `Elsa.Workflows.Management`, and `Elsa.Workflows.Runtime`
-- Persistence packages renamed: `Elsa.Persistence.*` → `Elsa.Persistence.EFCore.*`
+- Persistence packages renamed: `Elsa.Persistence.EntityFramework.*` → `Elsa.Persistence.EFCore.*`
 - .NET 8+ required (no longer supports .NET Standard 2.0)
 
 ### Namespace Changes
@@ -1185,8 +1185,8 @@ protected override void Execute(ActivityExecutionContext context)
 **Solution:** Ensure all Elsa packages are V3:
 ```xml
 <!-- All packages should be version 3.x -->
-<PackageReference Include="Elsa" Version="3.5.1" />
-<PackageReference Include="Elsa.Persistence.EFCore.SqlServer" Version="3.5.1" />
+<PackageReference Include="Elsa" Version="3.x.x" />
+<PackageReference Include="Elsa.Persistence.EFCore.SqlServer" Version="3.x.x" />
 ```
 
 ### 10. Trigger Activity Implementation

--- a/guides/onboarding/hosting-elsa-in-existing-app.md
+++ b/guides/onboarding/hosting-elsa-in-existing-app.md
@@ -46,19 +46,19 @@ dotnet add package Elsa.Workflows.Api
 For PostgreSQL:
 
 ```bash
-dotnet add package Elsa.EntityFrameworkCore.PostgreSql
+dotnet add package Elsa.Persistence.EFCore.PostgreSql
 ```
 
 For SQL Server:
 
 ```bash
-dotnet add package Elsa.EntityFrameworkCore.SqlServer
+dotnet add package Elsa.Persistence.EFCore.SqlServer
 ```
 
 For SQLite (development only):
 
 ```bash
-dotnet add package Elsa.EntityFrameworkCore.Sqlite
+dotnet add package Elsa.Persistence.EFCore.Sqlite
 ```
 
 ### Optional: HTTP Activities
@@ -140,9 +140,9 @@ app.Run();
 ### With Persistence (PostgreSQL Example)
 
 ```csharp
-using Elsa.EntityFrameworkCore.Extensions;
-using Elsa.EntityFrameworkCore.Modules.Management;
-using Elsa.EntityFrameworkCore.Modules.Runtime;
+using Elsa.Persistence.EFCore.Extensions;
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Persistence.EFCore.Modules.Runtime;
 using Elsa.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -349,7 +349,7 @@ Align your EF Core versions with Elsa's requirements:
   
   <!-- Elsa packages (replace x.y.z with the latest version from NuGet) -->
   <PackageReference Include="Elsa" Version="x.y.z" />
-  <PackageReference Include="Elsa.EntityFrameworkCore.PostgreSql" Version="x.y.z" />
+  <PackageReference Include="Elsa.Persistence.EFCore.PostgreSql" Version="x.y.z" />
 </ItemGroup>
 ```
 

--- a/guides/persistence/README-REFERENCES.md
+++ b/guides/persistence/README-REFERENCES.md
@@ -114,7 +114,7 @@ This document provides exact source file references in the elsa-core and elsa-ex
 
 ### EF Core Module
 
-**Path:** `src/modules/Elsa.EntityFrameworkCore/`
+**Path:** `src/modules/Elsa.Persistence.EFCore/`
 
 **Key Files:**
 - `ElsaDbContext.cs` — Base DbContext
@@ -131,9 +131,9 @@ This document provides exact source file references in the elsa-core and elsa-ex
 
 ### Database Provider Modules
 
-- `src/modules/Elsa.EntityFrameworkCore.PostgreSQL/`
-- `src/modules/Elsa.EntityFrameworkCore.SqlServer/`
-- `src/modules/Elsa.EntityFrameworkCore.Sqlite/`
+- `src/modules/Elsa.Persistence.EFCore.PostgreSql/`
+- `src/modules/Elsa.Persistence.EFCore.SqlServer/`
+- `src/modules/Elsa.Persistence.EFCore.Sqlite/`
 
 ## MongoDB
 

--- a/guides/persistence/README.md
+++ b/guides/persistence/README.md
@@ -497,7 +497,7 @@ When Elsa releases a new version with schema changes:
 
 ```bash
 dotnet add package Elsa --version 3.x.x
-dotnet add package Elsa.EntityFrameworkCore.PostgreSQL --version 3.x.x
+dotnet add package Elsa.Persistence.EFCore.PostgreSql --version 3.x.x
 ```
 
 **2. Generate Migration:**

--- a/guides/persistence/ef-migrations.md
+++ b/guides/persistence/ef-migrations.md
@@ -53,7 +53,7 @@ Elsa uses two separate `DbContext` classes to organize persistence concerns:
 
 ### Built-in Migrations
 
-Elsa ships with complete migrations that create and manage the database schema across versions. These migrations are embedded in the Elsa NuGet packages (`Elsa.EntityFrameworkCore.SqlServer`, `Elsa.EntityFrameworkCore.PostgreSQL`, etc.).
+Elsa ships with complete migrations that create and manage the database schema across versions. These migrations are embedded in the Elsa NuGet packages (`Elsa.Persistence.EFCore.SqlServer`, `Elsa.Persistence.EFCore.PostgreSql`, etc.).
 
 **Migration Naming Convention:**
 - Migrations follow a timestamped pattern: `YYYYMMDDHHMMSS_DescriptionOfChange`
@@ -488,7 +488,7 @@ When upgrading Elsa to a new version:
 **1. Update NuGet Packages:**
 ```bash
 dotnet add package Elsa --version 3.x.x
-dotnet add package Elsa.EntityFrameworkCore.SqlServer --version 3.x.x
+dotnet add package Elsa.Persistence.EFCore.SqlServer --version 3.x.x
 ```
 
 **2. Review Pending Migrations:**

--- a/guides/persistence/examples/efcore-setup.md
+++ b/guides/persistence/examples/efcore-setup.md
@@ -18,21 +18,21 @@ This document provides a minimal, copy-pasteable example for configuring Elsa Wo
 **For PostgreSQL:**
 ```bash
 dotnet add package Elsa
-dotnet add package Elsa.EntityFrameworkCore.PostgreSQL
+dotnet add package Elsa.Persistence.EFCore.PostgreSql
 dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
 ```
 
 **For SQL Server:**
 ```bash
 dotnet add package Elsa
-dotnet add package Elsa.EntityFrameworkCore.SqlServer
+dotnet add package Elsa.Persistence.EFCore.SqlServer
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 **For SQLite:**
 ```bash
 dotnet add package Elsa
-dotnet add package Elsa.EntityFrameworkCore.Sqlite
+dotnet add package Elsa.Persistence.EFCore.Sqlite
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 ```
 

--- a/guides/persistence/sql-server.md
+++ b/guides/persistence/sql-server.md
@@ -29,13 +29,13 @@ Install the required packages:
 
 ```bash
 dotnet add package Elsa
-dotnet add package Elsa.EntityFrameworkCore.SqlServer
+dotnet add package Elsa.Persistence.EFCore.SqlServer
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 ```
 
 **Package Descriptions:**
 - `Elsa` - Core Elsa Workflows library
-- `Elsa.EntityFrameworkCore.SqlServer` - SQL Server persistence provider for Elsa
+- `Elsa.Persistence.EFCore.SqlServer` - SQL Server persistence provider for Elsa
 - `Microsoft.EntityFrameworkCore.SqlServer` - Entity Framework Core SQL Server driver
 
 ## Configuration
@@ -319,11 +319,11 @@ To migrate an existing Elsa installation from SQLite to SQL Server:
 **1. Update packages:**
 ```bash
 # Remove SQLite packages
-dotnet remove package Elsa.EntityFrameworkCore.Sqlite
+dotnet remove package Elsa.Persistence.EFCore.Sqlite
 dotnet remove package Microsoft.EntityFrameworkCore.Sqlite
 
 # Add SQL Server packages
-dotnet add package Elsa.EntityFrameworkCore.SqlServer
+dotnet add package Elsa.Persistence.EFCore.SqlServer
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 ```
 

--- a/guides/plugins-modules/README-REFERENCES.md
+++ b/guides/plugins-modules/README-REFERENCES.md
@@ -62,9 +62,9 @@ Study these built-in features from elsa-core for reference:
    - Shows complex service registration and options configuration
    - Located in: `src/modules/Elsa.WorkflowManagement/Features/WorkflowManagementFeature.cs`
 
-2. **EntityFrameworkFeature** (`Elsa.EntityFrameworkCore`)
+2. **EntityFrameworkFeature** (`Elsa.Persistence.EFCore`)
    - Demonstrates database provider configuration
-   - Located in: `src/persistence/Elsa.EntityFrameworkCore/Features/EntityFrameworkFeature.cs`
+   - Located in: `src/persistence/Elsa.Persistence.EFCore/Features/EntityFrameworkFeature.cs`
 
 ## Extension Method Patterns
 
@@ -208,7 +208,7 @@ MyWorkflows.Extensions/
   <PackageReference Include="Elsa.Http" Version="3.0.*" />
   
   <!-- Optional: For entity framework -->
-  <PackageReference Include="Elsa.EntityFrameworkCore" Version="3.0.*" />
+  <PackageReference Include="Elsa.Persistence.EFCore" Version="3.0.*" />
 </ItemGroup>
 ```
 

--- a/guides/testing-debugging.md
+++ b/guides/testing-debugging.md
@@ -540,9 +540,9 @@ dotnet add package Testcontainers.RabbitMq
 ```csharp
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using Elsa.EntityFrameworkCore.Extensions;
-using Elsa.EntityFrameworkCore.Modules.Management;
-using Elsa.EntityFrameworkCore.Modules.Runtime;
+using Elsa.Persistence.EFCore.Extensions;
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Persistence.EFCore.Modules.Runtime;
 using Elsa.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Testcontainers.PostgreSql;
@@ -775,9 +775,9 @@ For faster tests, use Entity Framework Core's in-memory database:
 
 {% code title="InMemoryTestBase.cs" %}
 ```csharp
-using Elsa.EntityFrameworkCore.Extensions;
-using Elsa.EntityFrameworkCore.Modules.Management;
-using Elsa.EntityFrameworkCore.Modules.Runtime;
+using Elsa.Persistence.EFCore.Extensions;
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Persistence.EFCore.Modules.Runtime;
 using Elsa.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary

Elsa [3.6.0](https://github.com/elsa-workflows/elsa-core/releases/tag/3.6.0) renamed several packages (and their root namespaces). The docs still referenced the old names in 22 markdown files, which means anyone following the guides against a current Elsa version can't build their project. This PR applies the renames across all affected markdown files.

### Renames applied

| Old | New |
|-----|-----|
| `Elsa.EntityFrameworkCore.*` | `Elsa.Persistence.EFCore.*` |
| `Elsa.EntityFrameworkCore.PostgreSQL` (uppercase) | `Elsa.Persistence.EFCore.PostgreSql` (also normalizes casing) |
| `Elsa.JavaScript` | `Elsa.Expressions.JavaScript` |
| `Elsa.CSharp` | `Elsa.Expressions.CSharp` |
| `Elsa.Liquid` | `Elsa.Expressions.Liquid` |
| `Elsa.Python` | `Elsa.Expressions.Python` |

Both `dotnet add package` / `<PackageReference>` entries and `using` directives were updated, since the root namespaces were renamed along with the package IDs (verified against `src/modules/Elsa.Persistence.EFCore/**` and `src/modules/Elsa.Expressions.JavaScript/**` at tag `3.6.0`, and against `Elsa.Server.Web/Program.cs`).

### Notable edge cases

- `guides/migration-v2-to-v3.md`: the v2→v3 comparison tables preserve the v2 `Elsa.Persistence.EntityFramework.*` names on the LHS and now show the current 3.6.0 names (`Elsa.Persistence.EFCore.*`) on the RHS, so users migrating today land on correct final package names.
- `guides/persistence/README-REFERENCES.md` and `guides/plugins-modules/README-REFERENCES.md`: source-path references (e.g. `src/modules/Elsa.EntityFrameworkCore/`) were updated to match the renamed directories in elsa-core.

Other breaking changes in the 3.6.0 release notes (EF migration column widening, multitenancy tenant-ID conventions, `DefaultRegistriesPopulator` constructor, `DistributedLock.Core` trim) are code/deployment concerns that aren't referenced by the docs, so no doc changes were needed for those.

## Test plan

- [ ] Skim rendered pages on the GitBook preview to make sure no sample code blocks were garbled by the substitution
- [ ] Spot-check `guides/migration-v2-to-v3.md` — confirm v2→v3 rename table still reads correctly with v2 names preserved on the left
- [ ] Confirm `guides/architecture/README.md` module table still renders as a table (column widths are now slightly uneven but pipes still align per CommonMark)

https://claude.ai/code/session_0165DkwUPNS7vXTYqmg1XZMK

---
_Generated by [Claude Code](https://claude.ai/code/session_0165DkwUPNS7vXTYqmg1XZMK)_