### PR TITLE
docs: add long-running workflow guides

### DIFF
--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-21)
+## Slice Inventory (2026-06-22)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -114,7 +114,7 @@ acceptance criterion below is already complete.
 ### Current slice note
 
 - `DOC-025` Long-running workflows:
-  completed on 2026-06-21.
+  completed on 2026-06-22.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/running-workflows/long-running-workflows.md
+++ b/guides/running-workflows/long-running-workflows.md
@@ -189,9 +189,11 @@ itself runs elsewhere.
 For long-running flows, prefer entry points that do not assume the workflow will
 finish in the same HTTP request.
 
-- use `/dispatch` when the workflow may suspend or continue in the background
-- use `/execute` only when the caller expects a synchronous response and the
-  workflow path can complete immediately
+- use `POST {RoutePrefix}/workflow-definitions/{definitionId}/dispatch` when
+  the workflow may suspend or continue in the background
+- use `GET` or `POST {RoutePrefix}/workflow-definitions/{definitionId}/execute`
+  only when the caller expects a synchronous response and the workflow path can
+  complete immediately
 
 If an HTTP workflow can block on timers, callbacks, or external events, design
 it as a dispatch-and-observe flow instead of a request-response flow.

--- a/guides/running-workflows/timer-and-scheduled-workflows.md
+++ b/guides/running-workflows/timer-and-scheduled-workflows.md
@@ -226,6 +226,12 @@ In `release/3.8.0`, Elsa's built-in `CronosCronParser` parses expressions with
 seconds included, and `UseQuartzScheduler()` swaps that parser for
 `QuartzCronParser`.
 
+Blank cron expressions are treated as disabled:
+
+- a trigger `Cron` activity is skipped during trigger creation
+- an inline `Cron` activity completes immediately instead of scheduling a
+  bookmark
+
 When it is not starting the workflow directly, `Cron.ExecuteAsync(...)`:
 
 - resolves the cron parser from DI


### PR DESCRIPTION
## Summary
- add a release-backed long-running workflows guide for Elsa `release/3.8.0`
- add a companion timer and scheduled workflows guide that explains trigger vs inline behavior
- update the docs backlog inventory and navigation for the completed `DOC-025` slice

## Validation
- checked runtime, scheduling, bookmark resume, and `RunTask` behavior against `release/3.8.0` in `elsa-core`, `elsa-studio`, and `elsa-extensions`
- ran `git diff --check -- SUMMARY.md docs/meta/backlog.md guides/long-running-workflows.md guides/timer-scheduled-workflows.md`
- ran a local relative-link validation pass on the touched docs files
