### PR TITLE
docs: expand MassTransit messaging guide

### DIFF
--- a/activities/masstransit/README.md
+++ b/activities/masstransit/README.md
@@ -1,18 +1,88 @@
 # MassTransit
 
-MassTransit is an open-source distributed application framework for .NET that provides a consistent abstraction on top of the supported message transports.
+MassTransit integration in Elsa lets you expose selected .NET message types as workflow activities. In `release/3.8.0`, Elsa generates these activities dynamically from the message types you register with the MassTransit feature.
 
-It enables .NET developers to model messages as C# types, which can then be sent & received. To receive messages, one would typically write a Consumer.
+Use this integration when you want workflows to publish application messages or wait for messages that arrive through a MassTransit bus.
 
-When using the MassTransit module with Elsa, there is an additional method of sending & handling messages; through workflow activities.
+## What This Feature Does
 
-## Messages as Activities﻿
+After you call `UseMassTransit(...)` and register one or more message types with `AddMessageType<T>()`, Elsa adds dynamic activities for those types:
 
-Elsa makes it easy to send and receive messages that are modeled as .NET type. All you need to do is define your type and then register it with the MassTransit feature.
+- A trigger activity named after the message type, implemented by `MessageReceived`
+- For class types only, an action activity named `Publish {MessageType}`, implemented by `PublishMessage`
 
-When a message type is registered, two new activities will be automatically available for use:
+For example, registering `OrderCreated` adds:
 
-* Publish {activity type}
-* {activity type}
+- `Order Created`
+- `Publish Order Created`
 
-The first activity will _publish_ your message. The second activity acts as a trigger and will start or resume your workflow when a message of this type is received.
+This behavior comes from `MassTransitActivityTypeProvider`, which creates a `MessageReceived` descriptor for every registered message type and a `PublishMessage` descriptor only when the type is a class.
+
+## Registration and Transport
+
+Install the base package for the feature and one transport package when you need broker-backed messaging:
+
+- `Elsa.ServiceBus.MassTransit`
+- `Elsa.ServiceBus.MassTransit.RabbitMq` or `Elsa.ServiceBus.MassTransit.AzureServiceBus`
+
+At minimum, enable the feature and register the message types you want to expose:
+
+```csharp
+builder.Services.AddElsa(elsa => elsa
+    .UseMassTransit(mt =>
+    {
+        mt.AddMessageType<OrderCreated>();
+    }));
+```
+
+If you do not configure a transport, Elsa uses MassTransit's in-memory transport. That is useful for local development and single-process setups, but it does not provide inter-process messaging.
+
+For multi-node or broker-backed messaging, configure a transport explicitly:
+
+```csharp
+builder.Services.AddElsa(elsa => elsa
+    .UseMassTransit(mt =>
+    {
+        mt.AddMessageType<OrderCreated>();
+        mt.UseRabbitMq(rabbitMqConnectionString);
+    }));
+```
+
+`release/3.8.0` also provides `UseAzureServiceBus(...)` in the `Elsa.ServiceBus.MassTransit.AzureServiceBus` package.
+
+## How Receiving Works
+
+When MassTransit receives a registered message type, Elsa's generated `WorkflowMessageConsumer<T>` sends a stimulus whose activity type name matches the registered message type and whose workflow input contains the message under the `Message` key.
+
+The generated `MessageReceived` activity then:
+
+- Matches incoming messages by exact CLR type
+- Stores the received message in the activity output
+- Removes the `Message` input from workflow input before moving to the next activity
+- Creates bookmarks without an activity instance ID, so matching messages can resume waiting workflow instances of the same activity type
+
+The generated activity is a trigger activity, but it does not automatically start every workflow that contains it. To start new workflow instances from a message, configure the activity as a start trigger, just as you would with other Elsa triggers.
+
+## How Publishing Works
+
+The generated `Publish {MessageType}` activity resolves `IBus` from DI and calls `bus.Publish(...)` with the configured message payload.
+
+Two details matter in practice:
+
+- The publish activity exists only for class message types. If you register an interface, Elsa creates the receive trigger but not the publish activity.
+- The message input is converted to the configured CLR type before publishing, so the payload must be compatible with the registered message type.
+
+## MassTransit Activities vs Other Messaging Features
+
+This page covers MassTransit-backed message-type activities. Elsa also has two related but different messaging integration paths:
+
+- The MassTransit workflow dispatcher, enabled with `UseMassTransitDispatcher()` on workflow management and runtime features, moves workflow dispatch and stimulus work over MassTransit. It is infrastructure for Elsa itself, not a replacement for message-type activities.
+- The Azure Service Bus activity module (`UseAzureServiceBus()`) provides transport-specific activities such as `SendMessage` and `MessageReceived`. Those are separate from the generic message-type activities described here.
+
+Use the generic MassTransit activities when your workflows exchange strongly typed application messages. Use transport-specific activity modules when you need queue or topic concepts that belong to a specific broker.
+
+## Operational Notes
+
+- `DisableConsumers` can be used to stop MassTransit consumers from being configured on a given node. The Elsa workbench uses this to keep API-only nodes from consuming messages directly.
+- `MassTransitOptions` in `release/3.8.0` include `TemporaryQueueTtl`, `ConcurrentMessageLimit`, `PrefetchCount`, and `MaxAutoRenewDuration` (Azure Service Bus only).
+- If you are using MassTransit for clustered workflow dispatch or distributed cache invalidation, see the distributed hosting and clustering guides as well. Those features share the broker, but they solve a different problem than workflow message activities.

