### PR TITLE
docs: harden alterations guides against 3.8.0

### DIFF
--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-15)
+## Slice Inventory (2026-06-16)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -36,7 +36,6 @@ acceptance criterion below is already complete.
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
 - `DOC-030` Custom UI components
-- `DOC-037` Alterations
 - `DOC-041` Loading workflows from JSON
 - `DOC-049` Studio custom-elements embedding cookbook
 
@@ -56,6 +55,7 @@ acceptance criterion below is already complete.
 - `DOC-043` Hangfire integration
 - `DOC-047` API reference
 - `DOC-048` Activity reference
+- `DOC-053` Alterations operational guide hardening
 
 ### Recommended next slice
 
@@ -79,6 +79,16 @@ acceptance criterion below is already complete.
   executions, and variable mutation endpoints when diagnosing live instances.
 
 ## Critical Priority (Must Have - Block Users)
+
+### Current slice note
+
+- `DOC-053` Alterations operational guide hardening:
+  `features/alterations` is present, but the current pages are not fully
+  release-backed. Examples still use pre-filter plan payloads, omit the built-in
+  `Cancel` alteration, describe `/alterations/run` as requiring manual resume
+  dispatch even though the endpoint already dispatches successful instances with
+  scheduled work, and do not explain the Studio alterations surface or the
+  persistence/dispatcher options available in `release/3.8.0`.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/features/alterations/README.md
+++ b/features/alterations/README.md
@@ -2,13 +2,70 @@
 
 An [alteration](../../getting-started/concepts/#alteration) represents a change that can be applied to a given [workflow instance](../../getting-started/concepts/#workflow-instance).
 
-Using alterations, you can modify a workflow instance's state, schedule activities, and more.
+Using alterations, you can change the state of a running workflow instance without republishing the workflow definition. In `release/3.8.0`, Elsa exposes alterations through server APIs and Elsa Studio.
+
+## When to use alterations
+
+Use alterations when you need to correct or steer existing workflow instances. Typical examples include:
+
+* updating a variable on a live instance
+* scheduling an activity so a stalled workflow can continue
+* canceling a workflow or a specific running activity
+* migrating a running instance to a newer published workflow version
 
 ## Alteration Types <a href="#alteration-types" id="alteration-types"></a>
 
 Elsa Workflows supports the following alteration types:
 
-* **ModifyVariable**: Modifies a variable.
-* **Migrate**: Migrates a workflow instance to a new version.
-* **ScheduleActivity**: Schedules an activity to be executed.
-* **CancelActivity**: Cancels an activity. For example, `Delay`, `Event`, `MessageReceived`, etc.
+* **Cancel**: Cancels the entire workflow instance.
+* **CancelActivity**: Cancels a specific running activity instance, or all running instances of an activity ID.
+* **ScheduleActivity**: Schedules an activity for execution by activity ID or activity instance ID.
+* **ModifyVariable**: Modifies a workflow variable by variable ID.
+* **Migrate**: Migrates a workflow instance to a newer published version of the same workflow definition.
+
+## Two execution modes
+
+Elsa supports two ways to execute alterations:
+
+1. Submit an **alteration plan** when you want Elsa to select target instances from a filter and process them asynchronously in the background.
+2. **Apply alterations immediately** when you already know the workflow instance IDs and want the results in the current request.
+
+Use these pages for each mode:
+
+* [Alteration Plans](alteration-plans/README.md)
+* [Applying Alterations](applying-alterations/README.md)
+
+## Elsa Studio
+
+Elsa Studio in `release/3.8.0` includes an alterations module. When the backend Alterations feature is enabled, Studio shows an **Alterable instances** page and adds **Alter** actions for running workflow instances.
+
+Studio currently focuses on altering individual running instances. For bulk operations across many instances, use alteration plans and their filter-based API.
+
+## Persistence and dispatch options
+
+By default, Alterations uses in-memory stores and an in-memory background dispatcher. For durable or multi-node deployments, configure persistence for alteration plans and jobs:
+
+```csharp
+services.AddElsa(elsa => elsa.UseAlterations(alterations =>
+{
+    alterations.UseEntityFrameworkCore(ef => ef.UseSqlServer(connectionString));
+}));
+```
+
+MongoDB persistence is available from `elsa-extensions`:
+
+```csharp
+services.AddElsa(elsa => elsa.UseAlterations(alterations =>
+{
+    alterations.UseMongoDb();
+}));
+```
+
+`elsa-extensions` also provides a MassTransit-backed dispatcher for background alteration jobs:
+
+```csharp
+services.AddElsa(elsa => elsa.UseAlterations(alterations =>
+{
+    alterations.UseMassTransitDispatcher();
+}));
+```

--- a/features/alterations/alteration-plans/README.md
+++ b/features/alterations/alteration-plans/README.md
@@ -1,21 +1,43 @@
 # Alteration Plans
 
-An alteration plan represents a collection of alterations that can be applied to a workflow instance or a set of workflow instances.
+An alteration plan represents a collection of alterations that Elsa applies asynchronously to workflow instances selected by a filter.
+
+Use alteration plans when you want Elsa to:
+
+* select workflow instances for you
+* create one alteration job per matching instance
+* process the work in the background
+* let you inspect plan status and per-instance job status separately
+
+In `release/3.8.0`, `IAlterationPlanScheduler` accepts `AlterationPlanParams`, which contains:
+
+* `alterations`: the changes to apply
+* `filter`: an `AlterationWorkflowInstanceFilter` describing which workflow instances to target
+* `id`: an optional plan ID; Elsa generates one when omitted
 
 ### Creating Alteration Plans <a href="#creating-alteration-plans" id="creating-alteration-plans"></a>
 
-To create an alteration plan, create a new instance of the `NewAlterationPlan` class. For example:
+To create an alteration plan in code, create an `AlterationPlanParams` instance:
 
 ```csharp
-var plan = new NewAlterationPlan
+var plan = new AlterationPlanParams
 {
     Alterations = new List<IAlteration>
     {
-        new ModifyVariable("MyVariable", "MyValue")
+        new ModifyVariable
+        {
+            VariableId = "83fde420b5794bc39a0a7db725405511",
+            Value = "MyValue"
+        }
     },
-    WorkflowInstanceIds = new[] { "26cf02e60d4a4be7b99a8588b7ac3bb9" } 
+    Filter = new AlterationWorkflowInstanceFilter
+    {
+        WorkflowInstanceIds = new[] { "26cf02e60d4a4be7b99a8588b7ac3bb9" }
+    }
 };
 ```
+
+The workflow-instance filter supports more than explicit instance IDs. In `release/3.8.0`, you can also filter by correlation IDs, names, search term, definition IDs, definition version IDs, statuses, sub-statuses, incidents, system-workflow flag, activity filters, and timestamp filters.
 
 ### Submitting Alteration Plans <a href="#submitting-alteration-plans" id="submitting-alteration-plans"></a>
 
@@ -26,18 +48,20 @@ var scheduler = serviceProvider.GetRequiredService<IAlterationPlanScheduler>();
 var planId = await scheduler.SubmitAsync(plan, cancellationToken);
 ```
 
-When a plan is submitted, an **alteration job** is created for each workflow instance, to which each alteration will be applied.
+When a plan is submitted, Elsa dispatches the built-in `Elsa.Alterations.ExecuteAlterationPlan` system workflow. That workflow stores the plan, finds matching workflow instances from the filter, creates one **alteration job** per matching instance, and dispatches those jobs through the configured alteration job dispatcher.
 
 Alteration plans are executed asynchronously in the background. To monitor the execution of an alteration plan, use the `IAlterationPlanStore` service. For example:
 
 ```csharp
 var store = serviceProvider.GetRequiredService<IAlterationPlanStore>();
-var plan = await _alterationPlanStore.FindAsync(new AlterationPlanFilter { Id = planId }, cancellationToken);
+var plan = await store.FindAsync(new AlterationPlanFilter { Id = planId }, cancellationToken);
 ```
 
 To get the alteration jobs that were created as part of the plan, use the `IAlterationJobStore` service. For example:
 
 ```csharp
 var store = serviceProvider.GetRequiredService<IAlterationJobStore>();
-var jobs = (await _alterationJobStore.FindManyAsync(new AlterationJobFilter { PlanId = planId }, cancellationToken)).ToList();
+var jobs = (await store.FindManyAsync(new AlterationJobFilter { PlanId = planId }, cancellationToken)).ToList();
 ```
+
+If the filter matches no workflow instances, Elsa still stores the plan, but it does not create jobs.

--- a/features/alterations/alteration-plans/rest-api.md
+++ b/features/alterations/alteration-plans/rest-api.md
@@ -1,34 +1,40 @@
 # REST API
 
-The Alterations module exposes a REST API for managing alteration plans. For example, to submit a plan that modifies a variable, migrates the workflow instance to a new version and to schedule an activity, use the following request:
+The Alterations module exposes a REST API for submitting, inspecting, and dry-running alteration plans.
+
+## Submit a plan
+
+Send `POST /alterations/submit` with `alterations` plus a `filter`:
 
 ```http
 POST /alterations/submit HTTP/1.1
 Host: localhost:5001
 
 {
-    "alterations": [
-        {
-            "type": "ModifyVariable",
-            "variableId": "83fde420b5794bc39a0a7db725405511",
-            "value": "Hello world!"
-        },
-        {
-            "type": "Migrate",
-            "targetVersion": 9
-        },
-        {
-            "type": "ScheduleActivity",
-            "activityId": "mY1rb4GRjkW3urm8dcNSog"
-        }
-    ],
+  "alterations": [
+    {
+      "type": "ModifyVariable",
+      "variableId": "83fde420b5794bc39a0a7db725405511",
+      "value": "Hello world!"
+    },
+    {
+      "type": "Migrate",
+      "targetVersion": 9
+    },
+    {
+      "type": "ScheduleActivity",
+      "activityId": "mY1rb4GRjkW3urm8dcNSog"
+    }
+  ],
+  "filter": {
     "workflowInstanceIds": [
-        "88ce68d00e824c78a53af04f16d276ea"
+      "88ce68d00e824c78a53af04f16d276ea"
     ]
+  }
 }
 ```
 
-The response wil include the Plan ID:
+The response includes the generated or accepted plan ID:
 
 ```json
 {
@@ -36,14 +42,42 @@ The response wil include the Plan ID:
 }
 ```
 
-You can use the Plan ID to query the status of the plan:
+## Dry-run a filter
+
+Use `POST /alterations/dry-run` to see which workflow instances a filter would target without creating a plan:
+
+```http
+POST /alterations/dry-run HTTP/1.1
+Host: localhost:5001
+
+{
+  "definitionIds": ["order-processing"],
+  "statuses": ["Running"],
+  "isSystem": false
+}
+```
+
+Example response:
+
+```json
+{
+  "workflowInstanceIds": [
+    "88ce68d00e824c78a53af04f16d276ea",
+    "23f2c2585cb14f5bb7da4e2cc2d6f0cb"
+  ]
+}
+```
+
+## Get plan and job status
+
+Use the plan ID to query the current plan and its jobs:
 
 ```bash
-GET /elsa/api/alterations/6cdc459867a94027a6f237417acf398f HTTP/1.1
+GET /alterations/6cdc459867a94027a6f237417acf398f HTTP/1.1
 Host: localhost:5001
 ```
 
-The response will include the plan's status:
+The response includes the stored plan and any generated jobs:
 
 ```json
 {
@@ -59,11 +93,15 @@ The response will include the plan's status:
         "activityId": "BK2-RkUrgkmMj3RIkKfh9g"
       }
     ],
