### PR TITLE
[codex] Update Studio OIDC GitBook docs

### DIFF
--- a/authentication/authentication.md
+++ b/authentication/authentication.md
@@ -32,18 +32,30 @@ Use Elsa's built-in identity system for authentication.
 
 ### Using OIDC (OpenID Connect)
 
-* **Description**: Integrate with an OIDC provider for authentication.
-*   **Configuration Steps**:
+OIDC integration has two parts:
 
-    * Register your application with the OIDC provider.
-    * Obtain client ID and secret.
-    * Update API configuration with OIDC provider details.
-    * Ensure redirect URIs are correctly set up.
+* Elsa Server must validate the access tokens sent to its API endpoints.
+* Elsa Studio must sign users in and attach an access token to calls to the Elsa Server API.
 
-    #### Conclusion
+For Elsa Studio 3.7, configure the `Elsa.Studio.Authentication.OpenIdConnect` modules with `Authentication:Provider` set to `OpenIdConnect`:
 
-    Choose the appropriate authentication mode based on your security requirements and follow the above steps to configure it.
-* Install and configure `Elsa.Identity` package.
-* Update API configuration to enable `Elsa.Identity` mode.
-* Set up user roles and permissions.
-* Set authentication mode to `None` in the configuration file.
+```json
+{
+  "Backend": {
+    "Url": "https://your-elsa-server.com/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://your-identity-provider.com",
+      "ClientId": "elsa-studio",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["elsa_api"]
+    }
+  }
+}
+```
+
+Use a `ClientSecret` only for confidential clients such as a Blazor Server Studio host. Do not use a client secret for WebAssembly or other browser-hosted public clients; use authorization code flow with PKCE instead.
+
+See the [Authentication & Authorization Guide](../guides/authentication.md#studio-authentication-configuration) for the full Studio OIDC setup.

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -192,7 +192,7 @@ OpenID Connect (OIDC) allows you to integrate with external identity providers l
 ### General OIDC Setup
 
 1. Register your application with the OIDC provider
-2. Obtain client ID and client secret
+2. Obtain a client ID, and a client secret only for confidential clients such as a server-side host
 3. Configure redirect URIs
 4. Install required NuGet packages
 5. Configure authentication middleware
@@ -215,7 +215,7 @@ Azure Active Directory (Azure AD / Microsoft Entra ID) is a popular choice for e
 5. Click **Register**
 6. Note the **Application (client) ID** and **Directory (tenant) ID**
 
-#### Step 2: Create Client Secret
+#### Step 2: Create Client Secret (Confidential Clients Only)
 
 1. In your app registration, go to **Certificates & secrets**
 2. Click **New client secret**
@@ -293,25 +293,44 @@ app.Run();
 
 #### Step 7: Configure Studio for Azure AD
 
-In your Elsa Studio `Program.cs`:
+Elsa Studio 3.7 uses the `Elsa.Studio.Authentication.OpenIdConnect` modules. For Blazor Server Studio hosts, configure `Authentication:Provider` and `Authentication:OpenIdConnect`:
 
-```csharp
-builder.Services.AddElsaStudio(studio =>
+```json
 {
-    studio.ConfigureBackend(backend =>
-    {
-        backend.Url = new Uri("https://your-elsa-server.com");
-        backend.UseAuthentication(() => new OpenIdConnectAuthenticationOptions
-        {
-            Authority = "https://login.microsoftonline.com/your-tenant-id",
-            ClientId = "your-studio-client-id",
-            RedirectUri = "https://your-studio.com/authentication/login-callback",
-            PostLogoutRedirectUri = "https://your-studio.com/",
-            ResponseType = "code",
-            Scope = ["openid", "profile", "email"]
-        });
-    });
-});
+  "Backend": {
+    "Url": "https://your-elsa-server.com/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://login.microsoftonline.com/your-tenant-id/v2.0",
+      "ClientId": "your-studio-client-id",
+      "ClientSecret": "your-client-secret",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["api://your-api-app-id/elsa-server-api"],
+      "SaveTokens": true
+    }
+  }
+}
+```
+
+`ClientSecret` is optional and should only be used by confidential clients such as a Blazor Server Studio host. For Studio WebAssembly, register a SPA/public client and omit the client secret:
+
+```json
+{
+  "Backend": {
+    "Url": "https://your-elsa-server.com/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://login.microsoftonline.com/your-tenant-id/v2.0",
+      "ClientId": "your-studio-wasm-client-id",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["api://your-api-app-id/elsa-server-api"]
+    }
+  }
+}
 ```
 
 ### Auth0 Integration
@@ -1036,151 +1055,100 @@ This configuration accepts either JWT Bearer tokens or API keys.
 
 ## Studio Authentication Configuration
 
-Elsa Studio needs to be configured to authenticate with the Elsa Server API.
+Elsa Studio needs to authenticate the user and send an access token to the Elsa Server API. In Elsa Studio 3.7, this is handled by the Studio authentication modules and the HTTP message handler configured for the backend client.
 
-### Studio with JWT Bearer Tokens
+### Studio with OpenID Connect
 
-When using JWT-based authentication (OIDC, Elsa.Identity):
+Set the Studio authentication provider to `OpenIdConnect` and configure the `Authentication:OpenIdConnect` section.
 
-```csharp
-using Elsa.Studio.Extensions;
+For a Blazor Server Studio host:
 
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddRazorPages();
-builder.Services.AddServerSideBlazor();
-
-builder.Services.AddElsaStudio(studio =>
+```json
 {
-    studio.ConfigureBackend(backend =>
-    {
-        backend.Url = new Uri(builder.Configuration["Backend:Url"]!);
-        
-        // Configure JWT authentication
-        backend.UseAuthentication(() => new JwtBearerAuthenticationOptions
-        {
-            TokenEndpoint = new Uri("https://your-elsa-server.com/identity/login"),
-            Username = "admin@localhost",
-            Password = "Admin123!"
-        });
-    });
-});
-
-var app = builder.Build();
-
-app.UseStaticFiles();
-app.UseRouting();
-app.MapBlazorHub();
-app.MapFallbackToPage("/_Host");
-
-app.Run();
+  "Backend": {
+    "Url": "https://your-elsa-server.com/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://your-identity-provider.com",
+      "ClientId": "elsa-studio",
+      "ClientSecret": "optional-client-secret",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["elsa_api"],
+      "SaveTokens": true
+    }
+  }
+}
 ```
 
-### Studio with OIDC
+For a Blazor WebAssembly Studio host:
 
-When using OpenID Connect:
+```json
+{
+  "Backend": {
+    "Url": "https://your-elsa-server.com/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://your-identity-provider.com",
+      "ClientId": "elsa-studio-wasm",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["elsa_api"]
+    }
+  }
+}
+```
+
+Use `ClientSecret` only for confidential clients that can protect the secret, such as Blazor Server. Do not configure a client secret for WebAssembly or any other browser-hosted public client.
+
+The corresponding Program.cs setup uses `AddOpenIdConnectAuth` and `OidcAuthenticatingApiHttpMessageHandler`:
 
 ```csharp
-builder.Services.AddElsaStudio(studio =>
+using Elsa.Studio.Authentication.OpenIdConnect.BlazorServer.Extensions; // Or .BlazorWasm.Extensions for WASM.
+using Elsa.Studio.Authentication.OpenIdConnect.HttpMessageHandlers;
+using Elsa.Studio.Extensions;
+using Elsa.Studio.Models;
+
+builder.Services.AddOpenIdConnectAuth(options =>
 {
-    studio.ConfigureBackend(backend =>
-    {
-        backend.Url = new Uri(builder.Configuration["Backend:Url"]!);
-        
-        backend.UseAuthentication(() => new OpenIdConnectAuthenticationOptions
-        {
-            Authority = "https://your-identity-provider.com",
-            ClientId = "elsa-studio-client",
-            RedirectUri = "https://your-studio.com/authentication/login-callback",
-            PostLogoutRedirectUri = "https://your-studio.com/",
-            ResponseType = "code",
-            Scope = ["openid", "profile", "email"]
-        });
-    });
+    builder.Configuration.GetSection("Authentication:OpenIdConnect").Bind(options);
 });
+
+var backendApiConfig = new BackendApiConfig
+{
+    ConfigureBackendOptions = options => builder.Configuration.GetSection("Backend").Bind(options),
+    ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(OidcAuthenticatingApiHttpMessageHandler)
+};
+
+builder.Services.AddRemoteBackend(backendApiConfig);
+```
+
+### Authentication Scopes and Backend API Scopes
+
+`AuthenticationScopes` are requested during sign-in. They usually include identity scopes such as `openid`, `profile`, `email`, and optionally `offline_access`.
+
+`BackendApiScopes` are requested for access tokens sent to the Elsa Server API. Use this when the Elsa Server API has its own scope or audience, such as `api://your-api-app-id/elsa-server-api`.
+
+### Studio with Elsa.Identity
+
+When using Elsa's built-in identity system, use the Elsa Identity Studio authentication modules. The default Studio hosts support this through:
+
+```json
+{
+  "Authentication": {
+    "Provider": "ElsaIdentity"
+  },
+  "Backend": {
+    "Url": "https://your-elsa-server.com/elsa/api"
+  }
+}
 ```
 
 ### Studio with API Keys
 
-When using API key authentication:
-
-```csharp
-builder.Services.AddElsaStudio(studio =>
-{
-    studio.ConfigureBackend(backend =>
-    {
-        backend.Url = new Uri(builder.Configuration["Backend:Url"]!);
-        
-        // Configure API key
-        backend.UseAuthentication(() => new ApiKeyAuthenticationOptions
-        {
-            HeaderName = "X-API-Key",
-            ApiKey = builder.Configuration["ApiKey"]
-        });
-    });
-});
-```
-
-Add to `appsettings.json`:
-
-```json
-{
-  "Backend": {
-    "Url": "https://your-elsa-server.com"
-  },
-  "ApiKey": "your-api-key-here"
-}
-```
-
-### Studio WASM Configuration
-
-For Elsa Studio WASM (WebAssembly), configure in the `Program.cs` of the WASM project:
-
-```csharp
-using Elsa.Studio.Extensions;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-
-var builder = WebAssemblyHostBuilder.CreateDefault(args);
-builder.RootComponents.Add<App>("#app");
-builder.RootComponents.Add<HeadOutlet>("head::after");
-
-builder.Services.AddElsaStudio(studio =>
-{
-    studio.ConfigureBackend(backend =>
-    {
-        backend.Url = new Uri(builder.Configuration["Backend:Url"]!);
-        
-        backend.UseAuthentication(() => new OpenIdConnectAuthenticationOptions
-        {
-            Authority = builder.Configuration["Oidc:Authority"],
-            ClientId = builder.Configuration["Oidc:ClientId"],
-            RedirectUri = builder.Configuration["Oidc:RedirectUri"],
-            PostLogoutRedirectUri = builder.Configuration["Oidc:PostLogoutRedirectUri"],
-            ResponseType = "code",
-            Scope = ["openid", "profile", "email"]
-        });
-    });
-});
-
-await builder.Build().RunAsync();
-```
-
-With `wwwroot/appsettings.json`:
-
-```json
-{
-  "Backend": {
-    "Url": "https://your-elsa-server.com"
-  },
-  "Oidc": {
-    "Authority": "https://your-identity-provider.com",
-    "ClientId": "elsa-studio-wasm",
-    "RedirectUri": "https://your-studio.com/authentication/login-callback",
-    "PostLogoutRedirectUri": "https://your-studio.com/"
-  }
-}
-```
+API keys are appropriate for trusted service-to-service access. For user-facing Studio deployments, prefer OIDC or Elsa.Identity so Studio can represent the signed-in user. If you need API key behavior, implement it as a backend HTTP message handler and configure it through `BackendApiConfig.ConfigureHttpClientBuilder`.
 
 ## Troubleshooting
 
@@ -1309,23 +1277,20 @@ app.UseWorkflowsApi();
    };
    ```
 
-2. **Implement token refresh**:
-   ```csharp
-   builder.Services.AddElsaStudio(studio =>
+2. **Enable refresh tokens for OIDC Studio hosts**:
+   ```json
    {
-       studio.ConfigureBackend(backend =>
-       {
-           backend.UseAuthentication(() => new JwtBearerAuthenticationOptions
-           {
-               TokenEndpoint = new Uri("https://your-server.com/identity/login"),
-               RefreshTokenEndpoint = new Uri("https://your-server.com/identity/refresh"),
-               Username = "admin@localhost",
-               Password = "Admin123!",
-               AutoRefreshToken = true
-           });
-       });
-   });
+     "Authentication": {
+       "Provider": "OpenIdConnect",
+       "OpenIdConnect": {
+         "AuthenticationScopes": ["openid", "profile", "offline_access"],
+         "SaveTokens": true
+       }
+     }
+   }
    ```
+
+   For Blazor Server Studio hosts, saved tokens are refreshed by the server-side OIDC cookie events when a refresh token is available. For WebAssembly Studio hosts, Microsoft's Blazor WebAssembly authentication stack handles token renewal through `IAccessTokenProvider`.
 
 ### HTTPS/SSL Certificate Issues
 

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -451,20 +451,18 @@ spec:
 **Studio Authentication:**
 - Configure Studio to use the same OIDC provider as Elsa Server
 - Example Studio configuration:
-  ```csharp
-  builder.Services.AddElsaStudio(studio =>
+  ```json
   {
-      studio.UseIdentity(identity =>
-      {
-          identity.UseOidcProvider(oidc =>
-          {
-              oidc.Authority = "https://your-idp.com";
-              oidc.ClientId = "elsa-studio";
-              oidc.ResponseType = "code";
-              oidc.Scope = "openid profile elsa_api";
-          });
-      });
-  });
+    "Authentication": {
+      "Provider": "OpenIdConnect",
+      "OpenIdConnect": {
+        "Authority": "https://your-idp.com",
+        "ClientId": "elsa-studio",
+        "AuthenticationScopes": ["openid", "profile", "offline_access"],
+        "BackendApiScopes": ["elsa_api"]
+      }
+    }
+  }
   ```
 
 **Authorization:**

--- a/guides/security/external-identity-providers.md
+++ b/guides/security/external-identity-providers.md
@@ -425,61 +425,27 @@ builder.Services
 
 When using an external IdP, configure Elsa Studio to authenticate users and forward tokens to Elsa Server.
 
-**Studio Program.cs (Conceptual):**
+**Studio configuration:**
 
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddRazorPages();
-builder.Services.AddServerSideBlazor();
-
-// Configure authentication (same IdP as Server)
-builder.Services
-    .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-    .AddOpenIdConnect(options =>
-    {
-        options.Authority = builder.Configuration["OIDC:Authority"];
-        options.ClientId = builder.Configuration["OIDC:ClientId"];
-        options.ClientSecret = builder.Configuration["OIDC:ClientSecret"];
-        options.ResponseType = "code";
-        options.SaveTokens = true;
-    });
-
-// Configure Elsa Studio
-builder.Services.AddElsaStudio(studio =>
+```json
 {
-    studio.ConfigureHttpClient(options =>
-    {
-        options.BaseAddress = new Uri("https://elsa-server.example.com");
-    });
-    
-    // Forward authentication token to Elsa Server
-    studio.ConfigureHttpClient((sp, client) =>
-    {
-        var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
-        var accessToken = httpContextAccessor.HttpContext?
-            .GetTokenAsync("access_token")
-            .GetAwaiter()
-            .GetResult();
-        
-        if (!string.IsNullOrEmpty(accessToken))
-        {
-            client.DefaultRequestHeaders.Authorization = 
-                new AuthenticationHeaderValue("Bearer", accessToken);
-        }
-    });
-});
-
-var app = builder.Build();
-
-app.UseAuthentication();
-app.UseAuthorization();
-app.MapBlazorHub()
-    .RequireAuthorization();  // Require authentication for Studio
-app.MapFallbackToPage("/_Host");
-
-app.Run();
+  "Backend": {
+    "Url": "https://elsa-server.example.com/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://your-identity-provider.com",
+      "ClientId": "elsa-studio",
+      "AuthenticationScopes": ["openid", "profile", "offline_access"],
+      "BackendApiScopes": ["elsa_api"],
+      "SaveTokens": true
+    }
+  }
+}
 ```
+
+For Blazor Server Studio hosts, `ClientSecret` can be added when the OIDC provider requires a confidential client. For WebAssembly Studio hosts, omit `ClientSecret` and register the client as a public SPA using authorization code flow with PKCE.
 
 ## REST API Integration
 


### PR DESCRIPTION
## Summary
- Updates GitBook authentication docs for Elsa Studio 3.7 OIDC configuration.
- Replaces stale Studio examples using non-current authentication option APIs.
- Clarifies Blazor Server vs WebAssembly behavior, client secret usage, and AuthenticationScopes vs BackendApiScopes.

## Why
The published docs implied Studio OIDC always needs a client secret and showed outdated setup snippets. That confused users configuring external OIDC providers.

## Validation
- Ran `git diff --check`.
- Searched touched docs for stale API names such as `OpenIdConnectAuthenticationOptions`, `JwtBearerAuthenticationOptions`, `ApiKeyAuthenticationOptions`, `AddOidcAuthentication`, `AddElsaOidcAuthentication`, and `BackendApiScopeOptions`.
