### PR TITLE
docs: add timer and scheduled workflow guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -67,6 +67,7 @@
 * [Running Workflows](guides/running-workflows/README.md)
   * [Using Elsa Studio](guides/running-workflows/using-elsa-studio.md)
   * [Using a Trigger](guides/running-workflows/using-a-trigger.md)
+  * [Timer and Scheduled Workflows](guides/running-workflows/timer-and-scheduled-workflows.md)
   * [Dispatch Workflow Activity](guides/running-workflows/dispatch-workflow-activity.md)
 * [Studio User Guide](guides/studio/README.md)
   * [Expressions](guides/studio/expressions.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-17)
+## Slice Inventory (2026-06-18)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -34,6 +34,7 @@ acceptance criterion below is already complete.
 - `DOC-020` EF Core migrations
 - `DOC-022` Scaling and performance
 - `DOC-024` MassTransit communication
+- `DOC-040` Timer and scheduled workflows
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
 - `DOC-030` Custom UI components
@@ -50,7 +51,6 @@ acceptance criterion below is already complete.
 - `DOC-027` Execution model
 - `DOC-038` Distributed tracing
 - `DOC-039` Performance tuning
-- `DOC-040` Timer and scheduled workflows
 - `DOC-042` Bulk dispatch workflows activity
 - `DOC-043` Hangfire integration
 - `DOC-047` API reference
@@ -59,11 +59,11 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-- `DOC-025` Long-running workflows: the documentation covers individual
-  blocking activities and runtime concepts, but it still lacks one
-  release-backed guide that connects bookmarks, timers, incidents,
-  cancellation, persistence, and operator troubleshooting into a single
-  workflow lifecycle narrative.
+- `DOC-025` Long-running workflows: the new scheduling guide now explains
+  timers and durable resumes, but the docs still lack one release-backed guide
+  that connects bookmarks, timers, incidents, cancellation, persistence,
+  background execution, and operator troubleshooting into a full workflow
+  lifecycle narrative.
 
 ### Newly discovered follow-on topics
 
@@ -81,6 +81,14 @@ acceptance criterion below is already complete.
   MassTransit message-type activities, the Azure Service Bus activity module,
   or MassTransit-backed workflow dispatching so teams do not conflate three
   different messaging integration paths.
+
+### Current run result
+
+- `DOC-040` Timer and scheduled workflows: completed in this run by adding a
+  dedicated guide for `Delay`, `StartAt`, `Timer`, and `Cron`, and grounding
+  the scheduling model in `DefaultBookmarkScheduler`, `ResumeWorkflowTask`,
+  `LocalScheduler`, and Quartz-backed scheduler configuration from
+  `release/3.8.0`.
 
 ## Critical Priority (Must Have - Block Users)
 

--- a/guides/running-workflows/README.md
+++ b/guides/running-workflows/README.md
@@ -4,6 +4,7 @@ There are multiple ways to run a workflow:
 
 * Using Elsa Studio.
 * Using a trigger, such as HTTP Endpoint.
+* Using timer and scheduled activities such as Delay, StartAt, Timer, and Cron.
 * Using Dispatch Workflow Activity
 * Using the Elsa REST API.
 * Using the Elsa library.

