### PR TITLE
Add release-backed monitoring and observability docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -107,6 +107,7 @@
 
 ## Operate
 
+* [Monitoring & Observability](operate/monitoring-observability.md)
 * [Variables](operate/workflow-instance-variables.md)
 * [Activation Strategies](operate/workflow-activation-strategies.md)
 * [Incidents](operate/incidents/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-13)
+## Slice Inventory (2026-06-14)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -27,6 +27,7 @@ acceptance criterion below is already complete.
 - `DOC-012` Blocking and trigger activities
 - `DOC-013` Studio integration
 - `DOC-014` Clustering and distributed hosting
+- `DOC-015` Monitoring and observability
 - `DOC-017` Common workflow patterns
 - `DOC-018` Plugins and modules development
 - `DOC-020` EF Core migrations
@@ -40,7 +41,6 @@ acceptance criterion below is already complete.
 
 ### Available next slices
 
-- `DOC-015` Monitoring and observability
 - `DOC-016` Workflow context V3
 - `DOC-019` HTTP endpoint security
 - `DOC-021` Configuration management
@@ -59,11 +59,11 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-- `DOC-015` Monitoring and observability: the logging and incidents pages
-  now cover parts of the runtime story, but there is still no
-  release-backed guide that explains how workflow execution logs, activity
-  execution records, sinks, and Studio/runtime diagnostics fit together for
-  operators and developers.
+- `DOC-016` Workflow context V3: multiple guides assume readers already
+  understand what lives in workflow state, activity state, variables,
+  inputs, outputs, bookmarks, and execution logs. A dedicated release-backed
+  guide would remove repeated confusion across both Studio and code-first
+  workflows.
 
 ### Newly discovered follow-on topics
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -4,7 +4,7 @@ This document summarizes the existing documentation structure and key topics cov
 
 ## Overview
 
-The documentation currently contains 67 markdown files organized into the following sections:
+The documentation currently contains a broad set of markdown pages organized into the following sections:
 
 
 ### ACTIVITIES (7 pages)
@@ -86,8 +86,9 @@ The documentation currently contains 67 markdown files organized into the follow
 - **Introduction** (`multitenancy/introduction.md`)
 - **Setup** (`multitenancy/setup.md`)
 
-### OPERATE (5 pages)
+### OPERATE (6 pages)
 
+- **Monitoring & Observability** (`operate/monitoring-observability.md`)
 - **Incidents** (`operate/incidents/README.md`)
 - **Configuration** (`operate/incidents/configuration.md`)
 - **Strategies** (`operate/incidents/strategies.md`)
@@ -193,7 +194,7 @@ Based on the current structure, the following core concepts are documented:
 5. **Observability & Troubleshooting**
    - ❌ No debugging guide
    - ❌ No troubleshooting common issues
-   - ❌ No monitoring/observability patterns
+   - ⚠️ Monitoring/observability guide now exists, but related guides still need deeper consistency work
 
 6. **Migration & Versioning**
    - ❌ No migration guide from v2 to v3

--- a/guides/api-client/README.md
+++ b/guides/api-client/README.md
@@ -742,9 +742,9 @@ Choose commit strategy based on your durability vs throughput requirements:
 For custom metrics and monitoring:
 
 * **User-defined metrics** for throughput, latency, error rates
-* **Built-in tracing** via Elsa.OpenTelemetry for workflow execution visibility
+* **Built-in OpenTelemetry instrumentation** via `Elsa.Workflows` for workflow execution visibility
 
-See [Performance & Scaling Guide](../performance/) (DOC-021) for observability patterns.
+See [Performance & Scaling Guide](../performance/) and [Monitoring & Observability](../../operate/monitoring-observability.md) for observability patterns.
 
 ### General Recommendations
 

--- a/guides/patterns/README.md
+++ b/guides/patterns/README.md
@@ -650,24 +650,16 @@ See [Clustering Guide](../clustering/) for configuration.
 
 #### Tracing with OpenTelemetry
 
