### PR TITLE
docs: add HTTP endpoint security guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -38,6 +38,7 @@
 * [Authentication & Authorization](guides/authentication.md)
 * [Security & Authentication](guides/security/README.md)
   * [Disable Auth in Development](guides/security/disable-auth.md)
+  * [HTTP Endpoint Security](guides/security/http-endpoint-security.md)
   * [External Identity Providers](guides/security/external-identity-providers.md)
 * [Deployment](guides/deployment/README.md)
   * [Kubernetes Basics](guides/deployment/kubernetes.md)

--- a/application-types/elsa-server-+-studio-wasm.md
+++ b/application-types/elsa-server-+-studio-wasm.md
@@ -360,7 +360,7 @@ Next, we will modify the client project.
     }
     ```
 
-    `AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant as well; if token acquisition or refresh fails for the backend API scope, include the same scope in both `AuthenticationScopes` and `BackendApiScopes`.
+    `AuthenticationScopes` are used during Studio sign-in. `BackendApiScopes` are used when Studio requests bearer tokens for Elsa Server API calls.
 
     Because this client is Blazor WebAssembly, register `{studio-url}/authentication/login-callback` as the redirect URI and `{studio-url}/authentication/logout-callback` as the logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 4.  **Modify MainLayout.razor**

--- a/application-types/elsa-studio.md
+++ b/application-types/elsa-studio.md
@@ -183,7 +183,7 @@ If you are using .NET 8.0+, you can just use `blazorwasm` instead of `blazorwasm
     }
     ```
 
