### PR TITLE
[codex] Clarify Studio WASM OIDC setup

### DIFF
--- a/authentication/authentication.md
+++ b/authentication/authentication.md
@@ -58,4 +58,11 @@ For Elsa Studio 3.7, configure the `Elsa.Studio.Authentication.OpenIdConnect` mo
 
 Use a `ClientSecret` only for confidential clients such as a Blazor Server Studio host. Do not use a client secret for WebAssembly or other browser-hosted public clients; use authorization code flow with PKCE instead.
 
+For WebAssembly Studio hosts, the default Elsa Studio shell does not require Razor page changes, but custom hosts must include the WebAssembly authentication script in `wwwroot/index.html`:
+
+```html
+<script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
+<script src="_framework/blazor.webassembly.js"></script>
+```
+
 See the [Authentication & Authorization Guide](../guides/authentication.md#studio-authentication-configuration) for the full Studio OIDC setup.

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1127,6 +1127,23 @@ var backendApiConfig = new BackendApiConfig
 builder.Services.AddRemoteBackend(backendApiConfig);
 ```
 
+If you use the standard Elsa Studio shell `App` component, no Razor page changes are required. The shell already uses `CascadingAuthenticationState`, `AuthorizeRouteView`, and the unauthorized component registered by the selected authentication module.
+
+If you replace the shell `App` component with your own router, wrap the router in `CascadingAuthenticationState` and use `AuthorizeRouteView`.
+
+For Blazor WebAssembly Studio hosts, `wwwroot/index.html` must also include Microsoft's WebAssembly authentication script before `_framework/blazor.webassembly.js`:
+
+```html
+<script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
+<script src="_framework/blazor.webassembly.js"></script>
+```
+
+If this script is missing, the browser console can show:
+
+```text
+Could not find 'AuthenticationService.init' ('AuthenticationService' was undefined).
+```
+
 ### Authentication Scopes and Backend API Scopes
 
 `AuthenticationScopes` are requested during sign-in. They usually include identity scopes such as `openid`, `profile`, `email`, and optionally `offline_access`.


### PR DESCRIPTION
## Summary
- Clarifies when Studio WebAssembly hosts need Razor changes.
- Documents the required Microsoft WebAssembly authentication script in `index.html`.
- Calls out the `AuthenticationService.init` console error caused by the missing script.

## Why
A user configuring OIDC hit `AuthenticationService` undefined in the browser and asked whether App.razor, package references, or backend changes are required.

## Validation
- Ran `git diff --check`.
- Searched the touched docs for the new `AuthenticationService.js` and App.razor guidance.
