### PR TITLE
Add Studio expression matrix and examples

### DIFF
--- a/guides/studio/expressions.md
+++ b/guides/studio/expressions.md
@@ -37,15 +37,56 @@ If your server does not register one of these features, Studio will not offer th
 In Elsa 3.8, C# and Python are only browsable in Studio when host code execution is allowed for those engines. If you do not see them in the picker, check your server configuration first.
 {% endhint %}
 
+## Expression matrix
+
+The following matrix separates what Studio shows from what the backend actually evaluates.
+
+| Studio choice | Source | Authoring style | Notes |
+| --- | --- | --- | --- |
+| `Default` | Studio UI mode | Field-specific editor | Not a separate runtime expression engine. |
+| `Variable` | Server descriptor | Picker UI | Resolves to a selected workflow variable. Different from `variables` in JavaScript or `Variable` in C#. |
+| `Input` | Server descriptor | Picker UI | Resolves to a selected workflow input. Different from `getInput(...)` or C# `Input`. |
+| `JavaScript` | `UseJavaScript(...)` | Monaco code editor | Best general-purpose dynamic option in Studio. |
+| `Liquid` | `UseLiquid(...)` | Monaco code editor | Best for text templates. |
+| `C#` | `UseCSharp(...)` | Monaco code editor | Browsable only when host code execution is allowed. |
+| `Python` | `UsePython(...)` | Monaco code editor | Browsable only when host code execution is allowed. |
+| Custom types such as `Secret` | Feature-specific descriptor | Usually picker or custom UI | Only appears when the related backend feature is installed. |
+
+Studio also has hidden internal descriptors such as `Literal` and `Object` that support plain values and structured values behind the scenes.
+
 ## Which syntax should you use?
 
 Use the simplest option that matches the job:
 
 - **Default** for plain text, numbers, booleans, dropdowns, and other normal field editors.
+- **Variable** when you want the field to resolve directly from a selected workflow variable without writing code.
+- **Input** when you want the field to resolve from a selected workflow input without writing code.
 - **JavaScript** for most dynamic value composition and workflow-variable lookups.
 - **Liquid** for templated text output.
 - **C#** when you explicitly want Roslyn-based expressions and have enabled them for trusted authors.
 - **Python** only when your server is configured for Python.NET expressions and you need it specifically.
+
+## Picker syntaxes versus code-expression objects
+
+This is the most common point of confusion in Studio:
+
+- **Variable** and **Input** in the syntax picker are expression types backed by picker UI.
+- `variables` in JavaScript is a runtime object injected into the JavaScript engine.
+- `Variable` and `Input` in C# are runtime proxies injected into the C# evaluator.
+
+So these are related, but they are not the same thing.
+
+### Variable picker
+
+Use **Variable** when a property should simply read from one workflow variable and you do not need any extra logic.
+
+Example: choose the `CustomerName` variable from the picker for a text field.
+
+### Input picker
+
+Use **Input** when a property should read directly from one declared workflow input.
+
+Example: choose the `OrderId` workflow input from the picker for a downstream activity field.
 
 ## JavaScript expressions
 
@@ -93,6 +134,24 @@ getOutputFrom("SendHttpRequest", "ParsedContent")
 getLastResult()
 ```
 
+### Practical JavaScript examples
+
+```javascript
+variables.Total > 1000 ? "Priority" : "Standard"
+```
+
+```javascript
+`${variables.FirstName} ${variables.LastName}`
+```
+
+```javascript
+getOutputFrom("SendHttpRequest", "ParsedContent")
+```
+
+```javascript
+setVariable("CorrelationCopy", getCorrelationId())
+```
+
 ### Important wrapper limitation
 
 The `variables.SomeName` style depends on two JavaScript runtime settings:
@@ -123,6 +182,44 @@ Variable.Set("OrderId", Guid.NewGuid());
 Variable.Set("Status", "Completed");
 ```
 
