### PR TITLE
Document Elsa API permission claims

### DIFF
--- a/authentication/authentication.md
+++ b/authentication/authentication.md
@@ -30,6 +30,12 @@ builder.Services.AddShell(x => x.DisableAuthorization = true);
 
 Use Elsa's built-in identity system for authentication.
 
+Elsa API endpoint authorization is based on permission claims. The claim type is `permissions`; each claim value must match an Elsa API permission, and `*` grants all Elsa API permissions.
+
+Elsa Identity roles collect permission strings. When Elsa Identity issues a token or validates an Elsa API key, permissions from assigned roles are emitted as `permissions` claims. External OIDC providers should emit these values as `permissions` claims, or the host application should map external roles, groups, or scopes into `permissions` claims.
+
+ASP.NET Core `RequireRole(...)` policies can protect custom host endpoints, but they do not replace the `permissions` claims checked by Elsa API endpoints. Permission names come from endpoint configuration and module constants, not only from shared `PermissionNames` constants.
+
 ### Using OIDC (OpenID Connect)
 
 OIDC integration has two parts:

--- a/authentication/authentication.md
+++ b/authentication/authentication.md
@@ -32,7 +32,7 @@ Use Elsa's built-in identity system for authentication.
 
 Elsa API endpoint authorization is based on permission claims. The claim type is `permissions`; each claim value must match an Elsa API permission, and `*` grants all Elsa API permissions.
 