--- a/activities/masstransit/tutorial.md
+++ b/activities/masstransit/tutorial.md
@@ -1,6 +1,13 @@
 # Tutorial
 
-The following example highlights creating and registering a fictive message type called `OrderCreated`.
+This example shows the full path for using a strongly typed message with Elsa:
+
+1. Define a message contract.
+2. Register the message type with the MassTransit feature.
+3. Configure a transport.
+4. Use the generated trigger and publish activities in workflows.
+
+## 1. Define the message contract
 
 {% code title="OrderCreated.cs" %}
 ```csharp
@@ -8,23 +15,101 @@ public record OrderCreated(string Id, string ProductId, int Quantity);
 ```
 {% endcode %}
 
+`OrderCreated` is a class, so Elsa will generate both a receive trigger and a publish activity for it.
+
+## 2. Register the message type and configure MassTransit
+
 {% code title="Program.cs" %}
 ```csharp
-services.AddElsa(elsa =>
-{
-    // Enable and configure MassTransit
-    elsa.UseMassTransit(massTransit =>
+builder.Services.AddElsa(elsa => elsa
+    .UseMassTransit(massTransit =>
     {
-        // Register our message type.
         massTransit.AddMessageType<OrderCreated>();
-    });
-});
+
+        // Use a broker for cross-process messaging.
+        massTransit.UseRabbitMq(rabbitMqConnectionString);
+    }));
 ```
 {% endcode %}
 