-    `AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant as well; if token acquisition or refresh fails for the backend API scope, include the same scope in both `AuthenticationScopes` and `BackendApiScopes`.
+    `AuthenticationScopes` are used during Studio sign-in. `BackendApiScopes` are used when Studio requests bearer tokens for Elsa Server API calls.
 
     Because this example is a Blazor WebAssembly host, register `{studio-url}/authentication/login-callback` as the redirect URI and `{studio-url}/authentication/logout-callback` as the logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 6.  **Update index.html**

--- a/authentication/authentication.md
+++ b/authentication/authentication.md
@@ -32,10 +32,11 @@ Use Elsa's built-in identity system for authentication.
 
 Elsa API endpoint authorization is based on permission claims. The claim type is `permissions`; each claim value must match an Elsa API permission, and `*` grants all Elsa API permissions.
 
-Elsa Identity roles collect permission strings. When Elsa Identity issues a token, permissions from assigned roles are emitted as `permissions` claims. API-key authentication handlers should add equivalent `permissions` claims. External OIDC providers should emit these values as `permissions` claims, or the host application should map external roles, groups, or scopes into `permissions` claims.
+Elsa Identity roles collect permission strings. When Elsa Identity issues a token or validates an Elsa API key, permissions from assigned roles are emitted as `permissions` claims. External OIDC providers should emit these values as `permissions` claims, or the host application should map external roles, groups, or scopes into `permissions` claims.
 
 ASP.NET Core `RequireRole(...)` policies can protect custom host endpoints, but they do not replace the `permissions` claims checked by Elsa API endpoints. Permission names come from endpoint configuration and module constants, not only from shared `PermissionNames` constants.
 
+Workflow routes handled by the `HttpEndpoint` activity use a separate authorization path based on the activity's `Authorize` and `Policy` settings. See the [HTTP Endpoint Security Guide](../guides/security/http-endpoint-security.md).
 ### Using OIDC (OpenID Connect)
 
 OIDC integration has two parts:
@@ -43,7 +44,7 @@ OIDC integration has two parts:
 * Elsa Server must validate the access tokens sent to its API endpoints.
 * Elsa Studio must sign users in and attach an access token to calls to the Elsa Server API.
 
-For Elsa Studio 3.7, configure the `Elsa.Studio.Authentication.OpenIdConnect` modules with `Authentication:Provider` set to `OpenIdConnect`:
+For Elsa Studio 3.8, configure the `Elsa.Studio.Authentication.OpenIdConnect` modules with `Authentication:Provider` set to `OpenIdConnect`:
 
 ```json
 {
@@ -62,7 +63,7 @@ For Elsa Studio 3.7, configure the `Elsa.Studio.Authentication.OpenIdConnect` mo
 }
 ```
 
-`AuthenticationScopes` are requested during Studio sign-in. `BackendApiScopes` are requested when Studio obtains an access token for calls to the Elsa Server API. Some identity providers require the backend API scope to be part of the original sign-in grant before they allow refresh-token or incremental token acquisition for that scope. If your provider behaves this way, include the backend API scope in both arrays, for example `AuthenticationScopes: ["openid", "profile", "offline_access", "elsa_api"]` and `BackendApiScopes: ["elsa_api"]`.
+`AuthenticationScopes` are used during Studio sign-in. `BackendApiScopes` are used when Studio obtains an access token for calls to the Elsa Server API.
 
 Register the redirect and logout callback URIs for the Studio host model you use:
 

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-28)
+## Slice Inventory (2026-06-29)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -31,6 +31,7 @@ acceptance criterion below is already complete.
 - `DOC-016` Workflow context V3
 - `DOC-017` Common workflow patterns
 - `DOC-018` Plugins and modules development
+- `DOC-019` HTTP endpoint security
 - `DOC-020` EF Core migrations
 - `DOC-022` Scaling and performance
 - `DOC-028` Studio customization
@@ -44,7 +45,6 @@ acceptance criterion below is already complete.
 
 ### Available next slices
 
-- `DOC-019` HTTP endpoint security
 - `DOC-021` Configuration management
 - `DOC-023` Identity provider integrations
 - `DOC-024` MassTransit communication
@@ -58,10 +58,10 @@ acceptance criterion below is already complete.
 - `DOC-048` Activity reference
 ### Recommended next slice
 
-- `DOC-019` HTTP endpoint security: still the highest-value next slice after the
-  alterations guide is tightened. A single release-backed guide should connect `Authorize`,
-  `HttpEndpoint`, API permissions, public vs authenticated endpoints, and
-  Studio-facing troubleshooting.
+- `DOC-021` Configuration management: still a high-value follow-on because
+  configuration details remain spread across app-type, deployment, auth, and
+  hosting guides. A single release-backed guide should connect appsettings,
+  environment variables, feature toggles, and common precedence pitfalls.
 
 ### Newly discovered follow-on topics
 
@@ -80,9 +80,10 @@ acceptance criterion below is already complete.
 
 ### Current slice note
 
-- `DOC-053` Alterations operational guide hardening:
-  tighten permissions, execution-mode guidance, and operational behavior around
-  plan submission, job inspection, durable stores, and Studio-facing plan usage.
+- `DOC-019` HTTP endpoint security:
+  add a dedicated release-backed guide for `HttpEndpoint` authorization,
+  public vs authenticated ingress, policy behavior, separation from Elsa API
+  permissions, and Studio/operator troubleshooting.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -190,7 +190,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 Elsa API endpoints authorize requests with `permissions` claims. Each claim value must match a permission configured by the endpoint, and `*` grants all Elsa API permissions.
 
-Elsa Identity roles are containers for permission strings. When Elsa Identity issues a JWT, it collects permissions from the assigned roles and emits them as `permissions` claims. API-key authentication handlers should add equivalent `permissions` claims. External OIDC providers should emit Elsa permissions directly as `permissions` claims, or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
+Elsa Identity roles are containers for permission strings. When Elsa Identity issues a JWT or validates an Elsa API key, it collects permissions from the assigned roles and emits them as `permissions` claims. External OIDC providers should emit Elsa permissions directly as `permissions` claims, or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
 
 ASP.NET Core role policies such as `RequireRole("Admin")` are useful for your own host endpoints, Razor pages, controllers, or custom APIs. They do not replace Elsa endpoint permissions.
 
@@ -211,6 +211,7 @@ Permission names are not limited to constants in `PermissionNames`. Shared const
 
 For read-only workflow instance and execution result screens, start with `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. The current runtime status endpoint requires `ManageWorkflowRuntime`, which also grants pause, resume, and force-drain authority.
 