-    "workflowInstanceIds": [
-      "5d87afa152e54f88ac22e5d69ead6b69"
-    ],
+    "workflowInstanceFilter": {
+      "workflowInstanceIds": [
+        "5d87afa152e54f88ac22e5d69ead6b69"
+      ],
+      "isSystem": false
+    },
     "status": 2,
     "createdAt": "2023-10-04T22:34:31.28188+00:00",
+    "startedAt": "2023-10-04T22:34:31.30000+00:00",
     "completedAt": "2023-10-04T22:34:31.44371+00:00",
     "id": "6cdc459867a94027a6f237417acf398f"
   },
@@ -85,6 +123,7 @@ The response will include the plan's status:
         }
       ],
       "createdAt": "2023-10-04T22:34:31.28188+00:00",
+      "startedAt": "2023-10-04T22:34:31.39000+00:00",
       "completedAt": "2023-10-04T22:34:31.426614+00:00",
       "id": "92062c77cbcd419a87ac621886e5f60a"
     }
@@ -92,81 +131,4 @@ The response will include the plan's status:
 }
 ```
 
-## Immediate Alterations <a href="#immediate-alterations" id="immediate-alterations"></a>
-
-Instead of submitting alteration plans for asynchronous execution, you can apply alterations immediately using the `IAlterationRunner` service. For example:
-
-```csharp
-var alterations = new List<IAlteration>
-{
-    new ModifyVariable("MyVariable", "MyValue")
-},
-
-var workflowInstanceIds = new[] { "26cf02e60d4a4be7b99a8588b7ac3bb9" };
-var runner = serviceProvider.GetRequiredService<IAlterationRunner>();
-var results = await runner.RunAsync(plan, cancellationToken);
-```
-
-When an alteration plan is executed immediately, the alterations are applied synchronously and the results are returned. You will have to manually schedule affected workflow instances to resume execution. Use the `IAlteredWorkflowDispatcher`:
-
-```
-var dispatcher = serviceProvider.GetRequiredService<IAlteredWorkflowDispatcher>();
-await dispatcher.DispatchAsync(results, cancellationToken);
-```
-
-This will tell the workflow engine to pickup the altered workflow instances and execute them.
-
-## Extensibility <a href="#extensibility" id="extensibility"></a>
-
-Elsa Workflows supports custom alteration types, allowing developers to define their own types and utilise them as alterations.
-
-To define a custom alteration type, implement the `IAlteration` interface.
-
-```csharp
-public interface IAlteration
-{
-}
-```
-
-Next, implement an **alteration handler** that handles the alteration type.
-
-```csharp
-public interface IAlterationHandler where T : IAlteration
-{
-    bool CanHandle(IAlteration alteration);
-    ValueTask HandleAsync(AlterationHandlerContext context);
-}
-```
-
-Or, derive from the `AlterationHandlerBase<T>` base class to simplify the implementation.
-
-Finally, register the alteration handler with the service collection.
-
-```csharp
-services.AddElsa(elsa => 
-{
-    elsa.UseAlterations(alterations => 
-    {
-        alterations.AddAlteration<MyAlteration, MyAlterationHandler>();
-    })
-});
-```
-
-### Example <a href="#example" id="example"></a>
-
-The following example demonstrates how to define a custom alteration type and handler.
-
-```csharp
-public class MyAlteration : IAlteration
-{
-    public string Message { get; set; }
-}
-
-public class MyAlterationHandler : AlterationHandlerBase<MyAlteration>
-{
-    public override async ValueTask HandleAsync(AlterationHandlerContext<MyAlteration> context, CancellationToken cancellationToken = default)
-    {
-        context.WorkflowExecutionContext.Output.Add("Message", context.Alteration.Message);
-    }
-}
-```
+`status` values are serialized from Elsa's plan and job status enums. Use the plan timestamps and per-job logs to understand whether Elsa found matching instances, whether jobs have started, and which alterations succeeded or failed.

--- a/features/alterations/applying-alterations/README.md
+++ b/features/alterations/applying-alterations/README.md
@@ -1,23 +1,42 @@
 # Applying Alterations
 
-Instead of submitting alteration plans for asynchronous execution, you can apply alterations immediately using the `IAlterationRunner` service. For example:
+Use immediate execution when you already know which workflow instance IDs you want to alter and you want the results in the current request.
+
+At the service level, immediate execution uses `IAlterationRunner`:
 
 ```csharp
 var alterations = new List<IAlteration>
 {
-    new ModifyVariable("MyVariable", "MyValue")
-},
+    new ModifyVariable
+    {
+        VariableId = "83fde420b5794bc39a0a7db725405511",
+        Value = "MyValue"
+    }
+};
 
 var workflowInstanceIds = new[] { "26cf02e60d4a4be7b99a8588b7ac3bb9" };
 var runner = serviceProvider.GetRequiredService<IAlterationRunner>();
