### PR TITLE
docs: add bulk dispatch workflow guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -69,6 +69,7 @@
   * [Using a Trigger](guides/running-workflows/using-a-trigger.md)
   * [Timer and Scheduled Workflows](guides/running-workflows/timer-and-scheduled-workflows.md)
   * [Dispatch Workflow Activity](guides/running-workflows/dispatch-workflow-activity.md)
+  * [Bulk Dispatch Workflows Activity](guides/running-workflows/bulk-dispatch-workflows.md)
 * [Studio User Guide](guides/studio/README.md)
   * [Expressions](guides/studio/expressions.md)
   * [Customization](guides/studio/customization.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-18)
+## Slice Inventory (2026-06-19)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -35,6 +35,7 @@ acceptance criterion below is already complete.
 - `DOC-022` Scaling and performance
 - `DOC-024` MassTransit communication
 - `DOC-040` Timer and scheduled workflows
+- `DOC-042` Bulk dispatch workflows activity
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
 - `DOC-030` Custom UI components
@@ -51,11 +52,17 @@ acceptance criterion below is already complete.
 - `DOC-027` Execution model
 - `DOC-038` Distributed tracing
 - `DOC-039` Performance tuning
-- `DOC-042` Bulk dispatch workflows activity
 - `DOC-043` Hangfire integration
 - `DOC-047` API reference
 - `DOC-048` Activity reference
 - `DOC-053` Alterations operational guide hardening
+
+### Current run selection
+
+- `DOC-042` Bulk dispatch workflows activity: add a release-backed guide that
+  explains fan-out child workflow dispatch, item-to-input mapping,
+  `WaitForCompletion`, per-child ports, and how the activity differs from the
+  REST bulk-dispatch endpoint.
 
 ### Recommended next slice
 
@@ -89,6 +96,11 @@ acceptance criterion below is already complete.
   the scheduling model in `DefaultBookmarkScheduler`, `ResumeWorkflowTask`,
   `LocalScheduler`, and Quartz-backed scheduler configuration from
   `release/3.8.0`.
+- `DOC-042` Bulk dispatch workflows activity: completed in this run by adding
+  a dedicated guide for `BulkDispatchWorkflows`, clarifying item input mapping,
+  wait-vs-fire-and-forget behavior, per-child completion and fault ports,
+  channel dispatch, and the difference between in-workflow bulk dispatch and
+  the `/workflow-definitions/{definitionId}/bulk-dispatch` API endpoint.
 
 ## Critical Priority (Must Have - Block Users)
 

--- a/guides/running-workflows/README.md
+++ b/guides/running-workflows/README.md
@@ -6,6 +6,7 @@ There are multiple ways to run a workflow:
 * Using a trigger, such as HTTP Endpoint.
 * Using timer and scheduled activities such as Delay, StartAt, Timer, and Cron.
 * Using Dispatch Workflow Activity
+* Using Bulk Dispatch Workflows Activity
 * Using the Elsa REST API.
 * Using the Elsa library.
 

