### PR TITLE
docs: add configuration management guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -41,6 +41,7 @@
   * [HTTP Endpoint Security](guides/security/http-endpoint-security.md)
   * [External Identity Providers](guides/security/external-identity-providers.md)
 * [Deployment](guides/deployment/README.md)
+  * [Configuration Management](guides/deployment/configuration-management.md)
   * [Kubernetes Basics](guides/deployment/kubernetes.md)
 * [Kubernetes Deployment](guides/kubernetes-deployment.md)
 * [Integration](guides/integration/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-29)
+## Slice Inventory (2026-06-30)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -33,6 +33,7 @@ acceptance criterion below is already complete.
 - `DOC-018` Plugins and modules development
 - `DOC-019` HTTP endpoint security
 - `DOC-020` EF Core migrations
+- `DOC-021` Configuration management
 - `DOC-022` Scaling and performance
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
@@ -45,7 +46,6 @@ acceptance criterion below is already complete.
 
 ### Available next slices
 
-- `DOC-021` Configuration management
 - `DOC-023` Identity provider integrations
 - `DOC-024` MassTransit communication
 - `DOC-025` Long-running workflows
@@ -58,10 +58,10 @@ acceptance criterion below is already complete.
 - `DOC-048` Activity reference
 ### Recommended next slice
 
-- `DOC-021` Configuration management: still a high-value follow-on because
-  configuration details remain spread across app-type, deployment, auth, and
-  hosting guides. A single release-backed guide should connect appsettings,
-  environment variables, feature toggles, and common precedence pitfalls.
+- `DOC-024` MassTransit communication: the existing activity guide is still
+  thinner than other integration topics and does not yet give operators and
+  workflow designers a single release-backed explanation of transports,
+  contracts, trigger routing, and failure handling.
 
 ### Newly discovered follow-on topics
 
@@ -75,15 +75,19 @@ acceptance criterion below is already complete.
 - `DOC-052` Workflow state and journal API cookbook: add an operations-facing
   guide for inspecting workflow state, filtered journal entries, activity
   executions, and variable mutation endpoints when diagnosing live instances.
+- `DOC-054` Standalone versus modular configuration matrix: add a compact
+  reference that maps `AddElsa(...)` host settings to `CShells` feature
+  settings so teams can migrate between hosting models without reverse
+  engineering sample apps.
 
 ## Critical Priority (Must Have - Block Users)
 
 ### Current slice note
 
-- `DOC-019` HTTP endpoint security:
-  add a dedicated release-backed guide for `HttpEndpoint` authorization,
-  public vs authenticated ingress, policy behavior, separation from Elsa API
-  permissions, and Studio/operator troubleshooting.
+- `DOC-021` Configuration management:
+  add a release-backed guide that connects standalone server, standalone
+  Studio, and modular-host section names, environment overrides, migration
+  toggles, and cross-host alignment pitfalls.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/deployment/README.md
+++ b/guides/deployment/README.md
@@ -4,6 +4,7 @@ This section covers deploying Elsa Workflows to various environments and platfor
 
 ## Guides in This Section
 
+* [Configuration Management](configuration-management.md) - Source-backed map of Elsa Server, Studio, and modular host configuration sections, overrides, and common pitfalls.
 * [Kubernetes Basics](kubernetes.md) - Quick-start guide for deploying Elsa to Kubernetes with PostgreSQL persistence, including troubleshooting and production best practices.
 
 ## Related Documentation