+For workflow routes handled by the `HttpEndpoint` activity, authorization is configured separately with the activity's `Authorize` and `Policy` settings. See [HTTP Endpoint Security](security/http-endpoint-security.md).
 ## OIDC Configuration
 
 OpenID Connect (OIDC) allows you to integrate with external identity providers like Azure AD, Auth0, Keycloak, and others.
@@ -319,7 +320,7 @@ app.Run();
 
 #### Step 7: Configure Studio for Azure AD
 
-Elsa Studio 3.7 uses the `Elsa.Studio.Authentication.OpenIdConnect` modules. Use the Blazor host pattern from [Studio Designer Integration](studio/integration/README.md), then configure `Backend:Url`, `Authentication:Provider`, and `Authentication:OpenIdConnect`.
+Elsa Studio 3.8 uses the `Elsa.Studio.Authentication.OpenIdConnect` modules. Use the Blazor host pattern from [Studio Designer Integration](studio/integration/README.md), then configure `Backend:Url`, `Authentication:Provider`, and `Authentication:OpenIdConnect`.
 
 For Blazor Server Studio hosts:
 
@@ -1088,7 +1089,7 @@ This configuration accepts either JWT Bearer tokens or API keys.
 
 ## Studio Authentication Configuration
 
-Elsa Studio needs to authenticate the user and send an access token to the Elsa Server API. In Elsa Studio 3.7, this is handled by the Studio authentication modules and the HTTP message handler configured for the backend client.
+Elsa Studio needs to authenticate the user and send an access token to the Elsa Server API. In Elsa Studio 3.8, this is handled by the Studio authentication modules and the HTTP message handler configured for the backend client.
 
 ### Studio with OpenID Connect
 
@@ -1171,18 +1172,7 @@ builder.Services.AddRemoteBackend(backendApiConfig);
 
 `BackendApiScopes` are requested for access tokens sent to the Elsa Server API. Use this when the Elsa Server API has its own scope or audience, such as `api://your-api-app-id/elsa-server-api`.
 
-Some identity providers require the backend API scope to be part of the original sign-in grant before they allow refresh-token or incremental token acquisition for that scope. If Studio signs in successfully but cannot obtain or refresh a backend API token, include the backend API scope in both arrays:
-
-```json
-{
-  "Authentication": {
-    "OpenIdConnect": {
-      "AuthenticationScopes": ["openid", "profile", "offline_access", "api://your-api-app-id/elsa-server-api"],
-      "BackendApiScopes": ["api://your-api-app-id/elsa-server-api"]
-    }
-  }
-}
-```
+Studio uses `AuthenticationScopes` during sign-in and `BackendApiScopes` when requesting bearer tokens for Elsa Server API calls.
 
 ### Studio with Elsa.Identity
 

--- a/guides/http-workflows/README.md
+++ b/guides/http-workflows/README.md
@@ -6,3 +6,5 @@ In this guide, we'll take a look at a workflow that can receive HTTP requests, s
 * SendHttpRequest
 * WriteHttpResponse
 * SetVariable
+
+For securing inbound workflow routes exposed by `HttpEndpoint`, see [HTTP Endpoint Security](../security/http-endpoint-security.md).

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -13,6 +13,7 @@ This guide provides actionable, Elsa-specific security practices for protecting 
 
 **What This Guide Covers:**
 - Configuring Identity and Authentication in Elsa Server (`UseIdentity`, `UseDefaultAuthentication`)
+- Securing `HttpEndpoint` workflow routes, including public vs authenticated endpoints
 - Securing tokenized bookmark resume URLs (TTL, revocation, rate limiting)
 - CORS, CSRF, and rate limiting for public-facing endpoints
 - Secrets management for API keys, database connections, and workflow variables
@@ -29,13 +30,15 @@ This guide provides actionable, Elsa-specific security practices for protecting 
 
 For clustering-specific security (distributed lock credentials, database permissions), see [Clustering Guide](../clustering/README.md) (DOC-015).
 
+For workflow-trigger ingress security specifically, see [HTTP Endpoint Security](http-endpoint-security.md).
+
 ---
 
 ## Identity & Authentication in Elsa Server
 
 ### UseIdentity Configuration
 