--- a/guides/running-workflows/timer-and-scheduled-workflows.md
+++ b/guides/running-workflows/timer-and-scheduled-workflows.md
@@ -1,0 +1,301 @@
+# Timer and Scheduled Workflows
+
+Use Elsa's scheduling activities when a workflow should pause until a future
+time or start on a schedule instead of responding immediately to an HTTP
+request, message, or manual dispatch.
+
+In `release/3.8.0`, the scheduling behavior is implemented by:
+
+- `Delay`, `Timer`, `Cron`, and `StartAt` in `Elsa.Scheduling.Activities`
+- `DefaultBookmarkScheduler` for turning bookmarks into scheduled work
+- `ResumeWorkflowTask` for resuming suspended workflow instances
+- `QuartzSchedulerFeature` and `QuartzFeature` when you choose Quartz-backed
+  scheduling
+
+## Choose the right activity
+
+Use these activities for different timing behaviors:
+
+| Activity | Use it for | Starts a workflow | Resumes a running workflow |
+| --- | --- | --- | --- |
+| `Delay` | Pause for a fixed duration | No | Yes |
+| `StartAt` | Start or continue at a specific timestamp | Yes | Yes |
+| `Timer` | Repeat on a fixed interval | Yes | Yes |
+| `Cron` | Repeat using a cron expression | Yes | Yes |
+
+## How Elsa schedules work
+
+When a scheduling activity blocks, Elsa creates a bookmark and hands it to the
+bookmark scheduler.
+
+`DefaultBookmarkScheduler` groups bookmarks by stimulus type:
+
+- `Elsa.Delay`
+- `Elsa.StartAt`
+- `Elsa.Timer`
+- `Elsa.Cron`
+
+It then asks `IWorkflowScheduler` to do one of two things:
+
+- `ScheduleAtAsync(...)` for one-time resumes such as `Delay`, `StartAt`, and
+  the next `Timer` occurrence
+- `ScheduleCronAsync(...)` for recurring cron execution
+
+When the scheduled time arrives, Elsa runs `ResumeWorkflowTask`, which loads the
+workflow instance and resumes it at the bookmarked activity.
+
+## Local scheduler vs Quartz
+
+If you only call `UseScheduling()`, Elsa uses the default in-memory
+`LocalScheduler`.
+
+That is acceptable for:
+
+- local development
+- demos
+- single-process workloads where losing scheduled state on restart is
+  acceptable
+
+It is not a good fit when you need durable scheduled execution across restarts
+or multiple nodes.
+
+For production scheduling, enable Quartz-backed scheduling:
+
+{% code title="Program.cs" %}
+```csharp
+using Elsa.Extensions;
+
+builder.Services.AddElsa(elsa => elsa
+    .UseScheduling(scheduling => scheduling.UseQuartzScheduler())
+    .UseQuartz(quartz => quartz.UsePostgreSql(connectionString)));
+```
+{% endcode %}
+
+`QuartzFeature` configures Quartz itself, while `UseQuartzScheduler()` swaps
+Elsa's `IWorkflowScheduler` and cron parser to Quartz-backed implementations.
+
+## Single-node setup
+
+For a single-node application that still needs durable scheduled work, use
+Quartz with a persistent store but without clustering:
+
+{% code title="Program.cs" %}
+```csharp
+using Elsa.Extensions;
+
+builder.Services.AddElsa(elsa => elsa
+    .UseScheduling(scheduling => scheduling.UseQuartzScheduler())
+    .UseQuartz(quartz => quartz.UseSqlite("Data Source=quartz.db")));
+```
+{% endcode %}
+
+This keeps scheduled jobs outside process memory so they survive app restarts.
+
+## Multi-node setup
+
+For clustered deployments, combine `UseQuartzScheduler()` with a shared Quartz
+database and clustering enabled on the provider:
+
+{% code title="Program.cs" %}
+```csharp
+using Elsa.Extensions;
+
+builder.Services.AddElsa(elsa => elsa
+    .UseScheduling(scheduling => scheduling.UseQuartzScheduler())
+    .UseQuartz(quartz => quartz
+        .ConfigureClusteringIdentity()
+        .UsePostgreSql(connectionString, useClustering: true)));
+```
+{% endcode %}
+
+In `release/3.8.0`, `QuartzFeature.ConfigureClusteringIdentity(...)` sets the
+scheduler ID and name that Quartz uses for clustered coordination. The shared
+job store is what lets only one node claim each scheduled resume.
+
+## Delay
+
+`Delay` pauses the current workflow instance for a `TimeSpan`.
+
+Internally, `Delay.Execute(...)` calls `context.DelayFor(timeSpan)`, which:
+
+- resolves the current UTC clock
+- calculates `resumeAt = now + delay`
+- creates a bookmark with an `Elsa.Delay` stimulus and `DelayPayload`
+
+{% code title="ApprovalWorkflow.cs" %}
+```csharp
+using Elsa.Scheduling.Activities;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+
+public class ApprovalWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new WriteLine("Waiting one day before sending a reminder."),
+                Delay.FromDays(1),
+                new WriteLine("Reminder window opened.")
+            }
+        };
+    }
+}
+```
+{% endcode %}
+
+Use `Delay` when the workflow is already running and should simply wait before
+continuing.
+
+## StartAt
+
+`StartAt` triggers execution at a specific `DateTimeOffset`.
+
+Two behaviors matter:
+
+- if the workflow reaches `StartAt` after the requested time has already
+  passed, the activity completes immediately
+- if the timestamp is in the future, Elsa creates an `Elsa.StartAt` bookmark
+
+{% code title="ProgrammaticWorkflow.cs" %}
+```csharp
+using Elsa.Scheduling.Activities;
+using Elsa.Workflows;
+
+public class ProgrammaticWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new StartAt(DateTimeOffset.UtcNow.AddHours(2))
+        {
+            CanStartWorkflow = true
+        };
+    }
+}
+```
+{% endcode %}
+
+Use `StartAt` when you need an explicit future timestamp instead of "wait this
+many minutes".
+
+## Timer
+
+`Timer` is for recurring execution with a fixed `TimeSpan` interval.
+
+`TimerBase.Execute(...)` calls `context.RepeatWithInterval(...)`, which behaves
+differently depending on whether the activity is acting as the workflow trigger:
+
+- when the workflow is starting from the timer trigger, Elsa completes the
+  trigger path immediately
+- otherwise, Elsa creates an `Elsa.Timer` bookmark with the next `ResumeAt`
+  timestamp
+
+{% code title="HeartbeatWorkflow.cs" %}
+```csharp
+using Elsa.Scheduling.Activities;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+
+public class HeartbeatWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new Timer(TimeSpan.FromMinutes(5)) { CanStartWorkflow = true },
+                new WriteLine("Heartbeat workflow started by timer.")
+            }
+        };
+    }
+}
+```
+{% endcode %}
+
+Use `Timer` when the interval is naturally expressed as a `TimeSpan` such as
+every 5 minutes or every 24 hours.
+
+## Cron
+
+`Cron` is for recurring execution based on a cron expression.
+
+In `release/3.8.0`, Elsa's built-in `CronosCronParser` parses expressions with
+seconds included, and `UseQuartzScheduler()` swaps that parser for
+`QuartzCronParser`.
+
+When it is not starting the workflow directly, `Cron.ExecuteAsync(...)`:
+
+- resolves the cron parser from DI
+- calculates the next occurrence
+- writes that timestamp to journal data as `ExecuteAt`
+- creates a `CronBookmarkPayload`
+
+{% code title="NightlyWorkflow.cs" %}
+```csharp
+using Elsa.Scheduling.Activities;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+
+public class NightlyWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new Cron("0 0 2 * * ?") { CanStartWorkflow = true },
+                new WriteLine("Nightly maintenance started.")
+            }
+        };
+    }
+}
+```
+{% endcode %}
+
+Use `Cron` when you need calendar-based schedules such as "2 AM every day" or
+"every Monday at 09:00".
+
+## Studio usage
+
+In Elsa Studio:
+
+1. Add `Delay`, `StartAt`, `Timer`, or `Cron` from the scheduling category.
+2. Mark `StartAt`, `Timer`, or `Cron` as a start trigger when the workflow
+   should begin from that activity.
+3. Configure the duration, timestamp, interval, or cron expression.
+4. Publish the workflow.
+
+If scheduled workflows behave differently across environments, verify that the
+runtime node actually runs the configured scheduler.
+
+## Operational guidance
+
+- Use the local scheduler only when losing scheduled state on restart is
+  acceptable.
+- Use Quartz with shared storage for clustered or durable scheduled execution.
+- Keep all cluster nodes on consistent time settings; scheduling uses UTC clock
+  calculations in Elsa and coordinated execution in Quartz.
+- If a scheduled workflow instance is deleted before resume time,
+  `ResumeWorkflowTask` logs a warning and skips execution instead of failing the
+  scheduler.
+
+## Troubleshooting
+
+- If a timer or cron workflow never fires, confirm `UseScheduling()` is enabled.
+- If scheduled work disappears after restart, you are likely using the in-memory
+  `LocalScheduler` instead of Quartz persistence.
+- If timers fire multiple times in a cluster, verify Quartz uses a shared store
+  with clustering enabled.
+- If a `StartAt` activity appears to do nothing, check whether the configured
+  timestamp is already in the past.
+
+## Related topics
+
+- [Using a Trigger](using-a-trigger.md)
+- [Clustering](../clustering/README.md)
+- [Troubleshooting](../troubleshooting/README.md)
+- [Performance & Scaling](../performance/README.md)

