### PR TITLE
docs: add release-backed MassTransit guide

### DIFF
--- a/activities/masstransit/README.md
+++ b/activities/masstransit/README.md
@@ -1,18 +1,174 @@
 # MassTransit
 
-MassTransit is an open-source distributed application framework for .NET that provides a consistent abstraction on top of the supported message transports.
+Use the MassTransit extension packages when your workflows need to react to
+brokered messages or publish messages to other services.
 
-It enables .NET developers to model messages as C# types, which can then be sent & received. To receive messages, one would typically write a Consumer.
+In `release/3.8.0`, the integration lives in the Elsa extensions repository
+under `Elsa.ServiceBus.MassTransit`. Once enabled, Elsa can:
 
-When using the MassTransit module with Elsa, there is an additional method of sending & handling messages; through workflow activities.
+* generate workflow activities from message types you register
+* connect those activities to MassTransit consumers and `IBus.Publish(...)`
+* optionally use MassTransit as the transport for workflow dispatch features in
+  the runtime and management modules
 
-## Messages as Activities﻿
+## What the integration actually adds
 
-Elsa makes it easy to send and receive messages that are modeled as .NET type. All you need to do is define your type and then register it with the MassTransit feature.
+Registering a message type with `AddMessageType<T>()` makes Elsa generate:
 
-When a message type is registered, two new activities will be automatically available for use:
+* a trigger activity based on `MessageReceived`
+* a publish activity based on `PublishMessage`
 
-* Publish {activity type}
-* {activity type}
+For a message type such as `OrderCreated`, Studio exposes activities similar to:
 
-The first activity will _publish_ your message. The second activity acts as a trigger and will start or resume your workflow when a message of this type is received.
+* `Order Created`
+* `Publish Order Created`
+
+The generated trigger waits for a MassTransit consumer to receive a matching
+message and then starts or resumes workflows whose bookmarks match that message
+type.
+
+The generated publish activity resolves `IBus` from DI and calls
+`Publish(...)` with the configured message payload.
+
+## Package and transport setup
+
+Use the MassTransit extension package plus a transport package when you want a
+real broker:
+
+* `Elsa.ServiceBus.MassTransit`
+* `Elsa.ServiceBus.MassTransit.RabbitMq` for RabbitMQ
+* `Elsa.ServiceBus.MassTransit.AzureServiceBus` for Azure Service Bus
+
+If you enable `UseMassTransit(...)` without configuring a transport, Elsa falls
+back to MassTransit's in-memory transport.
+
+## Basic registration pattern
+
+{% code title="Program.cs" %}
+
+```csharp
+using Elsa.Extensions;
+
+services.AddElsa(elsa =>
+{
+    elsa.UseMassTransit(massTransit =>
+    {
+        massTransit.AddMessageType<OrderCreated>();
+    });
+});
+```
+
+{% endcode %}
+
+This is enough to:
+
+* register a workflow-facing consumer for `OrderCreated`
+* expose generated activities in Studio and the activity registry
+* use the in-memory transport unless another transport is configured
+
+## Configuring a broker transport
+
+Use the transport-specific extension inside the same `UseMassTransit(...)`
+callback.
+
+### RabbitMQ
+
+{% code title="Program.cs" %}
+
+```csharp
+using Elsa.Extensions;
+
+services.AddElsa(elsa =>
+{
+    elsa.UseMassTransit(massTransit =>
+    {
+        massTransit.AddMessageType<OrderCreated>();
+        massTransit.UseRabbitMq("amqp://guest:guest@localhost:5672", rabbit =>
+        {
+            rabbit.ConfigureTransportBus = (context, bus) =>
+            {
+                bus.PrefetchCount = 50;
+                bus.ConcurrentMessageLimit = 32;
+            };
+        });
+    });
+});
+```
+
+{% endcode %}
+
+### Azure Service Bus
+
+{% code title="Program.cs" %}
+
+```csharp
+using Elsa.Extensions;
+
+services.AddElsa(elsa =>
+{
+    elsa.UseMassTransit(massTransit =>
+    {
+        massTransit.AddMessageType<OrderCreated>();
+        massTransit.UseAzureServiceBus("<connection-string>", bus =>
+        {
+            bus.EnableAutomatedSubscriptionCleanup = true;
+            bus.SubscriptionCleanupOptions = options =>
+                options.Interval = System.TimeSpan.FromMinutes(5);
+        });
+    });
+});
+```
+
+{% endcode %}
+
+Use RabbitMQ when your application architecture already standardizes on AMQP and
+queue-based routing. Use Azure Service Bus when Elsa participates in Azure
+native messaging and you want broker-managed topics and subscriptions.
+
+## How message reception works
+
+When a MassTransit consumer receives a registered message type, Elsa's
+`WorkflowMessageConsumer<T>` sends a stimulus whose payload identifies that .NET
+type. The `MessageReceived` trigger:
+
+* starts a workflow when used as the workflow trigger
+* resumes an existing workflow instance when the activity already created a
+  bookmark
+* exposes the received message as the activity output
+
+MassTransit correlation IDs are passed through to the stimulus metadata, so you
+can combine broker correlation with Elsa workflow correlation when your workflow
+design requires it.
+
+## Node topology and operational notes
+
+By default, the MassTransit feature registers consumers for the generated
+message activities.
+
+Set `massTransit.DisableConsumers = true` on nodes that should host the Elsa API
+or Studio backend but should not consume bus messages.
+
+MassTransit messaging for generated activities is separate from MassTransit as a
+workflow-dispatch transport. If you also enable:
+
+* `management.UseMassTransitDispatcher()`
+* `runtime.UseMassTransitDispatcher()`
+
+then Elsa uses MassTransit to dispatch workflow-management and workflow-runtime
+messages as well.
+
+## When to use this integration
+
+Use MassTransit-backed workflow activities when:
+
+* workflows need to start from or wait on brokered integration events
+* workflows need to publish typed integration events to other services
+* your team wants message contracts to appear directly as activities in Studio
+
+Use direct HTTP, scheduler, or native workflow-dispatch APIs instead when you
+do not need brokered messaging semantics.
+
+## Next step
+
+Continue with the [MassTransit tutorial](tutorial.md) for a minimal
+publish-and-receive setup.

