### PR TITLE
docs: ground alterations guides in 3.8.0 behavior

### DIFF
--- a/features/alterations/README.md
+++ b/features/alterations/README.md
@@ -52,8 +52,8 @@ Use these pages for each mode:
 | --- | --- |
 | You already know the exact workflow instance IDs and need the response now | `POST /alterations/run` or `IAlterationRunner` |
 | You need Elsa to find matching workflow instances from filters and process them in the background | alteration plans |
-| You need to retry faulted activities across one or more instances | `POST /alterations/workflows/retry` |
-| You want designers or operators to stage a bulk plan visually in Studio | Elsa Studio alterations module |
+| You need to retry faulted activities for known workflow instances | `POST /alterations/workflows/retry` |
+| You want designers or operators to stage alterations for one running instance visually and inspect resulting plans later | Elsa Studio alterations module |
 
 ## Elsa Studio
 
@@ -67,7 +67,7 @@ Studio exposes:
 * plan details pages that show plan status, generated jobs, and per-job logs
 * quick **Alter** actions from workflow-instance screens
 
-Studio currently focuses on staging or inspecting plans around individual running instances. For cross-instance bulk operations, use alteration plans and their filter-based API.
+Studio creates plan submissions from a selected workflow instance. For cross-instance bulk operations, use alteration plans and their filter-based API, then use Studio's **Plans** view to inspect the resulting jobs and logs.
 
 ## Persistence and dispatch options
 
@@ -108,4 +108,4 @@ Use the MassTransit dispatcher when alteration jobs should survive node boundari
 * If a submitted plan matches no instances, Elsa still stores the plan but generates no jobs.
 * `/alterations/run` dispatches successful workflow instances that still have scheduled work after the alterations finish.
 * `IAlterationRunner` by itself does not dispatch scheduled work; pair it with `IAlteredWorkflowDispatcher` when you call the service directly.
-* The built-in bulk retry endpoint schedules faulted activities by creating `ScheduleActivity` alterations and then dispatching the affected instances.
+* The retry endpoint schedules faulted activities by creating `ScheduleActivity` alterations and then dispatching the targeted workflow instances.

--- a/features/alterations/alteration-plans/README.md
+++ b/features/alterations/alteration-plans/README.md
@@ -108,7 +108,7 @@ Use plan timestamps plus per-job logs to answer operational questions such as:
 
 ## Elsa Studio workflow
 
-In Studio, the alterations designer submits the same `AlterationPlanParams` payload used by the server API.
+In Studio, the alterations designer submits the same `AlterationPlanParams` payload used by the server API, but in `release/3.8.0` it builds that payload from the currently selected workflow instance instead of exposing the full filter authoring surface.
 
 After submission, Studio navigates to a plan details page that shows:
 
@@ -117,4 +117,4 @@ After submission, Studio navigates to a plan details page that shows:
 * generated jobs
 * per-job log entries
 
-This is the fastest path for operators who want plan visibility without scripting the REST API directly.
+Use Studio when operators want to alter a known running instance and then inspect the resulting plan and jobs without scripting the REST API directly.

--- a/features/alterations/applying-alterations/README.md
+++ b/features/alterations/applying-alterations/README.md
@@ -66,7 +66,7 @@ Use alteration plans instead when Elsa should discover the target instances for 
 
 ## Retrying faulted workflow instances
 
-`release/3.8.0` also ships a bulk retry endpoint for faulted instances: `POST /alterations/workflows/retry`.
+`release/3.8.0` also ships a retry endpoint for faulted instances: `POST /alterations/workflows/retry`.
 
 That endpoint builds `ScheduleActivity` alterations for the specified activity IDs, or for all incident activity IDs when you omit `activityIds`, then dispatches the updated workflow instances.
 

--- a/features/alterations/applying-alterations/rest-api.md
+++ b/features/alterations/applying-alterations/rest-api.md
@@ -73,7 +73,7 @@ After the runner finishes, the endpoint automatically dispatches any successful 
 
 ## Retry faulted activities
 
-`release/3.8.0` also exposes `POST /alterations/workflows/retry` for retrying faulted activities across one or more workflow instances.
+`release/3.8.0` also exposes `POST /alterations/workflows/retry` for retrying faulted activities on specified workflow instances.
 
 If you omit `activityIds`, Elsa retries all incident activity IDs recorded on each specified workflow instance.
 


### PR DESCRIPTION
## Summary
- expand the alterations docs with release-backed behavior, permissions, and execution-mode guidance
- document plan/job lifecycle, Studio capabilities, and persistence/dispatcher options
- clarify retry endpoint wording to avoid overstating Studio bulk authoring or retry semantics

## Validation
- validated claims against release/3.8.0 source in elsa-core, elsa-studio, and elsa-extensions
- ran a local markdown link existence check for the altered files
- ran `git diff --check` on the altered files