-var results = await runner.RunAsync(plan, cancellationToken);
+var results = await runner.RunAsync(workflowInstanceIds, alterations, cancellationToken);
 ```
 
-When an alteration plan is run immediately, the alterations are applied synchronously, and the results are returned. You will have to manually schedule affected workflow instances to resume execution. Use the `IAlteredWorkflowDispatcher`:
+This updates the specified workflow instances synchronously and returns one `RunAlterationsResult` per instance.
+
+## Resuming scheduled work
+
+When you use `IAlterationRunner` directly, successful alterations may leave workflow instances with scheduled work waiting to be dispatched. In that case, resume them with `IAlteredWorkflowDispatcher`:
 
 ```csharp
 var dispatcher = serviceProvider.GetRequiredService<IAlteredWorkflowDispatcher>();
 await dispatcher.DispatchAsync(results, cancellationToken);
 ```
 
-This will tell the workflow engine to pickup the altered workflow instances and run them.
+The dispatcher only re-dispatches successful results that actually contain scheduled work.
+
+## Service API versus HTTP API
+
+This distinction matters:
+
+* `IAlterationRunner` only runs the alterations and returns the results.
+* `POST /alterations/run` runs the alterations and then automatically dispatches successful instances that have scheduled work.
+
+If you are using the HTTP API, you do not need a separate resume step after a successful `/alterations/run` request.

--- a/features/alterations/applying-alterations/extensibility.md
+++ b/features/alterations/applying-alterations/extensibility.md
@@ -41,14 +41,25 @@ The following example demonstrates how to define a custom alteration type and ha
 ```csharp
 public class MyAlteration : IAlteration
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = default!;
 }
 
 public class MyAlterationHandler : AlterationHandlerBase<MyAlteration>
 {
-    public override async ValueTask HandleAsync(AlterationContext context, MyAlteration alteration)
+    protected override ValueTask HandleAsync(AlterationContext context, MyAlteration alteration)
     {
-        context.WorkflowExecutionContext.Output.Add("Message", context.Alteration.Message);
+        context.WorkflowExecutionContext.Output["Message"] = alteration.Message;
+        context.Succeed();
+        return ValueTask.CompletedTask;
     }
 }
 ```
+
+## Handler guidance
+
+An alteration handler runs inside Elsa's alteration pipeline against an existing workflow instance. In practice, that means your handler should:
+
+* validate that the target activity, variable, or workflow state exists
+* call `context.Succeed()` when the alteration completed successfully
+* call `context.Fail(...)` when the alteration cannot be applied safely
+* schedule additional work only when the workflow should continue after the change

--- a/features/alterations/applying-alterations/rest-api.md
+++ b/features/alterations/applying-alterations/rest-api.md
@@ -1,6 +1,10 @@
 # REST API
 
-The Alterations module exposes a REST API for applying alterations directly. For example, to apply an alteration that modifies a variable, migrates the workflow instance to a new version and to schedule an activity, use the following request:
+The Alterations module exposes `POST /alterations/run` for immediate execution against explicit workflow instance IDs.
+
+Use this endpoint when you already know the target instance IDs and want the results immediately. If you want Elsa to select instances from a filter and process them in the background, use [alteration plans](../alteration-plans/rest-api.md) instead.
+
+For example, to apply an alteration that modifies a variable, migrates the workflow instance to a new version, and schedules an activity, use the following request:
 
 ```http
 POST /alterations/run HTTP/1.1