+### Accessing inputs and outputs
+
+```csharp
+Input.CustomerId
+Input.Get<Guid>("CustomerId")
+Output.From<string>("SendHttpRequest", "ParsedContent")
+Output.LastResult
+```
+
+### Accessing workflow metadata
+
+```csharp
+WorkflowInstanceId
+CorrelationId
+WorkflowInstanceName
+```
+
+You can also assign metadata in C# expressions when the scenario supports it:
+
+```csharp
+CorrelationId = Variable.Get<string>("OrderId");
+WorkflowInstanceName = $"Order {Variable.Get<string>("OrderId")}";
+```
+
+### Practical C# examples
+
+```csharp
+Variable.TotalAmount > 1000 ? "Priority" : "Standard"
+```
+
+```csharp
+$"{Variable.FirstName} {Variable.LastName}"
+```
+
+```csharp
+Output.From<string>("SendHttpRequest", "ParsedContent")
+```
+
 ### When to prefer `Get<T>()`
 
 Use `Get<T>()` when:
@@ -141,6 +238,25 @@ Elsa 3.8 registers workflow variables through the `Variables` object and workflo
 Hello {{ Variables.CustomerName }}
 Order {{ Variables.OrderId }} is {{ Variables.Status }}
 Customer input: {{ Input.CustomerId }}
+```
+
+Liquid also exposes workflow metadata:
+
+```liquid
+Instance: {{ WorkflowInstanceId }}
+Correlation: {{ CorrelationId }}
+Definition: {{ WorkflowDefinitionId }}
+Version: {{ WorkflowDefinitionVersion }}
+```
+
+### Practical Liquid examples
+
+```liquid
+Hello {{ Variables.FirstName }} {{ Variables.LastName }}
+```
+
+```liquid
+Order {{ Variables.OrderId }} total is {{ Variables.TotalAmount }}
 ```
 
 Use Liquid when the result should primarily be formatted text, not when you need more procedural logic.
@@ -164,6 +280,40 @@ variables.OrderId
 variables.set("Status", "Processed")
 variables.get("CustomerName")
 ```
+
+### Accessing inputs and outputs
+
+```python
+input.Get("CustomerId")
+output.Get("SendHttpRequest", "ParsedContent")
+output.LastResult
+```
+
+### Practical Python examples
+
+```python
+variables.get("TotalAmount") > 1000
+```
+
+```python
+variables.set("ResponseBody", output.Get("SendHttpRequest", "ParsedContent"))
+variables.get("ResponseBody")
+```
+
+{% hint style="info" %}
+Python expressions are executed through Python.NET in Elsa 3.8. Keep them for intentionally enabled, trusted-author scenarios rather than as the default authoring path in Studio.
+{% endhint %}
+
+## Feature-specific custom expression types
+
+Studio can also surface feature-specific expression types beyond the core set above.
+
+For example, Elsa's secrets feature contributes a `Secret` expression descriptor with its own custom UI instead of a code editor. The general rule is:
+
+- if a backend feature registers an expression descriptor and marks it browsable, Studio can show it.
+- if the descriptor provides a custom `UIHint`, Studio renders that custom picker/editor instead of Monaco.
+
+That is why two Elsa deployments can show different syntax choices for the same activity field.
 
 ## Variable naming guidance
 

--- a/guides/studio/expressions.md
+++ b/guides/studio/expressions.md
@@ -1,536 +1,231 @@
 ---
 description: >-
-  Learn how to use expressions in Elsa Studio to reference variables, access data, and create dynamic workflows with JavaScript and C# code.
+  Learn how Elsa Studio expression editors map to Elsa Server expression
+  engines, how to access workflow variables, and which syntax choices are
+  actually available in Elsa 3.8.
 ---
 
 # Expressions in Elsa Studio
 
-Expressions are one of the most powerful features in Elsa Studio. They allow you to write dynamic values for activity properties, reference workflow variables, perform calculations, and make data-driven decisions in your workflows.
+Elsa Studio lets you enter activity values in different expression syntaxes. The exact choices you see are not hardcoded in Studio alone: Studio asks Elsa Server for the available expression descriptors and renders those options in the property editor.
 
