### PR TITLE
Add workflow context documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,7 @@
 ## Getting Started
 
 * [Concepts](getting-started/concepts/README.md)
+  * [Workflow Context](getting-started/concepts/workflow-context.md)
   * [Outcomes](getting-started/concepts/outcomes.md)
   * [Correlation ID](getting-started/concepts/correlation-id.md)
 * [Architecture Overview](getting-started/architecture-overview.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-14)
+## Slice Inventory (2026-06-15)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -28,6 +28,7 @@ acceptance criterion below is already complete.
 - `DOC-013` Studio integration
 - `DOC-014` Clustering and distributed hosting
 - `DOC-015` Monitoring and observability
+- `DOC-016` Workflow context V3
 - `DOC-017` Common workflow patterns
 - `DOC-018` Plugins and modules development
 - `DOC-020` EF Core migrations
@@ -41,7 +42,6 @@ acceptance criterion below is already complete.
 
 ### Available next slices
 
-- `DOC-016` Workflow context V3
 - `DOC-019` HTTP endpoint security
 - `DOC-021` Configuration management
 - `DOC-023` Identity provider integrations
@@ -59,11 +59,11 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-- `DOC-016` Workflow context V3: multiple guides assume readers already
-  understand what lives in workflow state, activity state, variables,
-  inputs, outputs, bookmarks, and execution logs. A dedicated release-backed
-  guide would remove repeated confusion across both Studio and code-first
-  workflows.
+- `DOC-019` HTTP endpoint security: the HTTP workflow guides now explain how
+  to build endpoints, but the auth surface is still spread across multiple
+  pages. A single release-backed guide should connect `Authorize`,
+  `HttpEndpoint`, API permissions, public vs authenticated endpoints, and
+  Studio-facing troubleshooting.
 
 ### Newly discovered follow-on topics
 
@@ -74,6 +74,9 @@ acceptance criterion below is already complete.
   `Elsa.Testing.Shared`, `ActivityTestFixture`, and `WorkflowTestFixture`
   so custom activity authors can validate behavior without reverse
   engineering test setup from source.
+- `DOC-052` Workflow state and journal API cookbook: add an operations-facing
+  guide for inspecting workflow state, filtered journal entries, activity
+  executions, and variable mutation endpoints when diagnosing live instances.
 
 ## Critical Priority (Must Have - Block Users)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -49,9 +49,10 @@ The documentation currently contains a broad set of markdown pages organized int
 - **REST API** (`features/alterations/applying-alterations/rest-api.md`)
 - **Logging Framework** (`features/logging-framework.md`)
 
-### GETTING-STARTED (13 pages)
+### GETTING-STARTED (14 pages)
 
 - **>-** (`getting-started/concepts/README.md`)
+- **Workflow Context** (`getting-started/concepts/workflow-context.md`)
 - **Correlation ID** (`getting-started/concepts/correlation-id.md`)
 - **Outcomes** (`getting-started/concepts/outcomes.md`)
 - **Containers** (`getting-started/containers/README.md`)
@@ -123,6 +124,7 @@ Based on the current structure, the following core concepts are documented:
 
 ### Workflows
 - ✅ Basic workflow concepts (Concepts section)
+- ✅ Workflow context, state, variables, inputs, outputs, bookmarks, and incidents
 - ✅ Outcomes and correlation IDs
 - ✅ Running workflows (multiple methods)
 - ✅ Loading workflows from JSON

--- a/getting-started/concepts/README.md
+++ b/getting-started/concepts/README.md
@@ -14,6 +14,8 @@ A workflow is a sequence of steps called **activities** that represents a proces
 
 A workflow instance represents a database-persisted instance of a workflow in execution, encapsulated by the `WorkflowInstance` class.
 
+[Read more](workflow-context.md)
+
 ## Activity
 
 An activity is a unit of work executed by the workflow engine. In Elsa, these are classes implementing the `IActivity` interface and can be linked or composed together to form a workflow.
@@ -73,6 +75,8 @@ Variables can be set at the workflow level to store data. Use dynamic expression
 **In Elsa Studio**: Learn how to reference variables in expressions using JavaScript and C# in the [Expressions guide](../../guides/studio/expressions.md).
 {% endhint %}
 
+[Read more](workflow-context.md)
+
 ## Incident
 
 An incident is an error event that occurred in the workflow. For example, if an activity faults, an incident is recorded as part of the workflow execution.