@@ -28,15 +32,16 @@ Host: localhost:5001
 }
 ```
 
-Notice that the JSON structure is exactly the same as when submitting a plan. The only difference is that the request is sent to the `/alterations/run` endpoint instead of the `/alteration/submit` endpoint.
+Unlike `/alterations/submit`, this endpoint does not accept a filter. It requires explicit `workflowInstanceIds`.
 
-The response wil include the execution results:
+The response includes one result per targeted workflow instance:
 
 ```json
 {
   "results": [
     {
       "workflowInstanceId": "88ce68d00e824c78a53af04f16d276ea",
+      "workflowHasScheduledWork": true,
       "log": {
         "logEntries": [
           {
@@ -61,3 +66,5 @@ The response wil include the execution results:
   ]
 }
 ```
+
+After the runner finishes, the endpoint automatically dispatches any successful workflow instance that still has scheduled work.


### PR DESCRIPTION
## Summary
- rewrite the alterations docs around the actual release/3.8.0 plan and run contracts
- document built-in alteration types, Studio support, and persistence/dispatch options
- update the documentation slice inventory to track the alterations hardening follow-up

## Validation
- validated altered claims against elsa-core, elsa-studio, and elsa-extensions on release/3.8.0
- ran `git diff --check`
- verified all local markdown links in the changed alteration pages resolve
- confirmed stale examples and endpoints were removed from the altered docs