-Elsa Server's identity system is configured in `Program.cs` via the `UseIdentity` extension method. In the 3.7.0 server sample, token options are bound from `Identity:Tokens`, while users, applications, and roles are provided by configuration-based providers bound from the `Identity` section.
+Elsa Server's identity system is configured in `Program.cs` via the `UseIdentity` extension method. In the 3.8.0 server sample, token options are bound from `Identity:Tokens`, while users, applications, and roles are provided by configuration-based providers bound from the `Identity` section.
 
 **Reference:** `src/apps/Elsa.Server.Web/Program.cs` in elsa-core
 
@@ -139,11 +142,11 @@ Elsa validates the API key against configured applications; store hashed API key
 
 Elsa API endpoints check the `permissions` claim. Each claim value must match a permission required by the endpoint, and `*` grants all Elsa API permissions.
 
-Elsa Identity roles collect permission strings. When Elsa Identity issues a JWT, permissions from the assigned roles are emitted as `permissions` claims. API-key authentication handlers should add equivalent `permissions` claims. External IdPs should emit the same claim type or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
+Elsa Identity roles collect permission strings. When Elsa Identity issues a JWT or validates an Elsa API key, permissions from the assigned roles are emitted as `permissions` claims. External IdPs should emit the same claim type or the host should map external roles, groups, or scopes into `permissions` claims during token validation.
 
 ASP.NET Core policies such as `RequireRole("Admin")` protect custom host endpoints, pages, or controllers. They do not replace Elsa endpoint permission claims. Elsa endpoint permissions come from endpoint configuration and module constants, not only from shared `PermissionNames` constants.
 
-Common read-only workflow access uses `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. Use `*` only for full administrative access.
+Common read-only workflow access uses `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. Use `*` only for full administrative access. For workflow ingress routes handled by the `HttpEndpoint` activity, see [HTTP Endpoint Security](http-endpoint-security.md).
 
 **Important:**
 - **Never commit secrets** to source control
@@ -479,7 +482,7 @@ spec:
 ### SSO/Identity Integration
 
 **Studio Authentication:**
-- Configure Studio to use the same OIDC provider as Elsa Server through Studio 3.7.0 configuration
+- Configure Studio to use the same OIDC provider as Elsa Server through the current Studio OIDC configuration
 - Use the Blazor host pattern in [Studio Designer Integration](../studio/integration/README.md), then configure:
   ```json
   {
@@ -498,7 +501,7 @@ spec:
   }
   ```
 
-  `AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant as well; if backend API token acquisition or refresh fails, include the same scope in both `AuthenticationScopes` and `BackendApiScopes`.
+  `AuthenticationScopes` are used for Studio sign-in. `BackendApiScopes` are used when Studio requests access tokens for Elsa Server API calls.
 
   Register Studio redirect and logout callback URIs according to the host model: Blazor WebAssembly uses `/authentication/login-callback` and `/authentication/logout-callback`; Blazor Server uses `/signin-oidc` and `/signout-callback-oidc` by default. Studio initiates logout at `/authentication/logout`.
 

--- a/guides/security/external-identity-providers.md
+++ b/guides/security/external-identity-providers.md
@@ -320,8 +320,8 @@ builder.Services
         options.ClaimActions.MapJsonKey("role", "roles");
     });
 
-// Translate Keycloak roles into "permissions" claims in the authentication
-// handler that protects Elsa API endpoints, usually AddJwtBearer.
+// Add an OnTokenValidated handler to translate Keycloak roles into
+// "permissions" claims before requests reach Elsa API endpoints.
 ```
 
 **Further Reading:**
@@ -370,11 +370,9 @@ builder.Services
 
 After authentication, Elsa API endpoints authorize requests with `permissions` claims. Each claim value must match a permission configured by the endpoint, and `*` grants all Elsa permissions.
 
-Elsa Identity roles are containers for permission strings. When Elsa Identity issues tokens, assigned role permissions are emitted as `permissions` claims. With an external IdP, either emit the same claim type from the provider or map external roles, groups, or scopes into `permissions` claims in the Elsa Server host.
+Elsa Identity roles are containers for permission strings. With an external IdP, either emit `permissions` claims from the provider or map external roles, groups, or scopes into `permissions` claims in the Elsa Server host.
 
 ### Mapping External Roles to Elsa Permissions