--- a/guides/running-workflows/using-a-trigger.md
+++ b/guides/running-workflows/using-a-trigger.md
@@ -11,6 +11,10 @@ Elsa ships with various triggers out of the box, such as:
 * Cron: triggers the workflow each given interval based on a CRON expression.
 * Event: triggers when a given event is received by the workflow server.
 
+For scheduling-focused guidance, including `Delay`, `StartAt`, `Timer`,
+`Cron`, local scheduling, and Quartz-backed durable scheduling, see
+[Timer and Scheduled Workflows](timer-and-scheduled-workflows.md).
+
 We will use the HTTP Endpoint trigger as an example.
 
 ## Using Code
@@ -57,4 +61,3 @@ public class HelloWorldHttpWorkflow : WorkflowBase
 Follow this guide to see step-by-step how to create a simple HTTP workflow using the HTTP Endpoint trigger.
 
 {% embed url="https://dubble.so/guides/http-trigger-zuc6xtxdvoo49omo5oly" %}
-


### PR DESCRIPTION
## Summary
- add a release-backed guide for Delay, StartAt, Timer, and Cron workflows
- explain LocalScheduler vs Quartz-backed durable scheduling and cluster setup
- update running workflow navigation and slice inventory for the new guide

## Validation
- validated behavior against `release/3.8.0` source in `elsa-core` and `elsa-extensions`
- ran targeted local link-resolution checks for the updated pages
- ran `git diff --check`
