### PR TITLE
docs: harden bulk dispatch workflow guide

### DIFF
--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-25)
+## Slice Inventory (2026-06-26)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -59,10 +59,10 @@ acceptance criterion below is already complete.
 
 ### Current run selection
 
-- `DOC-024` MassTransit communication: refine the newly added guide against
-  `release/3.8.0` source so it clearly explains generated activities,
-  transport setup, consumer behavior, `DisableConsumers`, correlation flow,
-  and how this feature differs from MassTransit-backed workflow dispatching.
+- `DOC-042` Bulk dispatch workflows activity: harden the existing guide
+  against `release/3.8.0` runtime behavior so it documents input precedence,
+  wait vs fire-and-forget completion, child ports, tracing, and the
+  parent-child runtime linkage accurately.
 
 ### Recommended next slice
 
@@ -94,18 +94,20 @@ acceptance criterion below is already complete.
 
 ### Current run result
 
-- `DOC-024` MassTransit communication: refined the overview and tutorial to
-  align with `MassTransitActivityTypeProvider`, `WorkflowMessageConsumer<T>`,
-  `MessageReceived`, `PublishMessage`, transport extension methods, and
-  `MassTransitOptions` in `release/3.8.0`.
+- `DOC-042` Bulk dispatch workflows activity: refined the guide to align with
+  `BulkDispatchWorkflows`, `ResumeBulkDispatchWorkflowActivity`, and the
+  `release/3.8.0` component tests, including item merge precedence,
+  `ParentWorkflowInstanceId` vs `ParentInstanceId`, `StartNewTrace`,
+  completion outcomes, and child-port behavior.
 
 ## Critical Priority (Must Have - Block Users)
 
 ### Current slice note
 
-- `DOC-024` MassTransit communication:
-  refined on 2026-06-25 to clarify transport choices, generated activities,
-  and operational boundaries against the released source.
+- `DOC-042` Bulk dispatch workflows activity:
+  refined on 2026-06-26 to clarify input precedence, completion outcomes,
+  parent-child linkage, tracing, and when child ports execute against the
+  released runtime.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/running-workflows/bulk-dispatch-workflows.md
+++ b/guides/running-workflows/bulk-dispatch-workflows.md
@@ -31,8 +31,13 @@ At execution time, Elsa:
 
 1. evaluates `Items` into a materialized list
 2. resolves the published child workflow definition from `WorkflowDefinitionId`
-3. dispatches one child workflow instance per item
-4. either completes immediately or waits for child completion, depending on
+3. creates a new child workflow instance per item
+4. sets `ParentWorkflowInstanceId` on each dispatch request so the runtime can
+   track the parent-child relationship
+5. adds `ParentInstanceId` to the child input and dispatch properties
+6. merges the current item into the child workflow input
+7. dispatches the child workflow through the selected channel
+8. either completes immediately or waits for child completion, depending on
    `WaitForCompletion`
 
 If the target workflow definition does not have a published version, the
@@ -98,6 +103,9 @@ variable and passes these values as workflow input:
 - `WorkflowStatus`
 - `WorkflowSubStatus`
 
+If `WaitForCompletion` is `false`, Elsa never schedules these ports because the
+parent workflow does not wait for child completion events.
+
 ## Using code
 
 ### Wait for all child workflows
@@ -106,6 +114,7 @@ This example dispatches one child workflow per employee and waits for all of
 them to complete.
 
 {% code title="GreetEmployeesWorkflow.cs" %}
+
 ```csharp
 using System.Collections.Generic;
 using Elsa.Workflows;
@@ -143,9 +152,11 @@ public class GreetEmployeesWorkflow : WorkflowBase
     }
 }
 ```
+
 {% endcode %}
 
 {% code title="EmployeeGreetingWorkflow.cs" %}
+
 ```csharp
 using Elsa.Extensions;
 using Elsa.Workflows;
@@ -164,6 +175,7 @@ public class EmployeeGreetingWorkflow : WorkflowBase
     }
 }
 ```
+
 {% endcode %}
 
 Because each item is a dictionary, the child workflow receives `Employee`


### PR DESCRIPTION
## Summary
- harden the Bulk Dispatch Workflows guide against release/3.8.0 runtime behavior
- document item merge precedence, completion outcomes, tracing, and parent-child linkage
- update the documentation slice backlog to record this run and keep the next slice inventory current

## Validation
- reviewed Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
- reviewed ResumeBulkDispatchWorkflowActivity.cs
- reviewed bulk dispatch component tests on release/3.8.0
- ran `git diff --check origin/main...HEAD`
- ran `npx -y markdownlint-cli --disable MD013 -- guides/running-workflows/bulk-dispatch-workflows.md`

## Notes
- docs/meta/backlog.md still has pre-existing markdownlint findings unrelated to this slice, so lint was targeted to the edited guide.