-
-The following example uses JWT bearer authentication because Elsa Server API endpoints validate access tokens on incoming API requests. Use OpenID Connect middleware for interactive sign-in flows, typically paired with cookies, and use JWT bearer middleware for API access-token validation.
 
 ```csharp
 builder.Services
@@ -387,13 +385,13 @@ builder.Services
         {
             OnTokenValidated = context =>
             {
-                var identity = (ClaimsIdentity)context.Principal!.Identity!;
+                var claimsIdentity = (ClaimsIdentity)context.Principal!.Identity!;
 
                 if (context.Principal.IsInRole("workflow-viewer"))
                 {
-                    identity.AddClaim(new Claim("permissions", "read:workflow-definitions"));
-                    identity.AddClaim(new Claim("permissions", "read:workflow-instances"));
-                    identity.AddClaim(new Claim("permissions", "read:activity-execution"));
+                    claimsIdentity.AddClaim(new Claim("permissions", "read:workflow-definitions"));
+                    claimsIdentity.AddClaim(new Claim("permissions", "read:workflow-instances"));
+                    claimsIdentity.AddClaim(new Claim("permissions", "read:activity-execution"));
                 }
 
                 if (context.Principal.IsInRole("workflow-admin"))
@@ -405,29 +403,7 @@ builder.Services
     });
 ```
 
-ASP.NET Core role policies still apply to endpoints you map yourself:
-
-```csharp
-builder.Services.AddAuthorization(options =>
-{
-    options.AddPolicy("HostAdminOnly", policy => policy.RequireRole("admin"));
-});
-
-app.MapGet("/host/admin", () => Results.Ok())
-   .RequireAuthorization("HostAdminOnly");
-```
-
-These policies do not replace Elsa API permissions. Elsa endpoint permissions come from endpoint configuration such as `ConfigurePermissions(...)` and from module constants, not only from the shared `PermissionNames` constants.
-
-Common read-only workflow access uses:
-
-```text
-read:workflow-definitions
-read:workflow-instances
-read:activity-execution
-```
-
-Add Studio metadata permissions only as needed, such as `read:activity-descriptors`, `read:expression-descriptors`, `read:storage-drivers`, `read:variable-descriptors`, and `read:installed-features`.
+ASP.NET Core `RequireRole(...)` policies protect custom host endpoints. They do not replace Elsa API permissions. Elsa endpoint permissions come from endpoint configuration such as `ConfigurePermissions(...)` and from module constants, not only from shared `PermissionNames` constants.
 
 ## Elsa Studio Configuration
 
