### PR TITLE
docs: clarify Studio OIDC scopes and callbacks

### DIFF
--- a/application-types/elsa-server-+-studio-wasm.md
+++ b/application-types/elsa-server-+-studio-wasm.md
@@ -337,7 +337,7 @@ Next, we will modify the client project.
     ```json
     {
         "Authentication": {
-            "Provider": "ElsaIdentity",
+            "Provider": "OpenIdConnect",
             "OpenIdConnect": {
                 "Authority": "https://login.microsoftonline.com/{tenant-id}/v2.0",
                 "ClientId": "{client-id}",
@@ -359,6 +359,10 @@ Next, we will modify the client project.
         }
     }
     ```
+
+    `AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant as well; if token acquisition or refresh fails for the backend API scope, include the same scope in both `AuthenticationScopes` and `BackendApiScopes`.
+
+    Because this client is Blazor WebAssembly, register `{studio-url}/authentication/login-callback` as the redirect URI and `{studio-url}/authentication/logout-callback` as the logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 4.  **Modify MainLayout.razor**
 
     Update `Layout/MainLayout.razor` with the following code listing:

--- a/application-types/elsa-studio.md
+++ b/application-types/elsa-studio.md
@@ -160,7 +160,7 @@ If you are using .NET 8.0+, you can just use `blazorwasm` instead of `blazorwasm
             "Url": "https://localhost:5001/elsa/api"
         },
         "Authentication": {
-            "Provider": "ElsaIdentity",
+            "Provider": "OpenIdConnect",
             "OpenIdConnect": {
                 "Authority": "https://login.microsoftonline.com/{tenant-id}/v2.0",
                 "ClientId": "{client-id}",
@@ -182,6 +182,10 @@ If you are using .NET 8.0+, you can just use `blazorwasm` instead of `blazorwasm
         }
     }
     ```
+
+    `AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant as well; if token acquisition or refresh fails for the backend API scope, include the same scope in both `AuthenticationScopes` and `BackendApiScopes`.
+
+    Because this example is a Blazor WebAssembly host, register `{studio-url}/authentication/login-callback` as the redirect URI and `{studio-url}/authentication/logout-callback` as the logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 6.  **Update index.html**
 
     To conclude the setup, open the `index.html` file and replace its content with the code showcased below:

--- a/authentication/authentication.md
+++ b/authentication/authentication.md
@@ -56,6 +56,15 @@ For Elsa Studio 3.7, configure the `Elsa.Studio.Authentication.OpenIdConnect` mo
 }
 ```
 
+`AuthenticationScopes` are requested during Studio sign-in. `BackendApiScopes` are requested when Studio obtains an access token for calls to the Elsa Server API. Some identity providers require the backend API scope to be part of the original sign-in grant before they allow refresh-token or incremental token acquisition for that scope. If your provider behaves this way, include the backend API scope in both arrays, for example `AuthenticationScopes: ["openid", "profile", "offline_access", "elsa_api"]` and `BackendApiScopes: ["elsa_api"]`.
+
+Register the redirect and logout callback URIs for the Studio host model you use:
+
+* Blazor WebAssembly Studio uses `{studio-url}/authentication/login-callback` and `{studio-url}/authentication/logout-callback`.
+* Blazor Server Studio uses `{studio-url}/signin-oidc` and `{studio-url}/signout-callback-oidc` by default.
+
+Studio initiates OIDC logout through `{studio-url}/authentication/logout`.
+
 Use a `ClientSecret` only for confidential clients such as a Blazor Server Studio host. Do not use a client secret for WebAssembly or other browser-hosted public clients; use authorization code flow with PKCE instead.
 
 See the [Authentication & Authorization Guide](../guides/authentication.md#studio-authentication-configuration) for the full Studio OIDC setup.

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -316,7 +316,9 @@ For Blazor Server Studio hosts:
 }
 ```
 
-`ClientSecret` is optional and should only be used by confidential clients such as a Blazor Server Studio host. For Studio WebAssembly, register a SPA/public client and omit the client secret:
+`ClientSecret` is optional and should only be used by confidential clients such as a Blazor Server Studio host. Register `{studio-url}/signin-oidc` as the redirect URI and `{studio-url}/signout-callback-oidc` as the signed-out callback URI unless you override the defaults. Studio initiates logout at `{studio-url}/authentication/logout`.
+
+For Studio WebAssembly, register a SPA/public client and omit the client secret:
 
 ```json
 {
@@ -334,6 +336,8 @@ For Blazor Server Studio hosts:
   }
 }
 ```
+
+Register `{studio-url}/authentication/login-callback` as the WebAssembly redirect URI and `{studio-url}/authentication/logout-callback` as the WebAssembly logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 
 ### Auth0 Integration
 
@@ -356,12 +360,14 @@ Auth0 is a flexible identity platform with extensive features for authentication
 3. Configure **Allowed Callback URLs**:
    ```
    https://your-elsa-server.com/signin-oidc,
+   https://your-studio-server.com/signin-oidc,
    https://your-studio.com/authentication/login-callback
    ```
 4. Configure **Allowed Logout URLs**:
    ```
    https://your-elsa-server.com/signout-callback-oidc,
-   https://your-studio.com/
+   https://your-studio-server.com/signout-callback-oidc,
+   https://your-studio.com/authentication/logout-callback
    ```
 5. Configure **Allowed Web Origins** (for CORS):
    ```
@@ -1105,6 +1111,13 @@ For a Blazor WebAssembly Studio host:
 
 Use `ClientSecret` only for confidential clients that can protect the secret, such as Blazor Server. Do not configure a client secret for WebAssembly or any other browser-hosted public client.
 
+Register callback URIs according to the Studio host model:
+
+- Blazor WebAssembly Studio: `{studio-url}/authentication/login-callback` and `{studio-url}/authentication/logout-callback`.
+- Blazor Server Studio: `{studio-url}/signin-oidc` and `{studio-url}/signout-callback-oidc` by default.
+
+Studio initiates OIDC logout at `{studio-url}/authentication/logout`.
+
 The corresponding Program.cs setup uses `AddOpenIdConnectAuth` and `OidcAuthenticatingApiHttpMessageHandler`:
 
 ```csharp
@@ -1132,6 +1145,19 @@ builder.Services.AddRemoteBackend(backendApiConfig);
 `AuthenticationScopes` are requested during sign-in. They usually include identity scopes such as `openid`, `profile`, `email`, and optionally `offline_access`.
 
 `BackendApiScopes` are requested for access tokens sent to the Elsa Server API. Use this when the Elsa Server API has its own scope or audience, such as `api://your-api-app-id/elsa-server-api`.
+
+Some identity providers require the backend API scope to be part of the original sign-in grant before they allow refresh-token or incremental token acquisition for that scope. If Studio signs in successfully but cannot obtain or refresh a backend API token, include the backend API scope in both arrays:
+
+```json
+{
+  "Authentication": {
+    "OpenIdConnect": {
+      "AuthenticationScopes": ["openid", "profile", "offline_access", "api://your-api-app-id/elsa-server-api"],
+      "BackendApiScopes": ["api://your-api-app-id/elsa-server-api"]
+    }
+  }
+}
+```
 
 ### Studio with Elsa.Identity
 
@@ -1285,14 +1311,15 @@ app.UseWorkflowsApi();
      "Authentication": {
        "Provider": "OpenIdConnect",
        "OpenIdConnect": {
-         "AuthenticationScopes": ["openid", "profile", "offline_access"],
+         "AuthenticationScopes": ["openid", "profile", "offline_access", "elsa_api"],
+         "BackendApiScopes": ["elsa_api"],
          "SaveTokens": true
        }
      }
    }
    ```
 
-   For Blazor Server Studio hosts, saved tokens are refreshed by the server-side OIDC cookie events when a refresh token is available. For WebAssembly Studio hosts, Microsoft's Blazor WebAssembly authentication stack handles token renewal through `IAccessTokenProvider`.
+   For Blazor Server Studio hosts, saved tokens are refreshed by the server-side OIDC cookie events when a refresh token is available. For WebAssembly Studio hosts, Microsoft's Blazor WebAssembly authentication stack handles token renewal through `IAccessTokenProvider`. If your identity provider requires backend API scopes in the original sign-in grant, keep the backend API scope in both `AuthenticationScopes` and `BackendApiScopes`.
 
 ### HTTPS/SSL Certificate Issues
 

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -488,6 +488,10 @@ spec:
   }
   ```
 