-With the above setup, your workflow server will now add two activities that allow you to send and receive messages of type \`OrderCreated\`:
+With that configuration, Elsa adds two activities:
 
 * Order Created
 * Publish Order Created
 
-The **Order Created** activity acts as a trigger, which means that it will automatically start the workflow it is a part of when a message is received of this type. The **Publish Order Created** activity will publish a message of this type.
+If you omit `UseRabbitMq(...)` or another transport configuration method, Elsa falls back to MassTransit's in-memory transport.
+
+## 3. Start a workflow when the message arrives
+
+Use the generated `Order Created` trigger activity at the start of a workflow and mark it as a start trigger in Studio.
+
+In code, the equivalent looks like this:
+
+{% code title="OrderCreatedWorkflow.cs" %}
+```csharp
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
+
+public class OrderCreatedWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        var order = builder.WithVariable<OrderCreated>();
+
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new Elsa.ServiceBus.MassTransit.Activities.MessageReceived
+                {
+                    CanStartWorkflow = true,
+                    MessageType = typeof(OrderCreated),
+                    Result = new Output<OrderCreated>(order)
+                },
+                new WriteLine(context => $"Received order {order.Get(context)!.Id}")
+            }
+        };
+    }
+}
+```
+{% endcode %}
+
+When a MassTransit consumer receives `OrderCreated`, Elsa resumes or starts matching workflows by sending a stimulus that contains the message payload.
+
+## 4. Publish the message from a workflow
+
+Use the generated `Publish Order Created` activity when a workflow needs to emit the message:
+
+{% code title="PublishOrderWorkflow.cs" %}
+```csharp
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
+using Elsa.ServiceBus.MassTransit.Activities;
+
+public class PublishOrderWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new PublishMessage
+        {
+            MessageType = typeof(OrderCreated),
+            Message = new Input<object>(_ => new OrderCreated("1001", "SKU-1", 2))
+        };
+    }
+}
+```
+{% endcode %}
+
+In Studio, the equivalent activity is `Publish Order Created`.
+
+## When to Use This Pattern
+
+Use this pattern when:
+
+- Your application already uses MassTransit contracts between services.
+- You want workflows to react to or emit strongly typed domain messages.
+- You want the same broker to work across processes or nodes.
+
+Use a transport-specific module instead when you need broker-specific concepts such as Azure Service Bus queues, topics, or subscriptions.

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-16)
+## Slice Inventory (2026-06-17)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -33,6 +33,7 @@ acceptance criterion below is already complete.
 - `DOC-018` Plugins and modules development
 - `DOC-020` EF Core migrations
 - `DOC-022` Scaling and performance
+- `DOC-024` MassTransit communication
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
 - `DOC-030` Custom UI components
@@ -44,7 +45,6 @@ acceptance criterion below is already complete.
 - `DOC-019` HTTP endpoint security
 - `DOC-021` Configuration management
 - `DOC-023` Identity provider integrations
-- `DOC-024` MassTransit communication
 - `DOC-025` Long-running workflows
 - `DOC-026` Error handling and retry logic
 - `DOC-027` Execution model
@@ -59,11 +59,11 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-- `DOC-019` HTTP endpoint security: the HTTP workflow guides now explain how
-  to build endpoints, but the auth surface is still spread across multiple
-  pages. A single release-backed guide should connect `Authorize`,
-  `HttpEndpoint`, API permissions, public vs authenticated endpoints, and
-  Studio-facing troubleshooting.
+- `DOC-025` Long-running workflows: the documentation covers individual
+  blocking activities and runtime concepts, but it still lacks one
+  release-backed guide that connects bookmarks, timers, incidents,
+  cancellation, persistence, and operator troubleshooting into a single
+  workflow lifecycle narrative.
 
 ### Newly discovered follow-on topics
 
@@ -77,6 +77,10 @@ acceptance criterion below is already complete.
 - `DOC-052` Workflow state and journal API cookbook: add an operations-facing
   guide for inspecting workflow state, filtered journal entries, activity
   executions, and variable mutation endpoints when diagnosing live instances.
+- `DOC-054` Messaging transport decision guide: document when to use
+  MassTransit message-type activities, the Azure Service Bus activity module,
+  or MassTransit-backed workflow dispatching so teams do not conflate three
+  different messaging integration paths.
 
 ## Critical Priority (Must Have - Block Users)
 


### PR DESCRIPTION
## Summary
- replace the placeholder MassTransit page with a release-backed guide for `release/3.8.0`
- document registration, transports, trigger semantics, publish behavior, and the distinction from workflow dispatching and Azure Service Bus activities
- update the documentation slice inventory to mark `DOC-024` covered and queue the next recommended slice

## Validation
- verified claims and examples against `release/3.8.0` source in `elsa-extensions` and related Elsa runtime/workflow code
- ran `git diff --check`
- performed manual self-review of changed markdown for factual accuracy and formatting