-This guide covers how to use expressions in Studio, with a focus on JavaScript and C# expressions for working with variables.
+This matters for two reasons:
 
-## Expression Types in Studio
+- The list of available expression types depends on which expression features your server enables.
+- Some syntaxes shown in Studio are UI helpers, while others are real runtime expression engines.
 
-When configuring an activity property in Studio, you can choose from several expression types:
+## How expression selection works
 
-### Literal
+For most activity inputs, Studio shows a **Default** option plus one or more code-oriented expression types.
 
-A **Literal** expression is a static value that doesn't change. Use this when you want to hardcode a value.
+- **Default** means: use the activity's normal UI editor for that field.
+- **Literal** and **Object** are built-in Studio/UI syntaxes used behind the scenes for plain values and structured values.
+- **JavaScript**, **Liquid**, **C#**, **Python**, and other custom types are provided by the server.
 
-**Example**: Setting a variable to the text `"Hello, World!"`
+In the 3.8 sample server, the app enables these expression engines:
 
-### JavaScript
+```csharp
+.UseCSharp(...)
+.UseJavaScript(...)
+.UsePython(...)
+.UseLiquid(...)
+```
 
-**JavaScript** expressions let you write JavaScript code to compute values dynamically. This is the most commonly used expression type for referencing variables and performing simple operations.
-
-**Example**: `variables.OrderId` or `variables.Customer.Name`
-
-### C\#
-
-**C#** expressions let you write C# code with full access to .NET types and methods. Use this when you need strong typing, complex logic, or access to .NET libraries.
-
-**Example**: `Variable.Get<Guid>("OrderId")` or `Variable.OrderId`
-
-### JSON
-
-**JSON** expressions allow you to provide JSON data directly. This is useful when working with structured data.
-
-### Liquid
-
-**Liquid** is a template language that's useful for generating text with embedded variables.
-
-**Example**: `Hello, {{ Variables.CustomerName }}!`
-
-### Other Expression Types
-
-Elsa also supports Python and other expression types depending on your server configuration. Check your Elsa Server's installed packages to see what's available.
-
-## How to Choose an Expression Type
-
-In the Studio property panel, you'll see a dropdown next to each property where you can select the expression type:
-
-![Studio screenshot placeholder]
-
-**When to use each type:**
-
-- **Literal**: Simple static values (numbers, strings, booleans)
-- **JavaScript**: Quick variable access, simple calculations, most common use case
-- **C#**: Complex logic, strong typing, access to .NET libraries
-- **JSON**: Structured data objects
-- **Liquid**: Text templates with variables
+If your server does not register one of these features, Studio will not offer that syntax.
 
 {% hint style="info" %}
-If you're not sure which to use, start with **JavaScript** for simple variable references and switch to **C#** if you need more advanced features.
+In Elsa 3.8, C# and Python are only browsable in Studio when host code execution is allowed for those engines. If you do not see them in the picker, check your server configuration first.
 {% endhint %}
 
-## Understanding the Variables Object
+## Which syntax should you use?
 
-In Elsa workflows, variables are stored in a special `variables` object that's accessible in expressions. The structure of this object depends on how you've defined your variables.
+Use the simplest option that matches the job:
 
-### Variable Structure
+- **Default** for plain text, numbers, booleans, dropdowns, and other normal field editors.
+- **JavaScript** for most dynamic value composition and workflow-variable lookups.
+- **Liquid** for templated text output.
+- **C#** when you explicitly want Roslyn-based expressions and have enabled them for trusted authors.
+- **Python** only when your server is configured for Python.NET expressions and you need it specifically.
 
-When you create a variable in your workflow, it becomes a property on the `variables` object:
+## JavaScript expressions
 
-- Variable name: `OrderId` → Access as: `variables.OrderId`
-- Variable name: `CustomerName` → Access as: `variables.CustomerName`
-- Variable name: `variable1` → Access as: `variables.variable1`
+JavaScript is usually the most convenient dynamic syntax in Studio.
 