-Elsa Identity roles collect permission strings. When Elsa Identity issues a token or validates an Elsa API key, permissions from assigned roles are emitted as `permissions` claims. External OIDC providers should emit these values as `permissions` claims, or the host application should map external roles, groups, or scopes into `permissions` claims.
+Elsa Identity roles collect permission strings. When Elsa Identity issues a token, permissions from assigned roles are emitted as `permissions` claims. API-key authentication handlers should add equivalent `permissions` claims. External OIDC providers should emit these values as `permissions` claims, or the host application should map external roles, groups, or scopes into `permissions` claims.
 
 ASP.NET Core `RequireRole(...)` policies can protect custom host endpoints, but they do not replace the `permissions` claims checked by Elsa API endpoints. Permission names come from endpoint configuration and module constants, not only from shared `PermissionNames` constants.
 

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -727,8 +727,7 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
         
         var claims = new List<Claim>
         {
-            new Claim(ClaimTypes.Name, apiKey.Owner),
-            new Claim("ApiKey", providedApiKey)
+            new Claim(ClaimTypes.Name, apiKey.Owner)
         };
         
         claims.AddRange(apiKey.Permissions.Select(permission => new Claim("permissions", permission)));

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -22,6 +22,7 @@ Elsa Workflows supports multiple authentication mechanisms to secure both the El
 - [Prerequisites](#prerequisites)
 - [No Authentication (Development Only)](#no-authentication-development-only)
 - [Using Elsa.Identity](#using-elsaidentity)
+- [Elsa API Permission Claims](#elsa-api-permission-claims)
 - [OIDC Configuration](#oidc-configuration)
   - [Azure AD Integration](#azure-ad-integration)
   - [Auth0 Integration](#auth0-integration)
@@ -184,6 +185,31 @@ Use the `accessToken` in subsequent requests:
 GET /elsa/api/workflow-definitions
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
+
+## Elsa API Permission Claims
+
+Elsa API endpoints authorize requests with `permissions` claims. Each claim value must match a permission configured by the endpoint, and `*` grants all Elsa API permissions.
+
+Elsa Identity roles are containers for permission strings. When Elsa Identity issues a JWT or validates an Elsa API key, it collects permissions from the assigned roles and emits them as `permissions` claims. External OIDC providers should emit Elsa permissions directly as `permissions` claims, or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
+
+ASP.NET Core role policies such as `RequireRole("Admin")` are useful for your own host endpoints, Razor pages, controllers, or custom APIs. They do not replace Elsa endpoint permissions.
+
+Permission names are not limited to constants in `PermissionNames`. Shared constants include `*`, `ManageWorkflowRuntime`, expression execution permissions, and bookmark dead-letter permissions. Many endpoints use explicit strings through `ConfigurePermissions(...)`, and feature modules can define their own constants.
+
+| Scenario | Permissions |
+| --- | --- |
+| Full Elsa API access | `*` |
+| Read workflow definitions | `read:workflow-definitions` |
+| Read workflow instances, variables, and journal data | `read:workflow-instances` |
+| Read activity execution results and summaries | `read:activity-execution` |
+| Read common Studio metadata | `read:activity-descriptors`, `read:activity-descriptors-options`, `read:expression-descriptors`, `read:storage-drivers`, `read:variable-descriptors`, `read:installed-features` |
+| Create or edit workflow definitions | `write:workflow-definitions` |
+| Publish or retract workflow definitions | `publish:workflow-definitions`, `retract:workflow-definitions` |
+| Execute or dispatch workflow definitions | `exec:workflow-definitions` |
+| Cancel or delete workflow instances | `cancel:workflow-instances`, `delete:workflow-instances` |
+| Runtime administration | `ManageWorkflowRuntime` |
+
+For read-only workflow instance and execution result screens, start with `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. The current runtime status endpoint requires `ManageWorkflowRuntime`, which also grants pause, resume, and force-drain authority.
 
 ## OIDC Configuration
 
@@ -582,7 +608,7 @@ public class ApiKey
     public string Owner { get; set; }
     public DateTime Created { get; set; }
     public DateTime? Expires { get; set; }
-    public List<string> Roles { get; set; } = new();
+    public List<string> Permissions { get; set; } = new();
     public bool IsActive { get; set; } = true;
 }
 ```
@@ -595,7 +621,7 @@ Implement a store to manage API keys:
 public interface IApiKeyStore
 {
     Task<ApiKey?> GetApiKeyAsync(string key);
-    Task<ApiKey> CreateApiKeyAsync(string owner, List<string> roles, DateTime? expires = null);
+    Task<ApiKey> CreateApiKeyAsync(string owner, List<string> permissions, DateTime? expires = null);
     Task RevokeApiKeyAsync(string key);
 }
 
@@ -609,7 +635,7 @@ public class InMemoryApiKeyStore : IApiKeyStore
         return Task.FromResult(apiKey);
     }
     
-    public Task<ApiKey> CreateApiKeyAsync(string owner, List<string> roles, DateTime? expires = null)
+    public Task<ApiKey> CreateApiKeyAsync(string owner, List<string> permissions, DateTime? expires = null)
     {
         var apiKey = new ApiKey
         {
@@ -617,7 +643,7 @@ public class InMemoryApiKeyStore : IApiKeyStore
             Owner = owner,
             Created = DateTime.UtcNow,
             Expires = expires,
-            Roles = roles,
+            Permissions = permissions,
             IsActive = true
         };
         
@@ -705,7 +731,7 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
             new Claim("ApiKey", providedApiKey)
         };
         
-        claims.AddRange(apiKey.Roles.Select(role => new Claim(ClaimTypes.Role, role)));
+        claims.AddRange(apiKey.Permissions.Select(permission => new Claim("permissions", permission)));
         
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var principal = new ClaimsPrincipal(identity);
@@ -756,7 +782,7 @@ app.MapPost("/api/api-keys", async (IApiKeyStore store, CreateApiKeyRequest requ
 {
     var apiKey = await store.CreateApiKeyAsync(
         request.Owner,
-        request.Roles,
+        request.Permissions,
         request.ExpiresInDays.HasValue 
             ? DateTime.UtcNow.AddDays(request.ExpiresInDays.Value) 
             : null);
@@ -772,7 +798,7 @@ app.MapDelete("/api/api-keys/{key}", async (IApiKeyStore store, string key) =>
 })
 .RequireAuthorization();
 
-record CreateApiKeyRequest(string Owner, List<string> Roles, int? ExpiresInDays);
+record CreateApiKeyRequest(string Owner, List<string> Permissions, int? ExpiresInDays);
 ```
 
 #### Step 6: Using API Keys
@@ -814,7 +840,7 @@ public class DbApiKeyStore : IApiKeyStore
             .FirstOrDefaultAsync(x => x.Key == key);
     }
     
-    public async Task<ApiKey> CreateApiKeyAsync(string owner, List<string> roles, DateTime? expires = null)
+    public async Task<ApiKey> CreateApiKeyAsync(string owner, List<string> permissions, DateTime? expires = null)
     {
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
         
@@ -824,7 +850,7 @@ public class DbApiKeyStore : IApiKeyStore
             Owner = owner,
             Created = DateTime.UtcNow,
             Expires = expires,
-            Roles = roles,
+            Permissions = permissions,
             IsActive = true
         };
         
@@ -1374,9 +1400,9 @@ options.TokenOptions = options =>
 };
 ```
 
-### 4. Use Role-Based Access Control
+### 4. Use Role-Based Access Control for Host Endpoints
 
-Implement role-based authorization:
+Implement role-based authorization for your own ASP.NET Core endpoints:
 
 ```csharp
 builder.Services.AddAuthorization(options =>
@@ -1398,6 +1424,8 @@ Apply to endpoints:
 app.MapGet("/admin/users", () => { /* ... */ })
    .RequireAuthorization("AdminOnly");
 ```
+
+These policies apply to endpoints you map yourself. Elsa API endpoints use `permissions` claims, so external roles must still be translated into Elsa permission values such as `read:workflow-definitions`, `read:workflow-instances`, or `*`.
 
 ### 5. Implement Rate Limiting
 
@@ -1493,7 +1521,7 @@ public async Task<ApiKey> RotateApiKeyAsync(string oldKey)
     // Create new key with same permissions
     var newApiKey = await CreateApiKeyAsync(
         oldApiKey.Owner,
-        oldApiKey.Roles,
+        oldApiKey.Permissions,
         DateTime.UtcNow.AddDays(90));
     
     // Mark old key for deactivation after grace period

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -190,7 +190,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 Elsa API endpoints authorize requests with `permissions` claims. Each claim value must match a permission configured by the endpoint, and `*` grants all Elsa API permissions.
 
-Elsa Identity roles are containers for permission strings. When Elsa Identity issues a JWT or validates an Elsa API key, it collects permissions from the assigned roles and emits them as `permissions` claims. External OIDC providers should emit Elsa permissions directly as `permissions` claims, or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
+Elsa Identity roles are containers for permission strings. When Elsa Identity issues a JWT, it collects permissions from the assigned roles and emits them as `permissions` claims. API-key authentication handlers should add equivalent `permissions` claims. External OIDC providers should emit Elsa permissions directly as `permissions` claims, or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
 
 ASP.NET Core role policies such as `RequireRole("Admin")` are useful for your own host endpoints, Razor pages, controllers, or custom APIs. They do not replace Elsa endpoint permissions.
 

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -135,6 +135,16 @@ Authorization: ApiKey YOUR_API_KEY
 
 Elsa validates the API key against configured applications; store hashed API keys and salts in configuration, not raw API keys.
 
+### Elsa API Permission Claims
+
+Elsa API endpoints check the `permissions` claim. Each claim value must match a permission required by the endpoint, and `*` grants all Elsa API permissions.
+
+Elsa Identity roles collect permission strings. When Elsa Identity issues a JWT or validates an Elsa API key, permissions from the assigned roles are emitted as `permissions` claims. External IdPs should emit the same claim type or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
+
+ASP.NET Core policies such as `RequireRole("Admin")` protect custom host endpoints, pages, or controllers. They do not replace Elsa endpoint permission claims. Elsa endpoint permissions come from endpoint configuration and module constants, not only from shared `PermissionNames` constants.
+
+Common read-only workflow access uses `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. Use `*` only for full administrative access.
+
 **Important:**
 - **Never commit secrets** to source control
 - Use environment variables or secret managers (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault)
@@ -489,12 +499,8 @@ spec:
   ```
 
 **Authorization:**
-- Implement role-based access control (RBAC) for Studio users
-- Restrict workflow editing to authorized roles:
-  ```csharp
-  [Authorize(Roles = "WorkflowAdmin")]
-  public class WorkflowDefinitionsController : ControllerBase { }
-  ```
+- Grant Studio users only the Elsa `permissions` claims needed for the screens and actions they can use
+- Use ASP.NET Core role policies for custom host controllers or pages; Elsa API endpoints still require Elsa permission claims
 
 ### Session Affinity for Studio
 

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -139,7 +139,7 @@ Elsa validates the API key against configured applications; store hashed API key
 
 Elsa API endpoints check the `permissions` claim. Each claim value must match a permission required by the endpoint, and `*` grants all Elsa API permissions.
 
-Elsa Identity roles collect permission strings. When Elsa Identity issues a JWT or validates an Elsa API key, permissions from the assigned roles are emitted as `permissions` claims. External IdPs should emit the same claim type or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
+Elsa Identity roles collect permission strings. When Elsa Identity issues a JWT, permissions from the assigned roles are emitted as `permissions` claims. API-key authentication handlers should add equivalent `permissions` claims. External IdPs should emit the same claim type or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
 
 ASP.NET Core policies such as `RequireRole("Admin")` protect custom host endpoints, pages, or controllers. They do not replace Elsa endpoint permission claims. Elsa endpoint permissions come from endpoint configuration and module constants, not only from shared `PermissionNames` constants.
 

--- a/guides/security/external-identity-providers.md
+++ b/guides/security/external-identity-providers.md
@@ -57,14 +57,14 @@ Regardless of the specific provider, the general pattern for integrating Elsa wi
 
 - Install necessary NuGet packages
 - Configure authentication middleware in `Program.cs`
-- Map external claims to Elsa's authorization model
+- Map external claims to Elsa's `permissions` claims
 - Configure token validation parameters
 
 ### 3. Configure Elsa to Use ASP.NET Core Authentication
 
 - Enable Elsa's default authentication
-- Configure authorization policies
-- Map roles and claims to Elsa permissions
+- Ensure the authenticated principal has Elsa API permission claims
+- Use ASP.NET Core authorization policies only for custom host endpoints
 
 ### 4. Configure Elsa Studio (if used)
 
@@ -142,7 +142,7 @@ Microsoft Entra ID (formerly Azure Active Directory) is Microsoft's cloud-based 
 3. **Configure authentication in Elsa Server**
    - Install package: `Microsoft.AspNetCore.Authentication.OpenIdConnect`
    - Configure OIDC authentication middleware
-   - Map Azure AD roles/groups to Elsa authorization policies
+   - Map Azure AD roles/groups to Elsa `permissions` claims
 
 4. **Configure Elsa Studio**
    - Configure Studio OIDC client
@@ -219,7 +219,7 @@ Auth0 is a cloud-based authentication and authorization platform with extensive 
 
 3. **Define API in Auth0**
    - Create API for Elsa Server
-   - Define permissions/scopes (e.g., `workflows:read`, `workflows:write`)
+   - Define or map permissions/scopes to Elsa permission values such as `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`
    - Configure token lifetime
 
 4. **Configure authentication in Elsa Server**
@@ -254,11 +254,8 @@ builder.Services
         };
     });
 
-builder.Services.AddAuthorization(options =>
-{
-    options.AddPolicy("WorkflowAdmin", policy =>
-        policy.RequireClaim("permissions", "workflows:admin"));
-});
+// Auth0 can emit a "permissions" array. Ensure the values are Elsa API
+// permissions, for example "read:workflow-definitions" or "*".
 ```
 
 **Further Reading:**
@@ -323,11 +320,8 @@ builder.Services
         options.ClaimActions.MapJsonKey("role", "roles");
     });
 
-builder.Services.AddAuthorization(options =>
-{
-    options.AddPolicy("WorkflowAdmin", policy =>
-        policy.RequireRole("workflow-admin"));
-});
+// Add an OnTokenValidated handler to translate Keycloak roles into
+// "permissions" claims before requests reach Elsa API endpoints.
 ```
 
 **Further Reading:**
@@ -374,52 +368,64 @@ builder.Services
 
 ## Authorization and Claims Mapping
 
-After authentication, you need to map external claims to Elsa's authorization model.
+After authentication, Elsa API endpoints authorize requests with `permissions` claims. Each claim value must match a permission configured by the endpoint, and `*` grants all Elsa permissions.
 
-### Mapping Roles
+Elsa Identity roles are containers for permission strings. When Elsa Identity issues tokens, assigned role permissions are emitted as `permissions` claims. With an external IdP, either emit the same claim type from the provider or map external roles, groups, or scopes into `permissions` claims in the Elsa Server host.
 
-```csharp
-builder.Services.AddAuthorization(options =>
-{
-    // Map external roles to Elsa policies
-    options.AddPolicy("WorkflowAdmin", policy =>
-        policy.RequireRole("WorkflowAdmin", "admin", "workflow_admin"));
-    
-    options.AddPolicy("WorkflowDesigner", policy =>
-        policy.RequireRole("WorkflowDesigner", "designer", "workflow_designer"));
-    
-    options.AddPolicy("WorkflowViewer", policy =>
-        policy.RequireRole("WorkflowViewer", "viewer", "workflow_viewer"));
-});
-```
-
-### Custom Claims
+### Mapping External Roles to Elsa Permissions
 
 ```csharp
 builder.Services
-    .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-    .AddOpenIdConnect(options =>
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
     {
-        // ... other config ...
-        
-        options.Events = new OpenIdConnectEvents
+        // ... authority, audience, and token validation ...
+
+        options.Events = new JwtBearerEvents
         {
             OnTokenValidated = context =>
             {
-                var claimsIdentity = (ClaimsIdentity)context.Principal.Identity;
-                
-                // Add custom claims based on external claims
-                var permissions = context.Principal.FindAll("permissions");
-                foreach (var permission in permissions)
+                var identity = (ClaimsIdentity)context.Principal!.Identity!;
+
+                if (context.Principal.IsInRole("workflow-viewer"))
                 {
-                    claimsIdentity.AddClaim(new Claim("elsa_permission", permission.Value));
+                    identity.AddClaim(new Claim("permissions", "read:workflow-definitions"));
+                    identity.AddClaim(new Claim("permissions", "read:workflow-instances"));
+                    identity.AddClaim(new Claim("permissions", "read:activity-execution"));
                 }
-                
+
+                if (context.Principal.IsInRole("workflow-admin"))
+                    identity.AddClaim(new Claim("permissions", "*"));
+
                 return Task.CompletedTask;
             }
         };
     });
 ```
+
+ASP.NET Core role policies still apply to endpoints you map yourself:
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("HostAdminOnly", policy => policy.RequireRole("admin"));
+});
+
+app.MapGet("/host/admin", () => Results.Ok())
+   .RequireAuthorization("HostAdminOnly");
+```
+
+These policies do not replace Elsa API permissions. Elsa endpoint permissions come from endpoint configuration such as `ConfigurePermissions(...)` and from module constants, not only from the shared `PermissionNames` constants.
+
+Common read-only workflow access uses:
+
+```text
+read:workflow-definitions
+read:workflow-instances
+read:activity-execution
+```
+
+Add Studio metadata permissions only as needed, such as `read:activity-descriptors`, `read:expression-descriptors`, `read:storage-drivers`, `read:variable-descriptors`, and `read:installed-features`.
 
 ## Elsa Studio Configuration
 
@@ -504,7 +510,7 @@ For comprehensive security guidance, see:
 - Check claim names in token (decode JWT at jwt.io)
 - Verify claims mapping in OIDC options
 - Ensure roles/permissions are assigned in IdP
-- Review authorization policies
+- Verify the authenticated principal has the `permissions` claims required by the Elsa endpoint
 
 #### CORS Errors
 
@@ -535,7 +541,7 @@ The following sections will be expanded in future documentation updates:
 
 - **Configure your IdP**: Follow provider-specific documentation
 - **Test authentication flow**: Verify token issuance and validation
-- **Implement authorization**: Map roles and claims to Elsa policies
+- **Implement authorization**: Map roles and claims to Elsa `permissions` claims
 - **Deploy to production**: Follow [Security Guide](README.md) best practices
 - **Monitor authentication**: Set up logging and alerting
 

--- a/guides/security/external-identity-providers.md
+++ b/guides/security/external-identity-providers.md
@@ -374,6 +374,8 @@ Elsa Identity roles are containers for permission strings. When Elsa Identity is
 
 ### Mapping External Roles to Elsa Permissions
 
+The following example uses JWT bearer authentication because Elsa Server API endpoints validate access tokens on incoming API requests. Use OpenID Connect middleware for interactive sign-in flows, typically paired with cookies, and use JWT bearer middleware for API access-token validation.
+
 ```csharp
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/guides/security/external-identity-providers.md
+++ b/guides/security/external-identity-providers.md
@@ -320,8 +320,8 @@ builder.Services
         options.ClaimActions.MapJsonKey("role", "roles");
     });
 
-// Add an OnTokenValidated handler to translate Keycloak roles into
-// "permissions" claims before requests reach Elsa API endpoints.
+// Translate Keycloak roles into "permissions" claims in the authentication
+// handler that protects Elsa API endpoints, usually AddJwtBearer.
 ```
 
 **Further Reading:**


### PR DESCRIPTION
## Summary
- document Elsa API endpoint authorization through the `permissions` claim and `*` all-access grant
- explain Elsa Identity role-to-permission claim behavior and external IdP claim mapping
- clarify that ASP.NET Core role policies do not replace Elsa endpoint permissions
- add least-privilege examples for read-only workflow definitions, instances, and activity execution results

Closes #191.

## Checks
- git diff --check
- stale-term scan for incorrect claim names and obsolete examples