+  `AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant as well; if backend API token acquisition or refresh fails, include the same scope in both `AuthenticationScopes` and `BackendApiScopes`.
+
+  Register Studio redirect and logout callback URIs according to the host model: Blazor WebAssembly uses `/authentication/login-callback` and `/authentication/logout-callback`; Blazor Server uses `/signin-oidc` and `/signout-callback-oidc` by default. Studio initiates logout at `/authentication/logout`.
+
 **Authorization:**
 - Implement role-based access control (RBAC) for Studio users
 - Restrict workflow editing to authorized roles:

--- a/guides/security/external-identity-providers.md
+++ b/guides/security/external-identity-providers.md
@@ -131,7 +131,7 @@ Microsoft Entra ID (formerly Azure Active Directory) is Microsoft's cloud-based 
 1. **Register application in Azure Portal**
    - Navigate to Azure Active Directory → App registrations
    - Create new registration for Elsa Server
-   - Configure redirect URIs (e.g., `https://elsa.example.com/signin-oidc`)
+   - Configure redirect URIs for the Elsa Server and Studio host model you use
    - Generate client secret
    - Note Application (client) ID and Directory (tenant) ID
 
@@ -215,7 +215,7 @@ Auth0 is a cloud-based authentication and authorization platform with extensive 
 
 2. **Configure allowed callback URLs**
    - Add `https://elsa.example.com/signin-oidc`