-### Object Variables
+### Reading variables
 
-Variables can store complex objects with nested properties. For example, if you have a variable called `variable1` that contains an object with a `data` property:
+If variable wrappers are enabled and your variable names are valid JavaScript property names, you can use:
 
-```javascript
-// Variable structure
-variable1 = {
-  data: {
-    id: "12345",
-    name: "Example"
-  }
-}
-```
-
-You can access nested properties using dot notation:
-
-```javascript
-variables.variable1.data.id
-```
-
-## Referencing Variables in JavaScript Expressions
-
-JavaScript expressions are the most common way to work with variables in Studio. Here's how to use them effectively.
-
-### Reading a Simple Variable
-
-To read a variable value, use the `variables` object:
-
-**JavaScript:**
 ```javascript
 variables.OrderId
+variables.Customer.Name
+variables.Items[0]
 ```
 
-### Reading Nested Properties
+Elsa also exposes explicit helper functions:
 
-For variables that contain objects, use dot notation to access nested properties:
-
-**JavaScript:**
 ```javascript
-variables.variable1.data.id
-variables.Customer.Address.City
-variables.OrderDetails.Items[0].Price
+getVariable("OrderId")
+getVariable("Customer")
 ```
 
-### Setting a Variable Value
+Use `getVariable` when:
 
-The `variables` object is read-only in most contexts. To set variables, use the `SetVariable` activity or the `setVariable()` function:
+- the variable name is not a valid JavaScript identifier.
+- variable wrappers were disabled on the server.
+- you want to avoid depending on the `variables.SomeName` convenience wrapper.
 
-**JavaScript:**
+### Writing variables
+
+To assign a value from JavaScript, use:
+
 ```javascript
-setVariable("OrderId", newGuid())
+setVariable("OrderId", getGuidString())
+setVariable("Status", "Approved")
 ```
 
-### Using Variables in Calculations
+### Accessing inputs and outputs
 
-You can perform calculations with variable values:
+Elsa's JavaScript helpers also include:
 
-**JavaScript:**
 ```javascript
-variables.Quantity * variables.UnitPrice
-variables.FirstName + " " + variables.LastName
-variables.TotalAmount > 1000
+getInput("CustomerId")
+getOutputFrom("SendHttpRequest", "ParsedContent")
+getLastResult()
 ```
 
-### Handling Null or Undefined Variables
+### Important wrapper limitation
 
-Always be careful when accessing variables that might not exist:
+The `variables.SomeName` style depends on two JavaScript runtime settings:
 
-**JavaScript:**
-```javascript
-// Check if variable exists before using it
-variables.OrderId ? variables.OrderId : "default-value"
+- variable wrappers must be enabled.
+- variable copying must be enabled.
 
-// Or use optional chaining (if supported)
-variables.Customer?.Address?.City
+If either is disabled, use `getVariable(...)` and `setVariable(...)` instead.
 
-// Provide a default value
-variables.OrderId || "unknown"
-```
+## C# expressions
 
-## Referencing Variables in C# Expressions
+C# expressions are available when the server enables the C# expression feature and allows host code execution for trusted workflow authors.
 
-C# expressions provide type safety and access to the full .NET framework. There are several ways to access variables in C#.
+Elsa generates a variable proxy for C# expressions. In Elsa 3.8, both `Variables` and `Variable` work, but `Variable` is the preferred alias.
 
-### Strongly-Typed Access
+### Reading variables
 
-If your variable is defined in the workflow, Elsa generates strongly-typed properties on the `Variable` object:
-
-**C#:**
 ```csharp
 Variable.OrderId
-Variable.CustomerName
-```
-
-This approach provides compile-time type checking and IntelliSense support.
-
-### Using Variable.Get<T>()
-
-You can access variables by name with type safety using the `Get<T>()` method:
-
-**C#:**
-```csharp
 Variable.Get<Guid>("OrderId")
 Variable.Get<string>("CustomerName")
-Variable.Get<int>("Quantity")
 ```
 