--- a/guides/deployment/configuration-management.md
+++ b/guides/deployment/configuration-management.md
@@ -1,0 +1,302 @@
+---
+description: >-
+  Manage Elsa Server, Elsa Studio, and modular host configuration with
+  appsettings, environment overrides, and source-backed section names for
+  release 3.8.0.
+---
+
+# Configuration Management
+
+This guide shows how Elsa 3.8 hosts read configuration, which section names
+they actually bind in the release source, and where environment overrides fit.
+It focuses on the shipped host patterns in `release/3.8.0`:
+
+* `Elsa.Server.Web` in `elsa-core`
+* `Elsa.ModularServer.Web` in `elsa-core`
+* `Elsa.Studio.Host.Server` and `Elsa.Studio.Host.Wasm` in `elsa-studio`
+
+Use this guide when you need to answer questions such as:
+
+* Which settings belong in `appsettings.json` versus code?
+* Which keys can I override with environment variables?
+* Why did a setting not change anything?
+* Which settings must stay aligned across Elsa Server, Studio, and my reverse proxy?
+
+## How Elsa Reads Configuration
+
+Elsa does not add a custom global configuration system on top of ASP.NET Core.
+The shipped server hosts start with `WebApplication.CreateBuilder(args)`, and
+the WASM Studio host starts with `WebAssemblyHostBuilder.CreateDefault(args)`.
+After that, each host binds specific configuration sections into options inside
+`Program.cs`.
+
+That means two things:
+
+1. A setting only works if the host or feature actually binds it.
+2. Most overrides follow normal .NET configuration rules, including
+   `appsettings.json`, environment-specific JSON files, user secrets, command
+   line arguments, and environment variables for server-side hosts.
+
+## The Three Main Host Shapes
+
+### 1. Standalone Elsa Server (`AddElsa(...)`)
+
+The sample `Elsa.Server.Web` host binds these release-backed sections:
+
+| Section | Used for |
+| --- | --- |
+| `Http` | HTTP activity base URL, base path, content types, and related HTTP activity options |
+| `Identity` | configuration-based users, applications, roles, and token settings |
+| `Identity:Tokens` | signing key and token lifetime settings |
+| `Multitenancy` | configuration-based tenants |
+| `IngressRateLimiting` | fixed-window rate limit settings for Elsa APIs and HTTP workflow ingress |
+| `Scripting:CSharp` | C# expression engine options |
+| `Scripting:Python` | Python engine options such as DLL path and scripts |
+| `DistributedRuntime:AllowLocalLockProviderInDistributedRuntime` | development/single-host override for distributed runtime locking |
+
+The important constraint is that this host does **not** use a single `Elsa:*`
+root. The sections above are bound explicitly in code.
+
+### 2. Elsa Studio Hosts
+
+The standalone Studio hosts bind a different set of sections:
+
+| Section | Used for |
+| --- | --- |
+| `Backend` | Elsa Server API base URL |
+| `Authentication:Provider` | selects `ElsaIdentity`, `OpenIdConnect`, or `ElsaLogin` depending on host |
+| `Authentication:OpenIdConnect` | OIDC authority, client IDs, scopes, and token behavior |
+| `Localization` | default culture and supported cultures |
+| `Shell` | server-hosted Studio shell options |
+| `DesignerOptions` | flowchart designer options such as `UseReactFlow` |
+
+Set `Authentication:Provider` explicitly. The defaults differ by host:
+
+* `Elsa.Studio.Host.Server` falls back to `ElsaIdentity` if the setting is
+  missing.
+* `Elsa.Studio.Host.Wasm` falls back to `OpenIdConnect` if the setting is
+  missing.
+
+### 3. Modular Elsa Server (`CShells`)
+
+`Elsa.ModularServer.Web` uses shell-based configuration instead of the
+standalone `AddElsa(...)` pattern. Its primary sections are:
+
+| Section | Used for |
+| --- | --- |
+| `CShells:Shells:*` | per-shell feature enablement and feature settings |
+| `Diagnostics:OpenTelemetry:Exporter` | OTLP endpoint and protocol |
+| `Nuplane` | package feeds and autoload behavior |
+| `Elsa:PlatformIntegration:ShellOverlayPath` | optional JSON overlay file path loaded at startup |
+
+In this host, persistence, authentication, HTTP, secrets, and routing settings
+live under shell feature names such as `Identity`, `FastEndpoints`,
+`SqliteWorkflowPersistence`, `Http`, or `Secrets`.
+
+## Configuration Map by App Type
+
+### Standalone Elsa Server example
+
+The `Elsa.Server.Web` sample app ships with settings shaped like this:
+
+```json
+{
+  "Http": {
+    "BaseUrl": "https://localhost:5001",
+    "BasePath": "/workflows"
+  },
+  "Identity": {
+    "Tokens": {
+      "SigningKey": "CHANGE_ME_TO_A_SECURE_RANDOM_KEY"
+    }
+  },
+  "Multitenancy": {
+    "Tenants": []
+  },
+  "IngressRateLimiting": {
+    "Enabled": false
+  }
+}
+```
+
+Use this shape when you host Elsa directly in your own ASP.NET Core app with
+`builder.Services.AddElsa(...)`.
+
+### Elsa Studio example
+
+The standalone Studio hosts expect settings shaped like this:
+
+```json
+{
+  "Backend": {
+    "Url": "https://localhost:5001/elsa/api"
+  },
+  "Authentication": {
+    "Provider": "OpenIdConnect",
+    "OpenIdConnect": {
+      "Authority": "https://login.microsoftonline.com/<tenant>/v2.0",
+      "ClientId": "<client-id>"
+    }
+  },
+  "Localization": {
+    "DefaultCulture": "en-US",
+    "SupportedCultures": [ "en-US" ]
+  },
+  "DesignerOptions": {
+    "UseReactFlow": false
+  }
+}
+```
+
+For Blazor WebAssembly, these values usually live in
+`wwwroot/appsettings.json`. Browser clients do not read server environment
+variables directly, so production overrides usually happen during build,
+publish, or host-page generation.
+
+### Modular server example
+
+The modular server sample uses shell feature configuration like this:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Identity": {
+            "SigningKey": "CHANGE_ME_TO_A_SECURE_RANDOM_KEY"
+          },
+          "FastEndpoints": {
+            "GlobalRoutePrefix": "elsa/api"
+          },
+          "SqliteWorkflowPersistence": {
+            "ConnectionString": "Data Source=elsa_workflows.db;Cache=Shared"
+          },
+          "Http": {
+            "HttpActivityOptions": {
+              "BaseUrl": "https://localhost:5001"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Use this model when you need multiple shells, per-shell routing, or feature
+configuration that can vary by shell.
+
+## Environment Variables and Overrides
+
+For server-side hosts, normal .NET environment variable mapping applies:
+
+* `:` in configuration paths becomes `__`
+* keys are case-insensitive on the .NET side
+* later providers override earlier providers
+
+Examples:
+
+```bash
+Http__BaseUrl=https://workflows.example.com
+Http__BasePath=/workflows
+Identity__Tokens__SigningKey=<strong-random-key>
+IngressRateLimiting__Enabled=true
+IngressRateLimiting__ApiPermitLimit=300
+Backend__Url=https://workflows.example.com/elsa/api
+Authentication__Provider=OpenIdConnect
+ConnectionStrings__PostgreSql=Host=db;Database=elsa;Username=elsa;Password=secret
+```
+
+Prefer environment variables, user secrets, or a secret manager for:
+
+* signing keys
+* API keys and client secrets
+* database credentials
+* secrets encryption keys
+
+Do not commit production secrets into `appsettings.json`.
+
+## Settings That Must Stay Aligned
+
+### Public URLs
+
+If Elsa is exposed behind a reverse proxy or ingress, keep these consistent:
+
+* `Http:BaseUrl` should reflect the public Elsa Server URL.
+* `Backend:Url` in Studio should point to the public Elsa API URL.
+* Reverse proxy rules must preserve the same public API path that Studio uses.
+
+If these drift apart, generated links, callbacks, or Studio API calls can fail
+even when the application itself starts correctly.
+
+### HTTP workflow base path versus Elsa API path
+
+These are separate concerns:
+
+* `Http:BasePath` controls where `HttpEndpoint` activity routes are mounted.
+* Elsa API endpoints use `ApiEndpointOptions.RoutePrefix`, whose default is
+  `elsa/api`.
+
+In 3.8, `HttpActivityOptions.ApiRoutePrefix` is obsolete. Do not treat
+`Http:ApiRoutePrefix` as the source of truth for Elsa API routing in new host
+code.
+
+### Authentication mode
+
+Studio and Server must agree on the authentication story:
+
+* If Studio uses `OpenIdConnect`, Elsa Server must trust the same identity
+  provider and scopes.
+* If Studio uses `ElsaIdentity` or `ElsaLogin`, Elsa Server must expose the
+  corresponding identity endpoints and configured users or applications.
+
+## Migrations and Persistence Toggles
+
+Database connection strings alone do not switch persistence providers. The host
+must also call the provider-specific Elsa persistence configuration methods.
+
+For EF Core persistence, automatic migrations are controlled on the persistence
+features through `RunMigrations`, not through a built-in global
+`Elsa:AutoMigrate` setting.
+
+That distinction matters because:
+
+* changing only `ConnectionStrings:*` does not move Elsa off in-memory stores
+* migration behavior belongs to the configured persistence feature
+* different hosts can expose migration toggles differently
+
+See [Database Configuration](../../getting-started/database-configuration.md)
+and [EF Core Migrations](../persistence/ef-migrations.md) for provider-specific
+examples.
+
+## Common Pitfalls
+
+### A config key exists in docs but nothing reads it
+
+Check the host's `Program.cs`. Elsa settings are often bound explicitly, so an
+unbound section does nothing.
+
+### Studio can load, but API calls fail
+
+Check `Backend:Url`, the API route prefix, CORS, and auth provider alignment
+before debugging the workflow engine itself.
+
+### WASM settings do not change after updating server environment variables
+
+Blazor WASM reads client configuration from static assets such as
+`wwwroot/appsettings.json`. Updating server environment variables alone does not
+rewrite those files.
+
+### Reverse proxy deployments generate wrong absolute links
+
+Set `Http:BaseUrl` to the public URL seen by clients, not only the internal
+container or pod address.
+
+## Related Guides
+
+* [Database Configuration](../../getting-started/database-configuration.md)
+* [Authentication & Authorization](../authentication.md)
+* [Security & Authentication](../security/README.md)
+* [Deployment](README.md)
+* [Studio Integration](../studio/integration/README.md)

--- a/guides/deployment/kubernetes.md
+++ b/guides/deployment/kubernetes.md
@@ -353,15 +353,14 @@ builder.Services.AddElsa(elsa =>
 
 var app = builder.Build();
 
-// Auto-migrate on startup (optional, can also use init containers)
-if (builder.Configuration.GetValue<bool>("Elsa:AutoMigrate", false))
-{
-    await app.Services.MigrateElsaDatabaseAsync();
-}
-
 app.UseWorkflowsApi();
 app.Run();
 ```
+
+If you want migrations to run at application startup, enable them on the EF
+Core persistence features you configure rather than relying on a built-in
+`Elsa:AutoMigrate` setting. Elsa 3.8 wires migration execution through the
+`RunMigrations` property on the persistence features.
 
 ## Why Changing Only the Connection String Isn't Enough
 
@@ -453,20 +452,52 @@ spec:
 {% endhint %}
 ### Option 2: Auto-Migration on Startup
 
-Enable auto-migration in the application (simpler but not ideal for production):
+Enable auto-migration in the application by setting `RunMigrations` on the EF
+Core persistence features (simpler but not ideal for production):
 
 ```csharp
-// In Program.cs
-if (builder.Configuration.GetValue<bool>("Elsa:AutoMigrate", false))
+elsa.UseWorkflowManagement(management =>
 {
-    await app.Services.MigrateElsaDatabaseAsync();
-}
+    management.UseEntityFrameworkCore(ef =>
+    {
+        ef.UsePostgreSql(builder.Configuration.GetConnectionString("PostgreSql")!);
+    });
+    management.RunMigrations = true;
+});
+
+elsa.UseWorkflowRuntime(runtime =>
+{
+    runtime.UseEntityFrameworkCore(ef =>
+    {
+        ef.UsePostgreSql(builder.Configuration.GetConnectionString("PostgreSql")!);
+    });
+    runtime.RunMigrations = true;
+});
+```
+
+If you want to switch this behavior per environment, read your own config flag
+and assign `RunMigrations` from code:
+
+```csharp
+var runMigrations = builder.Configuration.GetValue("Persistence:RunMigrations", false);
+
+elsa.UseWorkflowManagement(management =>
+{
+    management.UseEntityFrameworkCore(ef => ef.UsePostgreSql(builder.Configuration.GetConnectionString("PostgreSql")!));
+    management.RunMigrations = runMigrations;
+});
+
+elsa.UseWorkflowRuntime(runtime =>
+{
+    runtime.UseEntityFrameworkCore(ef => ef.UsePostgreSql(builder.Configuration.GetConnectionString("PostgreSql")!));
+    runtime.RunMigrations = runMigrations;
+});
 ```
 
 Set the environment variable in the deployment:
 ```yaml
 env:
-- name: Elsa__AutoMigrate
+- name: Persistence__RunMigrations
   value: "true"
 ```
 


### PR DESCRIPTION
## Summary
- add a release-backed configuration management guide for standalone Elsa Server, standalone Studio, and modular CShells hosts
- document real 3.8 section names, environment override patterns, and cross-host alignment pitfalls
- replace stale Kubernetes auto-migration guidance with `RunMigrations`-based examples and advance the documentation slice backlog

## Validation
- validated section names and host behavior against `release/3.8.0` in `elsa-core` and `elsa-studio`
- ran `git diff --check`
- ran a targeted relative-link existence check for the touched deployment docs