-   - Add `https://studio.example.com/signin-oidc`
+   - Add `https://studio.example.com/signin-oidc` for Blazor Server Studio, or `https://studio.example.com/authentication/login-callback` for Blazor WebAssembly Studio
 
 3. **Define API in Auth0**
    - Create API for Elsa Server
@@ -448,6 +448,15 @@ When using an external IdP, configure Elsa Studio to authenticate users and forw
 Use the Blazor host pattern from [Studio Designer Integration](../studio/integration/README.md) and register the `Elsa.Studio.Authentication.OpenIdConnect` module so Studio can authenticate users and attach access tokens to backend API calls.
 
 For Blazor Server Studio hosts, `ClientSecret` can be added when the OIDC provider requires a confidential client. For WebAssembly Studio hosts, omit `ClientSecret` and register the client as a public SPA using authorization code flow with PKCE.
+
+`AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant before refresh-token or incremental token acquisition can return backend API tokens; in that case, include the backend API scope in both arrays.
+
+Register callback URIs according to the Studio host model:
+
+- Blazor WebAssembly Studio: `https://studio.example.com/authentication/login-callback` and `https://studio.example.com/authentication/logout-callback`.
+- Blazor Server Studio: `https://studio.example.com/signin-oidc` and `https://studio.example.com/signout-callback-oidc` by default.
+
+Studio initiates OIDC logout at `https://studio.example.com/authentication/logout`.
 
 ## REST API Integration
 

--- a/guides/studio/integration/README.md
+++ b/guides/studio/integration/README.md
@@ -132,6 +132,10 @@ With this provider, the server host registers `AddElsaIdentity()` and `AddElsaId
 
 Use `ClientSecret` only for confidential clients such as the server host. In the OpenID Connect modules, bearer tokens for Elsa API calls are attached by `OidcAuthenticatingApiHttpMessageHandler`, and SignalR connections are configured through `OidcHttpConnectionOptionsConfigurator`.
 
+`AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant before refresh-token or incremental token acquisition can return backend API tokens; in that case, include the backend API scope in both arrays.
+
+For Blazor Server Studio, register `{studio-url}/signin-oidc` as the redirect URI and `{studio-url}/signout-callback-oidc` as the signed-out callback URI unless you override the defaults. Studio initiates logout at `{studio-url}/authentication/logout`.
+
 ## Standalone Blazor WebAssembly Host
 
 The WebAssembly host lives in `src/hosts/Elsa.Studio.Host.Wasm`. It registers the same backend-facing modules, but the application runs in the browser and uses the WebAssembly-specific authentication and localization packages.
@@ -164,6 +168,10 @@ Use this host when you want a dedicated SPA-style Studio deployment.
 ```
 
 Do not configure a client secret in WebAssembly. The browser host is a public client.
+
+`AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant before refresh-token or incremental token acquisition can return backend API tokens; in that case, include the backend API scope in both arrays.
+
+For Blazor WebAssembly Studio, register `{studio-url}/authentication/login-callback` as the redirect URI and `{studio-url}/authentication/logout-callback` as the logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 
 ### Elsa Identity Configuration
 


### PR DESCRIPTION
Addresses elsa-workflows/elsa-gitbook#132 comment context for Studio OIDC configuration.

## Summary
- Clarify that AuthenticationScopes are requested at Studio sign-in, while BackendApiScopes are used for backend API access tokens.
- Document that some IdPs require the backend API scope in the original sign-in grant, so users may need to include it in both arrays.
- Distinguish WASM callback/logout callback routes from Blazor Server defaults and document /authentication/logout as the logout initiation route.
- Fix WASM setup examples that included OIDC settings while still selecting ElsaIdentity.

## Coordination
- This PR intentionally excludes concurrent issue #191 permission-claim documentation changes.
- Built from a clean worktree on origin/main to avoid staging Hume's overlapping edits.

## Checks
- git diff --check
- targeted rg scan for OIDC scope and callback/logout route references