-### Dynamic Access
+### Writing variables
 
-For variables with complex structures or when you need more flexibility:
-
-**C#:**
-```csharp
-// Using the variables dictionary (requires casting)
-var variable1 = Variable.Get<dynamic>("variable1");
-var id = variable1.data.id;
-
-// Or access as an object and cast
-var customerObj = Variable.Get<object>("Customer");
-```
-
-### Dictionary-Based Access
-
-When working with object variables that are stored as dictionaries:
-
-**C#:**
-```csharp
-var variable1 = Variable.Get<Dictionary<string, object>>("variable1");
-var data = variable1["data"] as Dictionary<string, object>;
-var id = data["id"] as string;
-```
-
-### Setting Variables in C#
-
-Use the `Set()` method to assign values:
-
-**C#:**
 ```csharp
 Variable.Set("OrderId", Guid.NewGuid());
 Variable.Set("Status", "Completed");
 ```
 
-## Practical Example: Using SetVariable Activity
+### When to prefer `Get<T>()`
 
-This example demonstrates the scenario from issue #89: reading a nested property from an object variable and using it to set another variable.
+Use `Get<T>()` when:
 
-### Scenario
+- the variable name is not a valid generated property name.
+- you want explicit typing.
+- wrappers were disabled in C# options.
 
-You have a variable called `variable1` that contains an object:
+## Liquid expressions
 
-```json
-{
-  "data": {
-    "id": "abc-123",
-    "name": "Sample Item"
-  }
-}
+Liquid is best for text templating.
+
+Elsa 3.8 registers workflow variables through the `Variables` object and workflow or activity inputs through `Input`.
+
+```liquid
+Hello {{ Variables.CustomerName }}
+Order {{ Variables.OrderId }} is {{ Variables.Status }}
+Customer input: {{ Input.CustomerId }}
 ```
 
-**Goal**: Extract the `id` value and store it in a new variable called `extractedId`.
+Use Liquid when the result should primarily be formatted text, not when you need more procedural logic.
 
-### Solution with JavaScript
+## Python expressions
 
-1. Add a `SetVariable` activity to your workflow
-2. Configure the activity:
-   - **Variable Name**: `extractedId` (Literal)
-   - **Value**: Choose **JavaScript** as the expression type
-   - **Expression**:
+Python expressions are available only when the Python feature is enabled and host code execution is allowed.
+
+Elsa injects these globals into the Python scope:
+
+- `execution_context`
+- `input`
+- `output`
+- `outcome`
+- `variables`
+
+Typical variable access looks like this:
+
+```python
+variables.OrderId
+variables.set("Status", "Processed")
+variables.get("CustomerName")
+```
+
+## Variable naming guidance
+
+If you want the most convenient cross-language experience in Studio, use variable names that are valid identifiers, such as:
+
+- `OrderId`
+- `CustomerName`
+- `RetryCount`
+
+Avoid names that require quoting or special handling, such as:
+
+- `order-id`
+- `customer name`
+- `123value`
+
+Those names can still work, but you will need accessor methods like `getVariable("order-id")` instead of wrapper-style property access.
+
+## Variable storage and expressions
+
+Expressions read the current value of workflow variables regardless of whether the variable is stored in memory or in workflow-instance storage.
+
+In Elsa 3.8:
+
+- **Memory** storage keeps the value in memory for the lifetime of the current execution context.
+- **Workflow Instance** storage persists the value in workflow state.
+- The legacy **Workflow** storage driver still exists for backward compatibility, but `Workflow Instance` is the current persisted option.
+
+Choose storage based on lifecycle and suspension/resumption needs; choose expression syntax based on authoring convenience.
+
+## Recommended patterns
+
+- Use **Default** unless you actually need dynamic behavior.
+- Use **JavaScript** for most dynamic field values in Studio.
+- Use **Liquid** for generated messages, templates, and text bodies.
+- Use **C#** and **Python** only for trusted-author scenarios where you intentionally enable host code execution.
+- Prefer identifier-friendly variable names so wrapper syntax stays simple.
+
+## Common pitfalls
+
+### "I don't see C# or Python in Studio"
+
+Usually this means the backend did not enable that engine, or host code execution for that engine is disabled.
+
+### "`variables.MyValue` does not work in JavaScript"
+
+Check these first:
+
+- the variable name is a valid identifier.
+- JavaScript variable wrappers were not disabled.
+- JavaScript variable copying was not disabled.
+
+If any of those are not true, switch to:
 
 ```javascript