-Elsa provides OpenTelemetry integration via `Elsa.OpenTelemetry`:
+In `release/3.8.0`, Elsa publishes workflow tracing through `Elsa.Workflows`.
 
-* **ActivitySource**: Traces workflow and activity execution
-* **Middleware**: Adds tracing to HTTP endpoints
-
-**Reference:** `elsa-extensions` - `Elsa.OpenTelemetry` ActivitySource and tracing middleware
+* **ActivitySource**: `Elsa.Workflows`
+* **Instrumentation**: workflow and activity execution spans plus built-in metrics
 
 ```csharp
-builder.Services.AddElsa(elsa =>
-{
-    elsa.UseOpenTelemetry(otel =>
-    {
-        otel.ConfigureTracing(tracing =>
-        {
-            tracing.AddSource("Elsa");
-        });
-    });
-});
+using Elsa.Workflows.Telemetry;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource(WorkflowInstrumentation.ActivitySourceName));
 ```
 
 #### Metrics

--- a/guides/performance/README.md
+++ b/guides/performance/README.md
@@ -197,9 +197,9 @@ builder.Services.AddElsa(elsa =>
 
 ## Observability and Monitoring
 
-### Built-in Tracing with Elsa.OpenTelemetry
+### Built-in OpenTelemetry instrumentation
 
-Elsa provides built-in OpenTelemetry integration through the `Elsa.OpenTelemetry` module, which automatically instruments workflow execution with traces and spans.
+In `release/3.8.0`, workflow traces and metrics come from `Elsa.Workflows` itself via `WorkflowInstrumentation.ActivitySourceName` and `WorkflowInstrumentation.MeterName`.
 
 **Configuration:**
 ```csharp
@@ -218,18 +218,6 @@ builder.Services.AddOpenTelemetry()
             .AddSource("Elsa.Workflows")  // Add Elsa's activity source
             .AddOtlpExporter();  // Export to OTLP-compatible backend
     });
-
-builder.Services.AddElsa(elsa =>
-{
-    elsa.UseWorkflows(workflows =>
-    {
-        // Enable OpenTelemetry middleware
-        workflows.UseWorkflowExecutionPipeline(pipeline =>
-        {
-            pipeline.UseDefaultPipeline();
-        });
-    });
-});
 
 var app = builder.Build();
 app.Run();
@@ -286,9 +274,11 @@ public class MetricsMiddleware : IActivityExecutionMiddleware
 }
 ```
 
-> **Important Distinction:** 
-> - **Built-in tracing** (Elsa.OpenTelemetry) provides distributed tracing for debugging and understanding execution flow
+> **Important Distinction:**
+> - **Built-in OpenTelemetry instrumentation** provides distributed tracing for debugging and understanding execution flow
 > - **User-defined metrics** are for custom performance monitoring, alerting, and capacity planning
+
+For the complete release-backed observability story, including Studio diagnostics modules and OTLP collection, see [Monitoring & Observability](../../operate/monitoring-observability.md).
 
 ## Performance Tuning Best Practices
 

--- a/guides/persistence/README.md
+++ b/guides/persistence/README.md
@@ -573,29 +573,26 @@ builder.Services.AddOpenTelemetry()
 | `elsa.bookmark.lookup.duration`        | Bookmark query time             | P95 > 100ms       |
 | `db.connection.pool.active`            | Active database connections     | > 80% of max pool |
 
-### Tracing with Elsa.OpenTelemetry
+### Tracing and telemetry
 
 For distributed tracing of workflow execution including persistence operations:
 
 ```csharp
-using Elsa.OpenTelemetry.Extensions;
-
-builder.Services.AddElsa(elsa =>
-{
-    elsa.UseOpenTelemetry();  // Enable workflow tracing
-});
+using Elsa.Workflows.Telemetry;
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
-        tracing.AddElsaSource();
+        tracing.AddAspNetCoreInstrumentation();
+        tracing.AddHttpClientInstrumentation();
+        tracing.AddSource(WorkflowInstrumentation.ActivitySourceName);
         tracing.AddOtlpExporter();
     });
 ```
 
-See [Performance & Scaling Guide](../performance/) for detailed observability configuration.
+See [Performance & Scaling Guide](../performance/) and [Monitoring & Observability](../../operate/monitoring-observability.md) for the release-backed observability setup.
 
-> **Note:** Elsa provides built-in tracing. Custom metrics (throughput, latency percentiles) are user-defined. See DOC-016 (Monitoring Guide) for implementation patterns.
+> **Note:** Elsa provides built-in OpenTelemetry instrumentation through `Elsa.Workflows`. Custom metrics beyond the built-in counters and histograms are still user-defined.
 
 ## Common Pitfalls
 

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -586,24 +586,23 @@ Monitor these metrics for security anomalies:
 - **Rate Limit Hits:** Track which IPs/tokens are rate-limited
 - **Workflow Cancellations:** Unusual patterns may indicate attacks
 
-### Tracing with Elsa.OpenTelemetry
+### Tracing and diagnostics
 
 Enable distributed tracing to track security-relevant events:
 
-**Reference:** `elsa-extensions/src/modules/diagnostics/Elsa.OpenTelemetry/*`
+**Reference:** `Elsa.Workflows.Core/Telemetry/WorkflowInstrumentation.cs` and `Elsa.Diagnostics.OpenTelemetry/*`
 
 ```csharp
-builder.Services.AddElsa(elsa =>
-{
-    elsa.UseOpenTelemetry(otel =>
+using Elsa.Workflows.Telemetry;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing =>
     {
-        otel.AddElsaActivitySource();
-        otel.AddOtlpExporter(options =>
-        {
-            options.Endpoint = new Uri("http://jaeger:4317");
-        });
+        tracing.AddAspNetCoreInstrumentation();
+        tracing.AddHttpClientInstrumentation();
+        tracing.AddSource(WorkflowInstrumentation.ActivitySourceName);
+        tracing.AddOtlpExporter(options => options.Endpoint = new Uri("http://jaeger:4317"));
     });
-});
 ```
 
 **Security Event Tracing:**
@@ -612,7 +611,7 @@ builder.Services.AddElsa(elsa =>
 - Workflow instance modifications
 - Permission checks
 
-For full monitoring setup, see the **Monitoring Guide** (DOC-016 - to be created).
+For full monitoring setup, see [Monitoring & Observability](../../operate/monitoring-observability.md).
 
 ---
 
@@ -672,7 +671,7 @@ For more troubleshooting guidance, see [Troubleshooting Guide](../troubleshootin
 - [Authentication & Authorization Guide](../authentication.md) - Detailed OIDC and API key setup
 - [Clustering Guide](../clustering/README.md) (DOC-015) - Distributed runtime security
 - [Troubleshooting Guide](../troubleshooting/README.md) (DOC-017) - Diagnosing security issues
-- [Monitoring Guide](#) (DOC-016 - to be created) - Security metrics and alerting
+- [Monitoring & Observability](../../operate/monitoring-observability.md) - Security metrics and alerting
 - [Workflow Patterns Guide](../patterns/README.md) (DOC-018) - Secure workflow design
 
 ---

--- a/guides/troubleshooting/README.md
+++ b/guides/troubleshooting/README.md
@@ -427,24 +427,20 @@ In workflows, the workflow instance ID and correlation ID are automatically adde
 
 ---
 
-## Tracing with Elsa.OpenTelemetry
+## OpenTelemetry tracing and diagnostics
 
-For production observability, Elsa provides OpenTelemetry integration through the `Elsa.OpenTelemetry` package in the [elsa-extensions](https://github.com/elsa-workflows/elsa-extensions) repository.
+In `release/3.8.0`, Elsa emits workflow traces through `Elsa.Workflows` and exposes separate Studio diagnostics modules for structured logs, console logs, and OTLP collection.
 
 **Quick Setup:**
 ```csharp
-using Elsa.OpenTelemetry.Extensions;
+using Elsa.Workflows.Telemetry;
 
-builder.Services.AddElsa(elsa =>
-{
-    elsa.UseOpenTelemetry();  // Adds tracing middleware
-});
-
-// Configure OpenTelemetry exporter
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
-        tracing.AddElsaSource();  // Add Elsa's ActivitySource
+        tracing.AddAspNetCoreInstrumentation();
+        tracing.AddHttpClientInstrumentation();
+        tracing.AddSource(WorkflowInstrumentation.ActivitySourceName);
         tracing.AddOtlpExporter();
     });
 ```
@@ -455,10 +451,11 @@ builder.Services.AddOpenTelemetry()
 - HTTP trigger processing
 - Background job execution
 
-For full setup including metrics export to Prometheus, Grafana dashboards, and distributed tracing with Jaeger, see **DOC-016: Monitoring Guide**.
+For the complete release-backed setup, see [Monitoring & Observability](../../operate/monitoring-observability.md).
 
 **Code Reference:**
-- `src/modules/diagnostics/Elsa.OpenTelemetry/*` (in elsa-extensions) - Contains tracing middleware and `ActivitySource` definitions for OpenTelemetry integration.
+- `src/modules/Elsa.Workflows.Core/Telemetry/WorkflowInstrumentation.cs` - Defines Elsa's `ActivitySource`, `Meter`, counters, and histograms.
+- `src/modules/Elsa.Diagnostics.OpenTelemetry/*` - Provides OTLP ingestion, query APIs, and the Studio diagnostics collector surface.
 
 ---
 

--- a/operate/monitoring-observability.md
+++ b/operate/monitoring-observability.md
@@ -1,0 +1,263 @@
+---
+description: >-
+  Release-backed guide to observing Elsa 3.8.0 with incidents, execution logs,
+  activity execution records, Studio diagnostics, and OpenTelemetry.
+---
+
+# Monitoring & Observability
+
+Elsa 3.8.0 gives you several different observability layers. They solve
+different problems, so it helps to treat them as complementary instead of
+interchangeable.
+
+Use this mapping:
+
+- For a single workflow instance, start with incidents, the workflow journal,
+  and activity execution records.
+- For host application logs, use the Structured Logs or Console Logs diagnostics
+  modules in Studio.
+- For exported traces, metrics, and OTLP logs, use
+  `Elsa.Workflows` OpenTelemetry instrumentation and your OTLP backend.
+- For readiness and liveness, use health checks such as `/health/live` and
+  `/health/ready` in `Elsa.Server.Web`.
+
+## Start with the workflow runtime signals
+
+When you investigate one workflow instance, start with Elsa's own runtime
+records before looking at infrastructure telemetry.
+
+### Incidents
+
+When an activity throws and the exception is not handled inside the workflow,
+Elsa records an incident on the workflow state. In `release/3.8.0`, incidents
+are stored on `WorkflowState.Incidents` and shown in Elsa Studio's workflow
+instance viewer.
+
+Use incidents when you need:
+
+- The failing activity and node ID.
+- The exception message, inner exception, and stack trace.
+- A quick answer to whether the workflow faulted or continued with recorded incidents.
+
+Related docs:
+
+- [Incidents](incidents/README.md)
+- [Incident configuration](incidents/configuration.md)
+
+### Workflow journal
+
+Elsa also keeps a workflow execution journal. The journal is an ordered stream
+of workflow execution log records such as `Started`, `Suspended`, and
+`Faulted`.
+
+In `release/3.8.0`, the workflow APIs expose the journal through:
+
+- `GET /workflow-instances/{id}/journal`
+- `POST /workflow-instances/{id}/journal`
+
+The `POST` variant supports filtering by activity IDs, node IDs, event names,
+and excluded activity types.
+
+Use the journal when you need:
+
+- A timeline of what happened.
+- The sequence of activity transitions.
+- Fault messages without opening raw application logs first.
+
+### Activity execution records
+
+For per-activity inspection, Elsa stores `ActivityExecutionRecord` entries in
+the runtime persistence store. These records are what power activity-level
+inspection in Studio, including state snapshots, outputs, timing, retries, and
+call stack navigation.
+
+In `release/3.8.0`, the relevant APIs include:
+
+- `GET /activity-executions/list`
+- `GET /activity-execution-summaries/list`
+
+Use activity execution records when you need:
+
+- The last captured state of a specific activity.
+- Inputs, outputs, metadata, exception state, and timestamps.
+- Cross-workflow scheduling context and call stack depth.
+
+How much input, output, and internal state Elsa stores is controlled by log
+persistence settings. If activity records are too noisy or contain more data
+than you want to retain, tune them with
+[Log Persistence](../optimize/log-persistence.md).
+
+## Use Studio diagnostics for host-level logs
+
+The runtime signals above are workflow-centric. For host diagnostics,
+Elsa 3.8.0 also ships separate Studio diagnostics modules.
+
+### Structured Logs
+
+`Elsa.Diagnostics.StructuredLogs` captures `ILogger` events, redacts sensitive
+values, keeps a bounded recent buffer, exposes REST endpoints, and streams live
+updates to Studio over SignalR.
+
+Key routes and permission:
+
+- `POST /diagnostics/structured-logs/recent`
+- `GET /diagnostics/structured-logs/sources`
+- `/elsa/hubs/diagnostics/structured-logs`
+- `read:diagnostics:structured-logs`
+
+Use Structured Logs when you want:
+
+- Application logs with categories, levels, timestamps, workflow IDs,
+  correlation IDs, and source metadata.
+- Filtering inside Studio by workflow instance, trace ID, category, level, or
+  source.
+- A safer operator-facing view than raw console output.
+
+### Console Logs
+
+`Elsa.Diagnostics.ConsoleLogs` captures raw `stdout` and `stderr` lines from
+the current process and streams them to Studio.
+
+Key routes and permission:
+
+- `POST /diagnostics/console-logs/recent`
+- `GET /diagnostics/console-logs/sources`
+- `/elsa/hubs/diagnostics/console-logs`
+- `read:diagnostics:console-logs`
+
+Use Console Logs when you want:
+
+- Raw console output exactly as the process emitted it.
+- ANSI-colored output during local troubleshooting.
+- Visibility into output that did not go through `ILogger`.
+
+Prefer Structured Logs for routine operations. Use Console Logs when you
+explicitly need raw process output.
+
+### Self-hosted Elsa Server example
+
+If you host Elsa yourself instead of using the modular sample host, enable the
+diagnostics modules explicitly:
+
+```csharp
+builder.Services.AddElsa(elsa =>
+{
+    elsa
+        .UseStructuredLogs()
+        .UseStructuredLogsDashboard()
+        .UseConsoleLogs()
+        .UseConsoleLogsDashboard();
+});
+
+var app = builder.Build();
+
+app.UseStructuredLogs();
+app.UseConsoleLogs();
+```
+
+## Export traces and metrics with OpenTelemetry
+
+In `release/3.8.0`, workflow tracing and metrics come from `Elsa.Workflows`
+itself. The core instrumentation publishes:
+
+- `ActivitySource`: `Elsa.Workflows`
+- `Meter`: `Elsa.Workflows`
+
+This is the release-backed way to export workflow traces and metrics to
+OTLP-compatible tooling.
+
+```csharp
+using Elsa.Workflows.Telemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddSource(WorkflowInstrumentation.ActivitySourceName)
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddMeter(WorkflowInstrumentation.MeterName)
+        .AddOtlpExporter());
+```
+
+The built-in workflow instrumentation includes workflow and activity spans plus
+counters and histograms such as workflow started, completed, faulted, and
+activity duration.
+
+## Studio OpenTelemetry diagnostics are collector-side
+
+Elsa 3.8.0 also includes `Elsa.Diagnostics.OpenTelemetry`, but it serves a
+different purpose from `Elsa.Workflows` instrumentation.
+
+- `Elsa.Workflows` produces traces and metrics.
+- `Elsa.Diagnostics.OpenTelemetry` ingests, stores, queries, and streams OTLP
+  telemetry for Studio.
+
+The diagnostics collector exposes:
+
+- `POST /elsa/otlp/v1/traces`
+- `POST /elsa/otlp/v1/metrics`
+- `POST /elsa/otlp/v1/logs`
+- `POST /diagnostics/opentelemetry/resources/search`
+- `POST /diagnostics/opentelemetry/traces/search`
+- `GET /diagnostics/opentelemetry/traces/{traceId}`
+- `POST /diagnostics/opentelemetry/metrics/search`
+- `POST /diagnostics/opentelemetry/logs/search`
+- `GET /diagnostics/opentelemetry/storage`
+- `GET /diagnostics/opentelemetry/collector-configuration`
+- `/elsa/hubs/diagnostics/opentelemetry`
+
+Read access requires `read:diagnostics:opentelemetry`. OTLP ingestion can also
+be protected with an API key through
+`OpenTelemetryDiagnosticsOptions.ApiKey`, using the `x-otlp-api-key` header by
+default.
+
+If you use the modular sample host, `Elsa.ModularServer.Web` already shows the
+intended setup for this release:
+
+- it exports logs, traces, and metrics with OpenTelemetry;
+- it uses `WorkflowInstrumentation.ActivitySourceName` and
+  `WorkflowInstrumentation.MeterName`;
+- it enables the `StructuredLogs`, `ConsoleLogs`, and `OpenTelemetry` shell
+  features in configuration.
+
+## Avoid the stale `Elsa.OpenTelemetry` guidance
+
+If you encounter older documentation or examples that tell you to use
+`Elsa.OpenTelemetry` from `elsa-extensions`, treat that guidance as outdated
+for `release/3.8.0`.
+
+For this release branch:
+
+- use `Elsa.Workflows` instrumentation for emitting traces and metrics;
+- use `Elsa.Diagnostics.OpenTelemetry` for collector and Studio diagnostics
+  scenarios;
+- use `Elsa.Diagnostics.StructuredLogs` and `Elsa.Diagnostics.ConsoleLogs` for
+  host log inspection in Studio.
+
+## Recommended operator flow
+
+When a production issue is reported, this order usually produces the fastest
+answer:
+
+1. Open the workflow instance in Studio and check **Status**,
+   **Sub status**, and **Incidents**.
+2. Inspect the workflow journal to see where execution started, suspended,
+   resumed, or faulted.
+3. Open the relevant activity execution record and call stack for the failing
+   branch.
+4. If you still need host context, open **Structured Logs** filtered by
+   workflow instance ID.
+5. If the problem spans multiple services, inspect exported OTLP traces and metrics.
+6. If the host may be unhealthy, verify `/health/ready` before retrying or scaling.
+
+## Related guides
+
+- [Incidents](incidents/README.md)
+- [Log Persistence](../optimize/log-persistence.md)
+- [Performance & Scaling Guide](../guides/performance/README.md)
+- [Troubleshooting Guide](../guides/troubleshooting/README.md)


### PR DESCRIPTION
## Summary
- add a release-backed monitoring and observability guide for Elsa 3.8.0
- update navigation and backlog metadata for DOC-015
- replace stale user-facing `Elsa.OpenTelemetry` references with the current `Elsa.Workflows` and diagnostics module guidance

## Validation
- validated claims against `release/3.8.0` in `elsa-core` and `elsa-studio`
- ran `git diff --check`
- ran `npx --yes markdownlint-cli2 operate/monitoring-observability.md`
- noted that repo-wide markdownlint still reports extensive pre-existing issues in older long-form guides