--- a/activities/masstransit/tutorial.md
+++ b/activities/masstransit/tutorial.md
@@ -1,30 +1,95 @@
 # Tutorial
 
-The following example highlights creating and registering a fictive message type called `OrderCreated`.
+This example shows the minimum setup needed to publish and receive a typed
+message through Elsa's MassTransit integration in `release/3.8.0`.
+
+## 1. Define a message contract
+
+Use a normal .NET message type. A `record` works well here because it is still a
+class type, which means Elsa can generate both the trigger activity and the
+publish activity.
 
 {% code title="OrderCreated.cs" %}
+
 ```csharp
-public record OrderCreated(string Id, string ProductId, int Quantity);
+public record OrderCreated(string OrderId, string ProductId, int Quantity);
 ```
+
 {% endcode %}
 
+## 2. Register MassTransit and the message type
+
 {% code title="Program.cs" %}
+
 ```csharp
+using Elsa.Extensions;
+
 services.AddElsa(elsa =>
 {
-    // Enable and configure MassTransit
     elsa.UseMassTransit(massTransit =>
     {
-        // Register our message type.
         massTransit.AddMessageType<OrderCreated>();
+        massTransit.UseRabbitMq("amqp://guest:guest@localhost:5672");
     });
 });
 ```
+
 {% endcode %}
 