--- a/guides/running-workflows/bulk-dispatch-workflows.md
+++ b/guides/running-workflows/bulk-dispatch-workflows.md
@@ -1,0 +1,210 @@
+# Bulk Dispatch Workflows Activity
+
+Use `BulkDispatchWorkflows` when one parent workflow should fan out work to
+many child workflow instances in one step.
+
+In `release/3.8.0`, the activity lives in
+`Elsa.Workflows.Runtime.Activities.BulkDispatchWorkflows` and is exposed in the
+`Composition` category in Elsa Studio.
+
+## When to use it
+
+Use `BulkDispatchWorkflows` when you need to:
+
+- dispatch the same child workflow for each item in a collection
+- optionally wait for all child workflows to finish
+- react differently when individual child workflows finish or fault
+- assign per-item correlation IDs
+
+Use the single [Dispatch Workflow Activity](dispatch-workflow-activity.md) when
+you only need one child workflow instance.
+
+## What it does
+
+At execution time, Elsa:
+
+1. evaluates `Items` into a materialized list
+2. resolves the published child workflow definition from `WorkflowDefinitionId`
+3. dispatches one child workflow instance per item
+4. either completes immediately or waits for child completion, depending on
+   `WaitForCompletion`
+
+If the target workflow definition does not have a published version, the
+activity faults.
+
+If `Items` is empty, the activity completes immediately even when
+`WaitForCompletion` is `true`.
+
+## Input mapping
+
+Each dispatched child workflow starts with the optional `Input` dictionary and
+then receives per-item input:
+
+- if an item is a plain value, Elsa sends it under `DefaultItemInputKey`
+  (default: `Item`)
+- if an item is already an `IDictionary<string, object>`, Elsa merges that
+  dictionary directly into the child input instead
+
+The activity also adds `ParentInstanceId` to the child workflow input before
+merging item dictionaries. If your item dictionaries use the same key, they
+overwrite that input value. The same overwrite behavior applies to any matching
+keys that were already present in the optional `Input` dictionary.
+
+## Waiting vs fire-and-forget
+
+`WaitForCompletion` defaults to `true`.
+
+| Setting | Runtime behavior |
+| --- | --- |
+| `true` | Creates a bookmark and waits until all dispatched child workflows finish |
+| `false` | Dispatches child workflows and completes the parent activity immediately |
+
+When Elsa waits for completion, it tracks how many child instances were
+dispatched and resumes the parent activity whenever a finished child workflow
+reports back through `ResumeBulkDispatchWorkflowActivity`.
+
+## Outcomes and child ports
+
+`BulkDispatchWorkflows` exposes these flowchart outcomes in its activity
+metadata:
+
+- `Done`
+- `Completed`
+- `Canceled`
+
+In `release/3.8.0`, the implementation completes with:
+
+- `Done` immediately when `WaitForCompletion` is `false`
+- `Done` immediately when `Items` is empty
+- `Completed` and `Done` after the last child finishes when
+  `WaitForCompletion` is `true`
+
+You can also attach per-child ports:
+
+- `ChildCompleted` runs for each child workflow whose sub-status is `Finished`
+- `ChildFaulted` runs for each child workflow whose sub-status is `Faulted`
+
+While those child-port activities run, Elsa adds a `ChildInstanceId` workflow
+variable and passes these values as workflow input:
+
+- `WorkflowOutput`
+- `WorkflowInstanceId`
+- `WorkflowStatus`
+- `WorkflowSubStatus`
+
+## Using code
+
+### Wait for all child workflows
+
+This example dispatches one child workflow per employee and waits for all of
+them to complete.
+
+```csharp
+using System.Collections.Generic;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Runtime.Activities;
+
+public class GreetEmployeesWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        var employees = new[]
+        {
+            new Dictionary<string, object> { ["Employee"] = "Alice" },
+            new Dictionary<string, object> { ["Employee"] = "Bob" },
+            new Dictionary<string, object> { ["Employee"] = "Charlie" }
+        };
+
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new BulkDispatchWorkflows
+                {
+                    WorkflowDefinitionId = new("EmployeeGreetingWorkflow"),
+                    Items = new(employees),
+                    WaitForCompletion = new(true)
+                },
+                new WriteLine("All employee greeting workflows finished.")
+            }
+        };
+    }
+}
+```
+
+Because each item is a dictionary, the child workflow receives `Employee`
+directly instead of an `Item` wrapper key.
+
+### Fire-and-forget batch dispatch
+
+Set `WaitForCompletion` to `false` when the parent workflow should continue
+without waiting for the children:
+
+```csharp
+new BulkDispatchWorkflows
+{
+    WorkflowDefinitionId = new("SlowBulkChildWorkflow"),
+    Items = new(new object[] { "A", "B", "C" }),
+    WaitForCompletion = new(false)
+}
+```
+
+This still records `ParentWorkflowInstanceId` on the dispatched workflow
+request, but the parent activity does not create a waiting bookmark.
+
+### Per-item correlation IDs
+
+`CorrelationIdFunction` is evaluated once per item. The current item is exposed
+to the expression evaluator arguments used by the activity.
+
+```csharp
+using Elsa.Expressions.JavaScript.Models;
+
+new BulkDispatchWorkflows
+{
+    WorkflowDefinitionId = new("BulkChildWorkflow"),
+    Items = new(new object[] { 1, 2, 3 }),
+    CorrelationIdFunction = new(JavaScriptExpression.Create("`correlation-${getItem()}`")),
+    WaitForCompletion = new(true)
+}
+```
+
+## Elsa Studio notes
+
+In Elsa Studio, look for `Bulk Dispatch Workflows` under the `Composition`
+activity category.
+
+The main properties to configure are:
+
+- `Workflow Definition`
+- `Items`
+- `Default Item Input Key`
+- `Correlation ID Function`
+- `Input`
+- `Wait For Completion`
+- `Channel`
+- `Start New Trace`
+
+Use `ChildCompleted` and `ChildFaulted` ports when the parent workflow needs
+per-child follow-up logic.
+
+## Activity vs REST bulk dispatch
+
+Elsa Server also exposes `POST /workflow-definitions/{definitionId}/bulk-dispatch`.
+
+That endpoint is useful when an external caller wants to start the same workflow
+`Count` times with the same input payload.
+
+`BulkDispatchWorkflows` is different:
+
+- it runs inside a parent workflow
+- it can send different input per item
+- it can wait for children and react to child completion or faults
+- it can dispatch to a configured workflow channel
+
+## Related guides
+
+- [Dispatch Workflow Activity](dispatch-workflow-activity.md)
+- [Running Workflows](README.md)
+- [Timer and Scheduled Workflows](timer-and-scheduled-workflows.md)

--- a/guides/running-workflows/dispatch-workflow-activity.md
+++ b/guides/running-workflows/dispatch-workflow-activity.md
@@ -4,6 +4,9 @@ The **Dispatch Workflow** activity can start a new workflow from the current wor
 
 It allows you to specify what workflow to run and provide any input required by the workflow.
 
+If you need to fan out one child workflow per item in a collection, use
+[Bulk Dispatch Workflows Activity](bulk-dispatch-workflows.md) instead.
+
 Let's try it out.
 
 ## Using Code


### PR DESCRIPTION
## Summary
- add a release-backed guide for the Bulk Dispatch Workflows activity
- cross-link it from the existing Dispatch Workflow activity docs and navigation
- update the documentation slice inventory for the completed DOC-042 run

## Validation
- verified behavior against release/3.8.0 activity/runtime source and component tests
- ran local relative-link resolution checks for touched markdown files
- ran git diff --check
