### PR TITLE
docs: add Studio customization guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -69,6 +69,7 @@
   * [Dispatch Workflow Activity](guides/running-workflows/dispatch-workflow-activity.md)
 * [Studio User Guide](guides/studio/README.md)
   * [Expressions](guides/studio/expressions.md)
+  * [Customization](guides/studio/customization.md)
   * [Custom UI Components](guides/studio/custom-ui-components.md)
   * [Integration](guides/studio/integration/README.md)
     * [Custom Elements Embedding](guides/studio/integration/custom-elements.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-11)
+## Slice Inventory (2026-06-12)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -30,6 +30,7 @@ acceptance criterion below is already complete.
 - `DOC-018` Plugins and modules development
 - `DOC-020` EF Core migrations
 - `DOC-022` Scaling and performance
+- `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
 - `DOC-030` Custom UI components
 - `DOC-037` Alterations
@@ -48,7 +49,6 @@ acceptance criterion below is already complete.
 - `DOC-025` Long-running workflows
 - `DOC-026` Error handling and retry logic
 - `DOC-027` Execution model
-- `DOC-028` Studio customization
 - `DOC-038` Distributed tracing
 - `DOC-039` Performance tuning
 - `DOC-040` Timer and scheduled workflows
@@ -59,10 +59,16 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-- `DOC-028` Studio customization: build on the Studio integration and
-  custom-elements guidance with a source-backed guide for changing
-  embedded Studio behavior, shell composition, and user-facing
-  customization seams.
+- `DOC-007` Custom activities V3 rewrite: the Studio customization slice
+  now explains the Studio-side seams, but the main custom-activities guide
+  still needs a release-backed V3 rewrite that ties backend activity
+  metadata, registration, and Studio behavior together.
+
+### Newly discovered follow-on topics
+
+- `DOC-050` Studio platform integration: add a focused guide for
+  `AddPlatformIntegrationModule`, workflow submission widgets, and when to
+  use that integration path instead of custom-elements embedding alone.
 
 ## Critical Priority (Must Have - Block Users)
 

--- a/guides/studio/README.md
+++ b/guides/studio/README.md
@@ -126,6 +126,7 @@ To start working with Elsa Studio:
 Explore these guides to learn more about using Elsa Studio effectively:
 
 - **[Expressions](expressions.md)**: Learn how to use JavaScript and C# expressions to reference variables and create dynamic workflows
+- **[Customization](customization.md)**: Understand the main Studio customization seams in release 3.8.0, including host composition, menus, widgets, branding, and editor extensibility
 - **[Custom UI Components](custom-ui-components.md)**: Create custom property editors for activity inputs
 - **[Integration](integration/README.md)**: Integrate Elsa Studio into React, Angular, Blazor, or MVC applications
 - **[Studio Tour & Troubleshooting](../../studio/studio-tour-troubleshooting.md)**: Detailed walkthrough of the Studio interface with troubleshooting tips
@@ -155,5 +156,6 @@ Explore these guides to learn more about using Elsa Studio effectively:
 Ready to dive deeper? Here are some recommended paths:
 
 - **[Expressions guide](expressions.md)** - Learn how to work with variables and create dynamic workflows using JavaScript and C# expressions
+- **[Customization](customization.md)** - Learn how to change Studio composition, branding, widgets, and editor behavior without forking the shell
 - **[Custom UI Components](custom-ui-components.md)** - Learn how to create custom property editors for specialized activity inputs
 - **[Integration guide](integration/README.md)** - Discover how to integrate Elsa Studio into your existing React, Angular, Blazor, or MVC application

--- a/guides/studio/customization.md
+++ b/guides/studio/customization.md
@@ -1,0 +1,263 @@
+---
+description: >-
+  Source-backed guide to the main Elsa Studio customization seams in release
+  3.8.0, including host composition, branding, menus, widgets, activity
+  pickers, and editor extensibility.
+---
+
+# Customizing Elsa Studio
+
+This guide is based on the `release/3.8.0` source code in
+`elsa-studio` and, where activity metadata is involved, `elsa-core`.
+
+Use this guide when you are embedding or hosting Elsa Studio and need to
+change how Studio looks, what it exposes, or how its editors behave.
+
+If you only need host setup, start with [Studio Integration](integration/README.md).
+If you only need embedded surfaces, go straight to
+[Custom Elements Embedding](integration/custom-elements.md).
+
+## Start With The Smallest Useful Seam
+
+In Elsa Studio 3.8.0, customization is mostly done through dependency
+injection and feature modules.
+
+| Goal | Use this seam | Source-backed entry point |
+| --- | --- | --- |
+| Change Studio shell services or options | Host startup | `AddShell`, `ShellOptions` |
+| Change branding in a standalone host | Replace `IBrandingProvider` | `MainLayout`, server host `Program.cs` |
+| Add or remove Studio capabilities | Host module registration | `AddWorkflowsModule`, `AddDashboardModule`, `AddSecretsModule`, and similar |
+| Add navigation items | `IMenuProvider` | `DefaultMenuService` |
+| Add app-bar UI | `IAppBarService` from an `IFeature` | `DefaultAppBarService` |
+| Add panels, tabs, or editor widgets | `IWidget` or `IWidgetRegistry` | `DefaultWidgetRegistry` |
+| Change the workflow activity picker | Replace `IActivityPickerComponentProvider` | workflows module plus host override |
+| Render a new input editor | Studio `IUIHintHandler` plus backend `UIHint` metadata | `AddDefaultUIHintHandlers`, `ActivityDescriber` |
+| Decorate an existing input editor | `IUIFieldExtensionHandler` | `FieldExtension.razor` |
+
+Pick the narrowest seam that solves the problem. That keeps your host
+close to the stock Studio behavior and reduces upgrade risk.
+
+## Host-Level Composition
+
+The three released Studio hosts all compose Studio by registering services
+and modules in `Program.cs`:
+
+- `src/hosts/Elsa.Studio.Host.Server`
+- `src/hosts/Elsa.Studio.Host.Wasm`
+- `src/hosts/Elsa.Studio.Host.CustomElements`
+
+That means host composition is the first customization seam.
+
+### Shell Options
+
+`AddShell` configures shared shell services and binds `ShellOptions`.
+In release 3.8.0, the exposed shell option is:
+
+```json
+{
+  "Shell": {
+    "DisableAuthorization": false
+  }
+}
+```
+
+`App.razor.cs` reads this option to decide whether authorization should be
+enforced in the shell.
+
+### Branding
+
+The shared services layer registers `DefaultBrandingProvider`, and
+`MainLayout.razor` renders the current provider inside the drawer header.
+
+The server host shows the supported replacement pattern by registering
+`StudioBrandingProvider` as `IBrandingProvider`.
+
+Use this seam when you need:
+
+- custom logos or product naming
+- organization-specific shell branding
+- different login or navigation branding in a dedicated Studio host
+
+### Module Set
+
+Studio capabilities are opt-in at host startup. For example, the released
+server host registers:
+
+- dashboard modules
+- workflows and workflow dashboard modules
+- alterations
+- diagnostics modules
+- secrets
+- localization
+
+If a host does not register a module, that capability is not present in
+the shell. This is the primary seam for building a smaller, purpose-built
+Studio.
+
+## Navigation, App Bar, And Feature Gating
+
+Studio uses `IFeature`, `IMenuProvider`, and `IAppBarService` to compose
+user-facing shell behavior.
+
+### Menus
+
+`DefaultMenuService` asks every registered `IMenuProvider` for menu items
+and then orders the combined result.
+
+Use `IMenuProvider` when you want to:
+
+- add a new top-level navigation item
+- add menu entries for a custom Studio module
+- hide stock menu areas by omitting the corresponding module from the host
+
+### App Bar
+
+`MainLayout.razor` renders `AppBarService.AppBarComponents`.
+
+Features such as localization and environment selection add app-bar
+elements during feature initialization. Use `IAppBarService` when you need
+global shell controls such as:
+
+- environment switchers
+- tenant switchers
+- custom status or action buttons
+
+### Remote Feature Gating
+
+`DefaultFeatureService` initializes all local `IFeature` registrations, but
+it skips any feature decorated with `RemoteFeatureAttribute` when the
+backend does not advertise the matching capability.
+
+This is how modules such as OpenTelemetry and console logs stay absent from
+the shell when the connected Elsa Server does not support them.
+
+Use the same pattern for optional modules that should appear only when a
+backend feature is available.
+
+## Widgets And Editor Surface Extensions
+
+Widgets are the main seam for adding UI inside existing Studio surfaces.
+
+`DefaultWidgetRegistry` collects all registered `IWidget` instances and
+renders them by zone and order.
+
+Use widgets when you need to extend an existing page rather than create a
+completely separate screen.
+
+Examples from the released source include:
+
+- workflow definition metadata, settings, and info widgets
+- workflow definition labels widgets
+- console log widgets in workflow instance views
+- dashboard widgets and dashboard companion widgets
+- platform submission widgets from `AddPlatformIntegrationModule`
+
+Use widgets for:
+
+- extra tabs or panels in workflow or instance screens
+- organization-specific metadata editors
+- submit or approval actions tied to existing Studio pages
+
+## Workflow Editor Customization
+
+The workflow editor has three main seams in release 3.8.0.
+
+### Activity Picker
+
+`AddWorkflowsModule()` registers
+`AccordionActivityPickerComponentProvider` by default.
+
+The server host replaces it with
+`TreeviewActivityPickerComponentProvider`.
+
+If you need a different activity browsing experience, replace
+`IActivityPickerComponentProvider` in your host.
+
+### Input Editors
+
+Studio-side input editors are selected through `IUIHintHandler`.
+
+`AddDefaultUIHintHandlers()` registers the built-in handlers for hints such
+as:
+
+- `singleline`
+- `dropdown`
+- `checkbox`
+- `json-editor`
+- `code-editor`
+- `workflow-definition-picker`
+- `dynamic-outcomes`
+
+If you introduce a new backend `UIHint`, register a matching Studio
+`IUIHintHandler`.
+
+For the full backend-plus-Studio flow, see
+[Custom UI Components](custom-ui-components.md).
+
+### Field Decorations
+
+`FieldExtension.razor` wraps input editors and renders matching
+`IUIFieldExtensionHandler` instances above or below the editor.
+
+Use field extensions when you want to:
+
+- add helper UI around an existing editor
+- add syntax-specific controls
+- add activity-specific hints or toolbars
+
+Use this seam when the stock editor is still correct and only the framing
+needs to change.
+
+For the detailed contract and example, see
+[Field Extensions](../../studio/workflow-editor/field-extensions.md).
+
+## Backend Metadata Still Matters
+
+Some Studio customization starts in `elsa-core`, not `elsa-studio`.
+
+`ActivityDescriber` builds input descriptors from activity metadata, and
+`PropertyUIHandlerResolver` combines:
+
+- explicit `UIHandler` or `UIHandlers` from `[Input]`
+- default property UI handlers associated with the selected backend UI hint
+
+The resulting UI metadata is sent to Studio in
+`InputDescriptor.UISpecifications`.
+
+If the metadata marks an input for refresh, Studio recomputes descriptor
+options through:
+
+`POST /descriptors/activities/{activityTypeName}/options/{propertyName}`
+
+That split matters:
+
+- use `elsa-core` to define activity metadata and option-generation logic
+- use `elsa-studio` to decide how that metadata is rendered
+
+## Choosing The Right Customization Shape
+
+Use a dedicated standalone host when you need:
+
+- a full Studio application
+- custom branding
+- server-side or SPA-level auth handling
+- a curated module set for operators or designers
+
+Use custom-elements embedding when you need:
+
+- selected Studio surfaces inside another application shell
+- host-controlled navigation and auth
+- incremental adoption instead of a full Studio shell
+
+Use widgets, menu providers, and app-bar features when you need to extend
+the stock shell without forking its pages.
+
+Use UI hint handlers and field extensions when the change belongs inside
+the workflow inspector rather than the shell.
+
+## Related Guides
+
+- [Studio Integration](integration/README.md)
+- [Custom Elements Embedding](integration/custom-elements.md)
+- [Custom UI Components](custom-ui-components.md)
+- [Field Extensions](../../studio/workflow-editor/field-extensions.md)

--- a/guides/studio/integration/README.md
+++ b/guides/studio/integration/README.md
@@ -25,6 +25,10 @@ Use the standalone hosts when Studio should run as its own application.
 
 Use the custom-elements host when you want to embed selected Studio capabilities, such as the workflow editor or workflow lists, inside an existing application shell.
 
+If you also need to change shell composition, branding, menus, widgets, or
+workflow-editor extension points, continue with
+[Customizing Elsa Studio](../customization.md).
+
 ## Shared Configuration
 
 All current host models connect to Elsa Server through the `Backend` section.


### PR DESCRIPTION
## Summary
- add a source-backed Studio customization guide for release 3.8.0
- wire the new guide into Studio docs navigation and integration guidance
- update the documentation slice inventory and note a follow-on Studio platform integration topic

## Validation
- reviewed claims against release/3.8.0 source in elsa-studio and elsa-core
- ran   - \
  - a local markdown link existence check on touched files