-variables.variable1.data.id
+getVariable("MyValue")
 ```
 
-![Studio screenshot placeholder]
+### "My field shows Default instead of a code editor"
 
-This reads the `id` property from the nested `data` object within `variable1` and assigns it to `extractedId`.
+That is normal. `Default` uses the activity's UI hint. Switch the syntax picker to a code-backed expression type such as JavaScript or Liquid if you want to write an expression.
 
-### Solution with C# (Using Get Method)
+## See also
 
-Using the `Get<T>()` method with type casting:
-
-1. Add a `SetVariable` activity
-2. Configure the activity:
-   - **Variable Name**: `extractedId` (Literal)
-   - **Value**: Choose **C#** as the expression type
-   - **Expression**:
-
-```csharp
-Variable.Get<dynamic>("variable1").data.id
-```
-
-{% hint style="info" %}
-If you need to ensure the result is a string, you can add `.ToString()` at the end, but it's often not necessary if the property is already a string.
-{% endhint %}
-
-{% hint style="warning" %}
-**Dynamic vs Strongly-Typed**: Using `dynamic` bypasses compile-time type checking, which means potential errors won't be caught until runtime. Use dynamic access when the variable structure is truly unknown at design time, but prefer strongly-typed access (with `Variable.Get<T>()` and specific types) when you know the structure for better safety and IntelliSense support.
-{% endhint %}
-
-### Solution with C# (Dictionary Access)
-
-If you need more control over type handling, use dictionary access:
-
-1. Add a `SetVariable` activity
-2. Configure the activity:
-   - **Variable Name**: `extractedId` (Literal)
-   - **Value**: Choose **C#** as the expression type
-   - **Expression**:
-
-```csharp
-var variable1 = Variable.Get<Dictionary<string, object>>("variable1");
-var data = variable1["data"] as Dictionary<string, object>;
-var id = data?["id"] as string;
-return id ?? string.Empty;
-```
-
-{% hint style="info" %}
-**Note**: The multi-line approach shown above is recommended for clarity and maintainability. While it's possible to write this as a complex single-line expression, the multi-line version is easier to read and debug.
-{% endhint %}
-
-{% hint style="warning" %}
-**Null Safety**: When using the `as` operator for casting, always check for null values. The example above uses the null-conditional operator (`?.`) and null-coalescing operator (`??`) to safely handle cases where the cast might fail or values might be missing. Without these checks, you risk `NullReferenceException` at runtime.
-{% endhint %}
-
-{% hint style="warning" %}
-When using dynamic access or dictionaries, you may need to cast values to the appropriate type. The exact approach depends on how your variable was created and what type of data it contains.
-{% endhint %}
-
-## More Complex Examples
-
-### Combining Multiple Variables
-
-**JavaScript:**
-```javascript
-`${variables.FirstName} ${variables.LastName} - Order #${variables.OrderId}`
-```
-
-**C#:**
-```csharp
-$"{Variable.FirstName} {Variable.LastName} - Order #{Variable.OrderId}"
-```
-
-### Conditional Logic
-
-**JavaScript:**
-```javascript
-variables.TotalAmount > 1000 ? "Premium" : "Standard"
-```
-
-**C#:**
-```csharp
-Variable.TotalAmount > 1000 ? "Premium" : "Standard"
-```
-
-### Working with Arrays
-
-**JavaScript:**
-```javascript
-// Get first item
-variables.Items[0].Name
-
-// Get array length
-variables.Items.length
-
-// Check if array contains value
-variables.Tags.includes("urgent")
-```
-
-**C#:**
-```csharp
-// Get first item
-Variable.Get<List<Item>>("Items")[0].Name
-
-// Get count
-Variable.Get<List<Item>>("Items").Count
-
-// Check if contains
-Variable.Get<List<string>>("Tags").Contains("urgent")
-```
-
-## Evaluation Context and Common Pitfalls
-
-Understanding where expressions are evaluated helps avoid common errors.
-
-### Where Variables Come From
-
-The `variables` object is constructed by the Elsa workflow engine at runtime. It contains:
-- Variables defined in your workflow definition
-- Variables set by activities during execution
-- Variables passed as workflow input
-
-Variables are stored in the workflow instance state and persist across workflow executions if the workflow is suspended and resumed.
-
-### Common Pitfalls
-
-#### 1. Misspelled Variable Names
-
-**Problem**: `variables.OrderID` when the variable is actually called `OrderId`
-
-**Solution**: Variable names are case-sensitive. Double-check the exact spelling in your workflow definition.
-
-#### 2. Wrong Expression Type
-
-**Problem**: Setting a property to "Literal" when you meant to use "JavaScript"
-
-**Solution**: Always verify the expression type dropdown is set correctly. If your expression looks like code but isn't evaluated, you probably have it set to "Literal".
-
-#### 3. Null Reference Errors
-
-**Problem**: Accessing `variables.Customer.Name` when `Customer` is null
-
-**Solution**: Use null-checking:
-- **JavaScript**: `variables.Customer?.Name` or `variables.Customer && variables.Customer.Name`
-- **C#**: `Variable.Customer?.Name`
-
-#### 4. Variable Not Found
-
-**Problem**: Variable doesn't exist yet when you try to access it
-
-**Solution**: Ensure the variable is:
-- Defined in your workflow definition, OR
-- Set by a previous activity that has already executed
-
-Variables are only available after they've been created or set.
-
-#### 5. Type Mismatches in C#
-
-**Problem**: Trying to access a string variable as an integer
-
-**Solution**: Use the correct type parameter in `Get<T>()`:
-```csharp
-Variable.Get<int>("Quantity")  // Not Variable.Get<string>("Quantity")
-```
-
-## Accessing Activity Outputs
-
-In addition to variables, you can access outputs from other activities in your workflow.
-
-### Using JavaScript
-
-**Access by activity name:**
-```javascript
-getOutputFrom("MyHttpRequest", "Body")
-```
-
-**Access last result:**
-```javascript
-getLastResult()
-```
-
-### Using C#
-
-**Access by activity name:**
-```csharp
-Output.From<string>("MyHttpRequest", "Body")
-```
-
-**Access last result:**
-```csharp
-Output.LastResult
-```
-
-## Accessing Workflow Input
-
-If your workflow receives input when it starts, you can access it in expressions.
-
-### Using JavaScript
-
-```javascript
-getInput("OrderId")
-```
-
-Or use the shorthand getter:
-```javascript
-getOrderId()
-```
-
-### Using C#
-
-```csharp
-Input.Get<Guid>("OrderId")
-```
-
-Or use strongly-typed access:
-```csharp
-Input.OrderId
-```
-
-## Testing Your Expressions
-
-{% hint style="info" %}
-**Test Early and Often**: After writing an expression, save your workflow and test it to make sure it works as expected. Use the Workflow Instances view to inspect variable values during execution.
-{% endhint %}
-
-To test expressions:
-
-1. **Run Your Workflow**: Execute the workflow in Studio
-2. **Check Instances**: Go to "Workflow Instances" in the sidebar
-3. **Inspect Variables**: Open the workflow instance and view the variables tab
-4. **Look for Errors**: If an expression fails, check the workflow instance for error messages
-
-## Best Practices
-
-### Choose the Right Expression Type
-
-- Use **Literal** for static values
-- Use **JavaScript** for simple variable access and logic
-- Use **C#** when you need type safety or complex .NET operations
-
-### Name Variables Clearly
-
-Use descriptive variable names that indicate what they contain:
-- ✅ `OrderId`, `CustomerEmail`, `TotalAmount`
-- ❌ `var1`, `temp`, `x`
-
-### Handle Null Cases
-
-Always consider whether a variable might be null or undefined:
-
-**JavaScript:**
-```javascript
-variables.OptionalField || "default value"
-```
-
-**C#:**
-```csharp
-Variable.OptionalField ?? "default value"
-```
-
-### Use Strongly-Typed Access in C#
-
-When possible, define variables in your workflow and use strongly-typed access for better IntelliSense and compile-time checking.
-
-### Keep Expressions Simple
-
-If an expression becomes too complex, consider breaking it into multiple activities. This makes your workflow easier to understand and debug.
-
-## Additional Resources
-
-- **[C# Expressions Reference](../../expressions/c.md)**: Complete reference for C# expressions in Elsa
-- **[JavaScript Expressions Reference](../../expressions/javascript.md)**: Complete reference for JavaScript expressions in Elsa
-- **[Workflow Variables API](../../operate/workflow-instance-variables.md)**: Working with variables programmatically
-- **[Studio User Guide](README.md)**: Overview of Elsa Studio features
-
-## Summary
-
-Expressions in Elsa Studio give you the power to create dynamic, data-driven workflows. By understanding how to:
-
-- Choose the right expression type
-- Access variables using `variables.VariableName`
-- Reference nested properties with dot notation
-- Handle null cases and type conversions
-- Use both JavaScript and C# expressions effectively
-
-You can build sophisticated workflows that respond to data and conditions in your business processes.
-
-{% hint style="success" %}
-**You're Ready!** With this knowledge, you can confidently use expressions in your workflows. Start simple with variable references, then gradually add more complex logic as needed.
-{% endhint %}
+- [Workflow Instance Variables](../../operate/workflow-instance-variables.md)
+- [Using Elsa Studio](../running-workflows/using-elsa-studio.md)

--- a/operate/workflow-instance-variables.md
+++ b/operate/workflow-instance-variables.md
@@ -37,14 +37,15 @@ Each variable retrieved is represented by a unique ID, a name, and a value.
 
 ### Updating﻿ <a href="#update-variables" id="update-variables"></a>
 
-You can also use the `IWorkflowInstanceVariableManager` service to update one or more variables of a workflow instance. Below is an example of how to perform the update:
+You can also use the `IWorkflowInstanceVariableManager` service to update one or more variables of a workflow instance. Provide the variable IDs you want to change and the new values to assign to them:
 
 ```csharp