-With the above setup, your workflow server will now add two activities that allow you to send and receive messages of type \`OrderCreated\`:
+If you omit `UseRabbitMq(...)` or `UseAzureServiceBus(...)`, Elsa uses the
+in-memory MassTransit transport instead.
 
-* Order Created
-* Publish Order Created
+## 3. Use the generated activities
 
-The **Order Created** activity acts as a trigger, which means that it will automatically start the workflow it is a part of when a message is received of this type. The **Publish Order Created** activity will publish a message of this type.
+After startup, Elsa exposes two activities derived from `OrderCreated`:
+
+* `Order Created`
+* `Publish Order Created`
+
+### `Order Created`
+
+Use this as a workflow trigger or as a blocking point later in the workflow.
+When a MassTransit consumer receives an `OrderCreated` message, Elsa sends that
+message through the stimulus pipeline and:
+
+* starts a matching workflow if the activity is the workflow trigger
+* resumes a waiting workflow instance if a bookmark already exists
+
+The received message becomes the activity output, so downstream activities can
+read `OrderId`, `ProductId`, and `Quantity`.
+
+### `Publish Order Created`
+
+Use this when the workflow needs to publish an `OrderCreated` event to the bus.
+Internally, the generated activity resolves `IBus` and calls `Publish(...)`.
+
+## 4. Example workflow shape
+
+A common pattern is:
+
+1. receive `Order Created`
+2. map fields from the received message
+3. call internal or external order-processing steps
+4. optionally publish another integration event
+
+This works well when Elsa is part of an event-driven workflow architecture and
+the workflow itself is the business process handler.
+
+## 5. Deployment notes
+
+* Keep consumers enabled on nodes that should process broker messages.
+* Set `massTransit.DisableConsumers = true` on nodes that should host the API
+  but not consume workflow messages.
+* Tune queue and broker throughput with `MassTransitOptions` and the transport
+  configurator callbacks.
+
+## 6. Troubleshooting checklist
+
+* If the activities do not appear, verify `AddMessageType<OrderCreated>()` runs
+  during startup.
+* If messages publish but workflows do not start, verify consumers are enabled
+  on the running node.
+* If you use a real broker, verify the relevant RabbitMQ or Azure Service Bus
+  transport package is installed and configured.
+* If correlation matters, confirm the producer sets a MassTransit
+  `CorrelationId` that matches your workflow design.

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-23)
+## Slice Inventory (2026-06-25)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -39,13 +39,13 @@ acceptance criterion below is already complete.
 - `DOC-041` Loading workflows from JSON
 - `DOC-042` Bulk dispatch workflows activity
 - `DOC-049` Studio custom-elements embedding cookbook
+- `DOC-024` MassTransit communication
 
 ### Available next slices
 
 - `DOC-019` HTTP endpoint security
 - `DOC-021` Configuration management
 - `DOC-023` Identity provider integrations
-- `DOC-024` MassTransit communication
 - `DOC-025` Long-running workflows
 - `DOC-026` Error handling and retry logic
 - `DOC-027` Execution model
@@ -82,12 +82,11 @@ acceptance criterion below is already complete.
 
 ### Current slice note
 
-- `DOC-042` Bulk dispatch workflows activity:
-  add a dedicated, release-backed guide for `BulkDispatchWorkflows` that
-  explains how item input mapping works, when `WaitForCompletion` blocks the
-  parent workflow, how `ChildCompleted` and `ChildFaulted` execute per child,
-  what Studio users should configure, and when to use this activity instead of
-  `DispatchWorkflow`, `ForEach`, or the workflow-definition bulk-dispatch API.
+- `DOC-024` MassTransit communication:
+  completed in this run by rewriting the overview and tutorial around
+  `AddMessageType<T>()`, generated trigger and publish activities, transport
+  setup for in-memory, RabbitMQ, and Azure Service Bus, and operational notes
+  such as `DisableConsumers` and dispatcher-related usage boundaries.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect


### PR DESCRIPTION
## Summary
- rewrite the MassTransit overview around actual 3.8.0 behavior
- add transport, consumer, and dispatcher guidance grounded in released source
- expand the tutorial and update the documentation slice backlog

## Validation
- validated claims against release/3.8.0 source in elsa-extensions
- npx --yes markdownlint-cli@0.39.0 activities/masstransit/README.md activities/masstransit/tutorial.md
- git diff --check