@@ -457,7 +433,7 @@ Use the Blazor host pattern from [Studio Designer Integration](../studio/integra
 
 For Blazor Server Studio hosts, `ClientSecret` can be added when the OIDC provider requires a confidential client. For WebAssembly Studio hosts, omit `ClientSecret` and register the client as a public SPA using authorization code flow with PKCE.
 
-`AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant before refresh-token or incremental token acquisition can return backend API tokens; in that case, include the backend API scope in both arrays.
+`AuthenticationScopes` are used during Studio sign-in. `BackendApiScopes` are used when Studio requests bearer tokens for Elsa Server API calls.
 
 Register callback URIs according to the Studio host model:
 
@@ -466,6 +442,7 @@ Register callback URIs according to the Studio host model:
 
 Studio initiates OIDC logout at `https://studio.example.com/authentication/logout`.
 
+For workflow routes secured with `HttpEndpoint`, see [HTTP Endpoint Security](http-endpoint-security.md).
 ## REST API Integration
 
 When calling Elsa Server APIs from external applications, use bearer token authentication:

--- a/guides/security/http-endpoint-security.md
+++ b/guides/security/http-endpoint-security.md
@@ -1,0 +1,143 @@
+---
+description: >-
+  Secure Elsa HTTP workflow endpoints in 3.8.0 by separating workflow ingress
+  authorization from Elsa API permissions and Studio access.
+---
+
+# HTTP Endpoint Security
+
+`HttpEndpoint` security in Elsa has two separate layers:
+
+1. Workflow ingress security for routes handled by the `HttpEndpoint` activity, usually under `/workflows/*`.
+2. Elsa API security for routes under `/elsa/api/*`, which Studio and automation clients use.
+
+These layers are independent. A public workflow endpoint does not make the Elsa API public, and Elsa API permissions do not secure a workflow endpoint unless the `HttpEndpoint` itself requires authorization.
+
+## How Elsa exposes `HttpEndpoint`
+
+In `release/3.8.0`, the HTTP module combines the configured HTTP base path with the activity path. By default, the base path is `/workflows`, so a workflow path such as `orders/{id}` is exposed as `/workflows/orders/{id}`.
+
+`HttpEndpoint` defaults that matter for security:
+
+- `SupportedMethods` defaults to `GET`.
+- `Authorize` defaults to `false`, so the endpoint is public unless you turn authorization on.
+- `Policy` is optional and only applies when the endpoint is authorized.
+
+The route, allowed methods, authorization flag, and optional policy are stored in the generated HTTP bookmark payload. Elsa uses that payload both when starting a workflow from a trigger and when resuming a waiting workflow through the same endpoint.
+
+## Public Endpoints
+
+Leave `Authorize` disabled when the endpoint must be callable anonymously, for example:
+
+- public webhooks
+- callback URLs protected by their own signed token
+- anonymous form posts that perform their own validation
+
+Public endpoints still need normal HTTP hardening. For `HttpEndpoint`, the built-in knobs are:
+
+- `RequestTimeout`
+- `RequestSizeLimit`
+- `FileSizeLimit`
+- `AllowedFileExtensions`
+- `BlockedFileExtensions`
+- `AllowedMimeTypes`
+
+You should still apply TLS, ingress rate limits, and payload validation in the host application or reverse proxy.
+
+## Authenticated Endpoints
+
+Set `Authorize` to `true` when the caller must be authenticated before the workflow can start or resume.
+
+With `Authorize = true` and no policy configured:
+
+- Elsa requires an authenticated `HttpContext.User`.
+- Any authenticated principal is accepted.
+
+This depends on the host having ASP.NET Core authentication and authorization enabled. If the host omits `app.UseAuthentication()` or `app.UseAuthorization()`, the request reaches Elsa as anonymous and the endpoint authorization fails.
+
+## Policy-Based Endpoints
+
+Set both `Authorize = true` and `Policy = "YourPolicyName"` when the endpoint should use a named ASP.NET Core authorization policy.
+
+Elsa evaluates that policy through `IAuthorizationService.AuthorizeAsync(...)` and passes the current workflow as the protected resource. This lets you use standard ASP.NET Core policies based on roles, claims, groups, or custom authorization handlers.
+
+Example host policy:
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("WorkflowOperators", policy =>
+        policy.RequireAuthenticatedUser()
+            .RequireRole("WorkflowOperator"));
+});
+```
+
+Then configure the `HttpEndpoint` activity with:
+
+- `Authorize`: enabled
+- `Policy`: `WorkflowOperators`
+
+## Actual 3.8.0 Response Behavior
+
+One important release-specific detail: in `release/3.8.0`, failed `HttpEndpoint` authorization currently results in `401 Unauthorized` from the HTTP workflows middleware, even when the failure comes from a policy check.
+
+That means these cases all surface as `401` at the workflow endpoint:
+
+- no authenticated user
+- an authenticated user that fails the configured policy
+
+If you are troubleshooting a protected endpoint, do not assume `401` means "not logged in" only. It can also mean the named policy rejected the authenticated caller.
+
+## Elsa API Permissions Are Separate
+
+Elsa API endpoints use `permissions` claims, not the `HttpEndpoint` `Authorize` flag.
+
+Common examples:
+
+| Scenario | Typical Elsa API permissions |
+| --- | --- |
+| View workflow definitions | `read:workflow-definitions` |
+| Edit workflow definitions | `write:workflow-definitions` |
+| Publish or retract definitions | `publish:workflow-definitions`, `retract:workflow-definitions` |
+| View workflow instances and journal-backed data | `read:workflow-instances` |
+| View activity execution summaries | `read:activity-execution` |
+| Load Studio designer metadata | `read:activity-descriptors`, `read:activity-descriptors-options`, `read:expression-descriptors`, `read:storage-drivers`, `read:variable-descriptors`, `read:installed-features` |
+| Administer workflow runtime | `ManageWorkflowRuntime` |
+| Full Elsa API access | `*` |
+
+This is why a user can successfully call a protected `HttpEndpoint` and still fail to use Elsa Studio, or vice versa.
+
+## Studio and Operator Troubleshooting
+
+### `404 Not Found` on a workflow route
+
+Check the effective URL first. With default HTTP settings, `Path = orders/{id}` is served from `/workflows/orders/{id}`, not `/orders/{id}`.
+
+### `401 Unauthorized` on `/workflows/...`
+
+In `release/3.8.0`, this usually means one of:
+
+- `Authorize` is enabled and the request is anonymous
+- `Authorize` is enabled, a `Policy` is configured, and the authenticated user failed that policy
+- the host did not enable ASP.NET Core authentication/authorization middleware
+
+### Studio signs in but cannot load definitions, instances, or designer metadata
+
+That is usually an Elsa API permissions problem, not a workflow ingress problem. Inspect the bearer token or API key identity and confirm it contains the required `permissions` claims for the `/elsa/api/*` endpoints Studio is calling.
+
+### Public webhook works locally but not behind a gateway
+
+Check the reverse proxy or ingress configuration for:
+
+- path rewriting
+- request size limits
+- TLS termination
+- forwarded authentication headers
+- rate limiting rules
+
+## Related Guides
+
+- [Authentication & Authorization](../authentication.md)
+- [Security & Authentication](README.md)
+- [External Identity Providers](external-identity-providers.md)
+- [HTTP Workflows](../http-workflows/README.md)

--- a/guides/studio/integration/README.md
+++ b/guides/studio/integration/README.md
@@ -132,7 +132,7 @@ With this provider, the server host registers `AddElsaIdentity()` and `AddElsaId
 
 Use `ClientSecret` only for confidential clients such as the server host. In the OpenID Connect modules, bearer tokens for Elsa API calls are attached by `OidcAuthenticatingApiHttpMessageHandler`, and SignalR connections are configured through `OidcHttpConnectionOptionsConfigurator`.
 
-`AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant before refresh-token or incremental token acquisition can return backend API tokens; in that case, include the backend API scope in both arrays.
+`AuthenticationScopes` are used during Studio sign-in. `BackendApiScopes` are used when Studio requests bearer tokens for Elsa Server API calls.
 
 For Blazor Server Studio, register `{studio-url}/signin-oidc` as the redirect URI and `{studio-url}/signout-callback-oidc` as the signed-out callback URI unless you override the defaults. Studio initiates logout at `{studio-url}/authentication/logout`.
 
@@ -169,7 +169,7 @@ Use this host when you want a dedicated SPA-style Studio deployment.
 
 Do not configure a client secret in WebAssembly. The browser host is a public client.
 
-`AuthenticationScopes` are requested during sign-in. `BackendApiScopes` are requested when Studio obtains an access token for the Elsa Server API. Some identity providers require the backend API scope in the original sign-in grant before refresh-token or incremental token acquisition can return backend API tokens; in that case, include the backend API scope in both arrays.
+`AuthenticationScopes` are used during Studio sign-in. `BackendApiScopes` are used when Studio requests bearer tokens for Elsa Server API calls.
 
 For Blazor WebAssembly Studio, register `{studio-url}/authentication/login-callback` as the redirect URI and `{studio-url}/authentication/logout-callback` as the logout callback URI. Studio initiates logout at `{studio-url}/authentication/logout`.
 


### PR DESCRIPTION
## Summary
- add a dedicated HTTP endpoint security guide grounded in `release/3.8.0`
- connect workflow ingress authorization to separate Elsa API permission guidance
- tighten related auth and Studio OIDC docs, and update the slice backlog

## Validation
- verified `HttpEndpoint`, HTTP middleware, permission claims, API key/JWT issuance, and Studio OIDC callback/token handling against `release/3.8.0` source
- ran `git diff --check`
- ran a targeted relative-link existence check for edited Markdown files