-var variablesToUpdate = [
+var workflowInstanceId = "some-workflow-instance-id";
+var variablesToUpdate = new[]
 {
     new VariableUpdateValue("some-variable-id", "Some variable value"),
     new VariableUpdateValue("another-variable-id", 42)
-}];
+};
 
 // Update the variables. This returns a complete list of variables, including both unchanged and changed variables.
 var variables = await _workflowInstanceVariableManager.SetVariablesAsync(workflowInstanceId, variablesToUpdate, cancellationToken);
@@ -57,7 +58,7 @@ foreach (var variable in variables)
 ```
 
 {% hint style="info" %}
-The `SetVariablesAsync` method replaces the specified variables' values. Any variable not included in the update request will retain its original value. Ensure that the variable IDs provided are correct to avoid unintended updates.
+`SetVariablesAsync` updates only the variables you specify by ID and then saves the workflow instance. Variables not included in the request keep their current values.
 {% endhint %}
 
 Updating variables in a workflow instance can be particularly useful for dynamically adjusting the workflow's behaviour based on changing data inputs or conditions during execution.


### PR DESCRIPTION
## Summary
- add a Studio/backend expression matrix
- distinguish picker syntaxes from runtime expression objects
- add richer C#, Liquid, Python, and JavaScript examples

## Validation
- validated guidance against local elsa-core and elsa-studio release/3.8.0 source branches
- docs-only changes; no automated tests run