@@ -82,3 +86,9 @@ An incident is an error event that occurred in the workflow. For example, if an 
 An alteration represents a change that can be applied to a given [workflow instance](./#workflow-instance).
 
 Using alterations, you can modify a workflow instance's state, schedule activities, and more.
+
+## Workflow Context
+
+Workflow execution in Elsa spans workflow-level state, activity-level state, scoped variables, bookmarks, incidents, and execution logs.
+
+[Read more](workflow-context.md)

--- a/getting-started/concepts/workflow-context.md
+++ b/getting-started/concepts/workflow-context.md
@@ -1,0 +1,241 @@
+---
+description: >-
+  Understand what Elsa 3.8 stores in workflow state, activity state, variables,
+  inputs, outputs, bookmarks, incidents, and execution logs.
+---
+
+# Workflow Context
+
+Elsa workflows execute with more than one kind of state in play. Some state belongs to the workflow instance as a whole, some belongs to the currently active activity stack, and some is only available while expressions are being evaluated.
+
+This page explains how that fits together in Elsa `release/3.8.0`, and where each piece shows up in code, APIs, and Elsa Studio.
+
+## The three layers
+
+### Workflow definition
+
+The workflow definition is the published design: activities, variables, inputs, outputs, outcomes, options, and metadata.
+
+In code-first workflows, these are declared on `IWorkflowBuilder`:
+
+```csharp
+protected override void Build(IWorkflowBuilder builder)
+{
+    var customerId = builder.WithInput<string>("CustomerId");
+    builder.WithOutput<string>("Result");
+    var status = new Variable<string>("Status", "Pending");
+
+    builder.WithVariable(status);
+    builder.Root = new Sequence
+    {
+        Activities =
+        {
+            new WriteLine(context => $"Customer: {context.GetInput<string>(customerId)}")
+        }
+    };
+}
+```
+
+This matches the `Inputs`, `Outputs`, and `Variables` collections on `WorkflowBuilder`.
+
+### Workflow instance
+
+A workflow instance is the persisted runtime state for one execution. In Elsa 3.8, `WorkflowState` stores:
+
+- definition identity and version
+- workflow `Input`
+- workflow `Output`
+- workflow `Properties`
+- `Bookmarks`
+- `Incidents`
+- active `ActivityExecutionContexts`
+- scheduled work items and completion callbacks
+- timestamps and execution status
+
+That is the state you inspect in the instance viewer, structured logs, and workflow-instance APIs.
+
+### Activity execution context
+
+Each active activity executes inside an `ActivityExecutionContext`. This is where Elsa keeps activity-local runtime data such as:
+
+- evaluated activity input state in `ActivityState`
+- activity-specific `Properties`
+- lightweight `Metadata`
+- `DynamicVariables`
+- activity `JournalData`
+- bookmarks created by the activity
+
+When a workflow is suspended, Elsa persists the active activity execution contexts as a flattened call stack inside workflow state and reconstructs them when resuming.
+
+## What lives where
+
+| Concern | Where it lives | Notes |
+| --- | --- | --- |
+| Workflow inputs | `WorkflowExecutionContext.Input` / `WorkflowState.Input` | Persisted only for inputs configured with a workflow or workflow-instance storage driver. |
+| Workflow outputs | `WorkflowExecutionContext.Output` / `WorkflowState.Output` | Written explicitly, typically with `SetOutput`. |
+| Workflow properties | `WorkflowExecutionContext.Properties` / `WorkflowState.Properties` | Global property bag for application or activity data. |
+| Variables | Memory blocks referenced by `Variable` objects | Scoped through the expression context chain. |
+| Activity input snapshots | `ActivityExecutionContext.ActivityState` | Persisted for historical/runtime inspection, subject to activity-state filtering. |
+| Bookmarks | `WorkflowExecutionContext.Bookmarks` / `WorkflowState.Bookmarks` | Pause and resume points for blocking work. |
+| Incidents | `WorkflowExecutionContext.Incidents` / `WorkflowState.Incidents` | Recorded failures and diagnostic information. |
+| Execution log | `WorkflowExecutionContext.ExecutionLog` plus persisted log records | Used for the journal and structured log views. |
+
+## Variables and scoping
+
+Variables in Elsa are memory block references. A variable declared as `new Variable<string>("Foo", "Bar")` gets a deterministic ID derived from its name and is resolved through the current expression-context chain.
+
+Variables can be declared at more than one level:
+
+- workflow level
+- container level, such as `Sequence`
+- dynamically at runtime
+
+Scope matters. Elsa resolves variables from the nearest matching scope first. The integration tests on `release/3.8.0` verify that when two scopes define `Foo`, `SetVariable` updates the nearest one.
+
+```csharp
+var workflowLevelVariable = new Variable<string>("Foo", "Workflow Value");
+var sequenceLevelVariable = new Variable<string>("Foo", "Initial Value");
+
+workflow.Root = new Sequence
+{
+    Variables = { workflowLevelVariable },
+    Activities =
+    {
+        new Sequence
+        {
+            Variables = { sequenceLevelVariable },
+            Activities =
+            {
+                new SetVariable
+                {
+                    Variable = sequenceLevelVariable,
+                    Value = new("Sequence Value")
+                },
+                new WriteLine(context => context.GetVariable<string>("Foo"))
+            }
+        }
+    }
+};
+```
+
+Use variables when the data belongs to workflow state that several activities need to read or update over time.
+
+Use workflow inputs when the caller supplies the value at start or resume time.
+
+Use workflow outputs when the workflow needs to return named results to the caller or parent workflow.
+
+## Inputs
+
+Workflow inputs are declared on the workflow definition and stored in the workflow input bag at runtime.
+
+In code, you usually read them in one of two ways:
+
+```csharp
+var message = builder.WithInput<string>("Message");
+
+builder.Root = new WriteLine(context => context.GetInput<string>(message));
+```
+
+```csharp
+builder.Root = new WriteLine(context => context.GetWorkflowInput<string>("Message"));
+```
+
+There is one important nuance in Elsa 3.8: `ExpressionExecutionContext.GetInput(name)` first checks for a variable with that name when the current activity executes inside a composite activity. If such a variable exists, that variable value wins over the workflow input.
+
+For Studio users, workflow inputs are defined on the workflow's **Inputs** tab and can then be referenced from activity editors and expressions.
+
+## Outputs
+
+Workflow outputs are named values declared on the workflow definition. Elsa persists them in `WorkflowExecutionContext.Output` and `WorkflowState.Output`.
+
+Code-first workflows typically declare outputs with `WithOutput<T>()` and set them with the `SetOutput` activity:
+
+```csharp
+var valueInput = builder.WithInput<double>("Value");
+var output = builder.WithOutput<double>("Output");
+
+builder.Root = new Sequence
+{
+    Activities =
+    {
+        new SetOutput
+        {
+            OutputName = new(output.Name),
+            OutputValue = new(context => context.GetInput<double>(valueInput) * 2)
+        }
+    }
+};
+```
+
+`SetOutput` writes to the nearest ancestor output when running inside a composite or workflow-as-activity scenario, and also updates the root workflow output bag when needed.
+
+For Studio users, workflow outputs are defined on the **Outputs** tab and are shown in the workflow instance viewer under **Input/output**.
+
+## Activity state versus variable state
+
+This is a common source of confusion:
+
+- Variables are live workflow data meant to be read and updated by activities and expressions.
+- `ActivityState` is Elsa's persisted snapshot of evaluated activity input values for an activity execution context.
+
+`ActivityState` is useful for diagnostics, replay context, and historical inspection. It is not the main API you should use to exchange data between activities.
+
+Elsa can filter activity state before persistence. For example, the sample server registers an activity-state filter that strips HTTP authentication header values from persisted HTTP request state.
+
+## Bookmarks and suspension
+
+Bookmarks represent places where a workflow can pause and later resume. Blocking activities create them. They are stored on workflow state, not on a separate variable system.
+
+When a workflow blocks:
+
+1. active activity execution contexts are persisted
+2. bookmarks are stored on `WorkflowState.Bookmarks`
+3. the workflow resumes later by selecting the matching bookmark
+
+This is why long-running workflows survive process restarts as long as runtime persistence is configured correctly.
+
+## Incidents
+
+Incidents are workflow-level records of execution failures. They are stored in `WorkflowState.Incidents` and surfaced in Elsa Studio's workflow instance viewer.
+
+Use incidents when you want to understand:
+
+- which activity failed
+- the exception message and stack trace
+- whether a workflow needs retry, cancellation, or manual intervention
+
+## Execution logs and journal data
+
+Elsa records execution-log entries such as `Started`, `Resumed`, `Suspended`, `Completed`, and `Faulted` during workflow and activity execution.
+
+Activity execution contexts also expose `JournalData`, which is appended to execution-log records. Elsa uses that to record details such as selected outcomes and serialized output values.
+
+Use the journal when you need an execution timeline.
+
+Use variables, inputs, outputs, and properties when you need the current state of the workflow.
+
+## Elsa Studio mapping
+
+For workflow authors using Studio:
+
+- **Variables**, **Inputs**, and **Outputs** are workflow-definition tabs.
+- The workflow instance viewer shows **Variables**, **Input/output**, and **Incidents** for a running or completed instance.
+- The alteration designer can also load and modify workflow instance variables.
+- Expression editors can read workflow inputs and variables; see [Expressions in Elsa Studio](../../guides/studio/expressions.md).
+
+## Inspecting and updating instance variables
+
+If you need to inspect or correct variable values on a live workflow instance, use the variable-management API or `IWorkflowInstanceVariableManager`.
+
+That operational workflow is covered in [Workflow Instance Variables](../../operate/workflow-instance-variables.md).
+
+## When to use what
+
+Use this rule of thumb:
+
+- Use **inputs** for caller-supplied values.
+- Use **variables** for mutable workflow state shared across steps.
+- Use **outputs** for named results.
+- Use **properties** for application-owned workflow metadata.
+- Use **bookmarks** to understand why a workflow is waiting.
+- Use **incidents** and the **journal** to diagnose faults and execution history.

--- a/operate/workflow-instance-variables.md
+++ b/operate/workflow-instance-variables.md
@@ -1,16 +1,35 @@
 ---
 description: >-
-  This topic covers various services and API endpoints available for listing and
-  managing the variables of a workflow instance.
+  Inspect and update workflow instance variables through Elsa Studio, the
+  runtime API, or `IWorkflowInstanceVariableManager`.
 ---
 
 # Workflow Instance Variables
 
-Manipulating workflow instance variables is crucial for correcting defects in workflows or variable values. This ability allows quick fixes without restarting processes, minimizing downtime, and ensuring consistent operations. It enables dynamic adjustments for unexpected changes, enhancing system robustness and efficiency.
+Use workflow instance variable management when you need to inspect or correct the current variable values of a running or suspended workflow without restarting it.
 
 {% hint style="info" %}
-**Using Variables in Elsa Studio**: If you're working with variables in the Elsa Studio designer, see the [Expressions guide](../guides/studio/expressions.md) to learn how to reference and manipulate variables using JavaScript and C# expressions in activities like SetVariable.
+If you need the broader model first, read [Workflow Context](../getting-started/concepts/workflow-context.md). That page explains how variables relate to workflow inputs, outputs, activity state, bookmarks, incidents, and the journal.
 {% endhint %}
+
+## What this page is for
+
+This page is specifically about live instance variable inspection and mutation.
+
+Use it when you need to:
+
+- inspect the current values of persisted workflow variables
+- correct a bad value on a suspended instance
+- build an operations tool around Elsa's variable-management API
+
+For authoring variables in workflow definitions, use [Workflow Context](../getting-started/concepts/workflow-context.md) and [Expressions in Elsa Studio](../guides/studio/expressions.md).
+
+## Elsa Studio
+
+Elsa Studio exposes variables in at least two places in 3.8:
+
+- the workflow instance viewer has a **Variables** tab for instance inspection
+- the alterations UI can load workflow instance variables before staging a change
 
 ## Programmatic Access﻿ <a href="#programmatic-access" id="programmatic-access"></a>
 
@@ -67,10 +86,14 @@ Updating variables in a workflow instance can be particularly useful for dynamic
 
 ### Listing﻿ <a href="#api-list-variables" id="api-list-variables"></a>
 
-The workflow instance API also provides an endpoint for retrieving a list of all variables for a specified workflow instance. You can make a `GET` request to the following endpoint:
+The workflow instance API exposes a relative endpoint at `/workflow-instances/{id}/variables`.
+
+If you run the default Elsa Server host, that endpoint is typically available under the global API prefix `/elsa/api`, so the full URL becomes `/elsa/api/workflow-instances/{id}/variables`.
+
+You can retrieve the variables for a workflow instance with:
 
 ```bash
-curl --location
+curl --location \
 'https://localhost:5001/elsa/api/workflow-instances/{your-workflow-instance-id}/variables' \
 --header 'Authorization: ApiKey {your-api-key}'
 ```
@@ -99,10 +122,10 @@ Each item in the response includes the variable's unique `id`, `name`, and `valu
 
 ### Updating﻿ <a href="#api-update-variables" id="api-update-variables"></a>
 
-To update one or more variables in a workflow instance via the API, send a `POST` request to the following endpoint:
+To update one or more variables in a workflow instance, send a `POST` request to the same route:
 
 ```bash
-curl --location
+curl --location \
 'https://localhost:5001/elsa/api/workflow-instances/{your-workflow-instance-id}/variables' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: ApiKey {your-api-key}' \
@@ -120,4 +143,9 @@ curl --location
 }'
 ```
 
-The request payload specifies the `id` of each variable to update, along with the new `value`. Ensure the variable IDs match those in the workflow instance to prevent accidental data mismatches.
+The request payload uses `VariableUpdateValue` records, so each entry contains:
+
+- `id`: the variable ID
+- `value`: the new value
+
+After the update, Elsa saves the workflow instance and returns the resolved variable list.


### PR DESCRIPTION
## Summary
- add a release-backed workflow context concept page for Elsa 3.8
- connect concepts and operations docs so variables, inputs, outputs, bookmarks, incidents, and logs are explained together
- update the slice inventory and current coverage notes for the completed doc slice

## Validation
- git diff --check
- python3 local link existence check for edited docs and SUMMARY.md