### PR TITLE
docs: expand MassTransit communication guide

### DIFF
--- a/activities/masstransit/README.md
+++ b/activities/masstransit/README.md
@@ -95,6 +95,84 @@ Use RabbitMQ when your environment already standardizes on AMQP-style queues.
 Use Azure Service Bus when Elsa participates in Azure-native messaging and you
 want broker-managed topics and subscriptions.
 
+If you need to tune endpoint lifetime or throughput, configure
+`MassTransitOptions` in your host:
+
+{% code title="Program.cs" %}
+
+```csharp
+builder.Services.Configure<MassTransitOptions>(options =>
+{
+    options.TemporaryQueueTtl = TimeSpan.FromHours(1);
+    options.ConcurrentMessageLimit = 16;
+    options.PrefetchCount = 32;
+    options.MaxAutoRenewDuration = TimeSpan.FromMinutes(5); // Azure Service Bus only
+});
+```
+
+{% endcode %}
+
+In `release/3.8.0`, these options are consumed by the in-memory, RabbitMQ, and
+Azure Service Bus configurators. `TemporaryQueueTtl` controls the lifetime of
+temporary queues created for temporary consumers, `ConcurrentMessageLimit` and
+`PrefetchCount` shape throughput, and `MaxAutoRenewDuration` applies only to
+Azure Service Bus.
+
+## How message types shape the designer
+
+Elsa uses reflection over the registered CLR type to build the generated
+activity descriptor. In `release/3.8.0`, these attributes influence what
+appears in Studio:
+
+* `ActivityAttribute`: can override the generated type name, display name,
+  category, and description
+* `DisplayNameAttribute`: changes the visible activity title when
+  `ActivityAttribute` does not provide one
+* `CategoryAttribute`: changes the Studio category from the default
+  `MassTransit`
+* `DescriptionAttribute`: populates the activity description and variable
+  descriptor metadata
+
+For example:
+
+{% code title="Contracts/OrderCreated.cs" %}
+
+```csharp
+using System.ComponentModel;
+using Elsa.Workflows.Attributes;
+
+[Activity(DisplayName = "Order Accepted", Category = "Sales")]
+[Description("Raised when an order has been accepted by the sales system.")]
+public record OrderCreated(string OrderId);
+```
+
+{% endcode %}
+
+Registering that type generates a trigger named `Order Accepted` in the
+`Sales` category, plus `Publish Order Accepted` because the type is a class.
+
+## Endpoint topology and consumer behavior
+
+The MassTransit feature does more than add activities. It also registers a
+generated `WorkflowMessageConsumer<T>` for each message type you add with
+`AddMessageType<T>()`.
+
+In `release/3.8.0`:
+
+* Elsa configures MassTransit with kebab-case endpoint names
+* each registered message type gets a concrete MassTransit consumer that turns
+  the incoming message into an Elsa stimulus
+* the stimulus activity type name is derived from the CLR message type
+* temporary consumers are created before the transport is configured so MassTransit
+  can bind them correctly
+* RabbitMQ and Azure Service Bus temporary endpoints are prefixed with the
+  current application instance name, which helps isolate per-node temporary
+  consumers
+
+This matters operationally because the same broker can host both your
+application messages and Elsa's own internal dispatcher traffic without those
+concerns being the same feature.
+
 ## How receiving works
 
 When MassTransit receives a registered message type, Elsa's generated
@@ -131,10 +209,40 @@ Two details matter in practice:
 * the message input is converted to the configured CLR type before publishing,
   so the payload must be compatible with the registered message type
 
-## MassTransit activities vs other messaging features
+## Deployment patterns
+
+`DisableConsumers` is the main release-backed switch for deciding whether a
+node should consume MassTransit messages directly.
+
+Use it when you split responsibilities across nodes, for example:
+
+* API-focused nodes: expose Elsa APIs and Studio-backed operations, but do not
+  consume workflow messages
+* worker-focused nodes: run the same application but keep consumers enabled so
+  they receive workflow messages and dispatcher traffic
+
+{% code title="Program.cs" %}
+
+```csharp
+builder.Services.AddElsa(elsa => elsa
+    .UseMassTransit(mt =>
+    {
+        mt.DisableConsumers = appRole == ApplicationRole.Api;
+        mt.AddMessageType<OrderCreated>();
+        mt.UseRabbitMq(rabbitMqConnectionString);
+    }));
+```
+
+{% endcode %}
+
+When consumers are disabled, the generated publish activities still exist, but
+that node does not configure the message consumers that turn inbound MassTransit
+messages into workflow stimuli.
+
+## MassTransit activities vs MassTransit infrastructure features
 
 This page covers MassTransit-backed message-type activities. Elsa also has two
-related but different messaging integration paths:
+related but different MassTransit integration paths:
 
 * the MassTransit workflow dispatcher, enabled with
   `UseMassTransitDispatcher()` on workflow management and runtime features,
@@ -145,17 +253,18 @@ related but different messaging integration paths:
   those are separate from the generic message-type activities described here
 
 Use the generic MassTransit activities when your workflows exchange strongly
-typed application messages. Use transport-specific activity modules when you
-need queue or topic concepts that belong to a specific broker.
+typed application messages. Use the workflow dispatcher when Elsa runtime and
+management work should move over the bus between nodes. Use transport-specific
+activity modules when you need queue or topic concepts that belong to a
+specific broker.
 
 ## Operational notes
 
-* `DisableConsumers` can stop MassTransit consumers from being configured on a
-  given node. The Elsa workbench uses this to keep API-only nodes from
-  consuming messages directly.
-* `MassTransitOptions` in `release/3.8.0` include `TemporaryQueueTtl`,
-  `ConcurrentMessageLimit`, `PrefetchCount`, and `MaxAutoRenewDuration` for
-  Azure Service Bus.
+* `MassTransitHostOptions.WaitUntilStarted` is enabled so the host waits for
+  the bus to start before startup completes.
+* Azure Service Bus can run automated subscription cleanup, but that cleanup is
+  broad: in `release/3.8.0` it can remove subscriptions that Elsa did not
+  create if their queues cannot be found.
 * If you are also using MassTransit for clustered workflow dispatch or
   distributed cache invalidation, see the distributed hosting and clustering
   guides as well. Those features share the broker, but they solve a different

--- a/activities/masstransit/tutorial.md
+++ b/activities/masstransit/tutorial.md
@@ -45,6 +45,22 @@ With that configuration, Elsa adds two activities:
 If you omit `UseRabbitMq(...)` or another transport configuration method, Elsa
 falls back to MassTransit's in-memory transport.
 
+If you want to control throughput or temporary queue lifetime, configure
+`MassTransitOptions` in the host as well:
+
+{% code title="Program.cs" %}
+
+```csharp
+builder.Services.Configure<MassTransitOptions>(options =>
+{
+    options.ConcurrentMessageLimit = 16;
+    options.PrefetchCount = 32;
+    options.TemporaryQueueTtl = TimeSpan.FromHours(1);
+});
+```
+
+{% endcode %}
+
 ## 3. Start a workflow when the message arrives
 
 Use the generated `Order Created` trigger activity at the start of a workflow
@@ -87,6 +103,9 @@ public class OrderCreatedWorkflow : WorkflowBase
 When a MassTransit consumer receives `OrderCreated`, Elsa resumes or starts
 matching workflows by sending a stimulus that contains the message payload.
 
+The message is also exposed as the activity result, so downstream activities
+can read it through the output or through a workflow variable, as shown above.
+
 ## 4. Publish the message from a workflow
 
 Use the generated `Publish Order Created` activity when a workflow needs to
@@ -117,11 +136,19 @@ public class PublishOrderWorkflow : WorkflowBase
 
 In Studio, the equivalent activity is `Publish Order Created`.
 
+Because `OrderCreated` is a class, Elsa generates both the trigger and publish
+activities. If you register an interface instead, Elsa generates only the
+receive trigger.
+
 ## 5. Deployment notes
 
 * Keep consumers enabled on nodes that should process broker messages.
 * Set `massTransit.DisableConsumers = true` on nodes that should host the API
   but not consume workflow messages.
+* If you also move Elsa runtime dispatch over MassTransit, configure
+  `UseMassTransitDispatcher()` separately on workflow management and runtime
+  features. Registering message types alone does not enable dispatcher-based
+  workflow execution.
 * Tune queue and broker throughput with `MassTransitOptions` and the transport
   configurator callbacks.
 
@@ -130,7 +157,7 @@ In Studio, the equivalent activity is `Publish Order Created`.
 * If the activities do not appear, verify `AddMessageType<OrderCreated>()`
   runs during startup.
 * If messages publish but workflows do not start, verify consumers are enabled
-  on the running node.
+  on the running node and that the trigger is marked as a start trigger.
 * If you use a real broker, verify the relevant RabbitMQ or Azure Service Bus
   transport package is installed and configured.
 * If correlation matters, confirm the producer sets a MassTransit

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-06-30)
+## Slice Inventory (2026-07-02)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -34,6 +34,7 @@ acceptance criterion below is already complete.
 - `DOC-019` HTTP endpoint security
 - `DOC-020` EF Core migrations
 - `DOC-021` Configuration management
+- `DOC-024` MassTransit communication
 - `DOC-022` Scaling and performance
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
@@ -47,7 +48,6 @@ acceptance criterion below is already complete.
 ### Available next slices
 
 - `DOC-023` Identity provider integrations
-- `DOC-024` MassTransit communication
 - `DOC-025` Long-running workflows
 - `DOC-026` Error handling and retry logic
 - `DOC-027` Execution model
@@ -58,10 +58,10 @@ acceptance criterion below is already complete.
 - `DOC-048` Activity reference
 ### Recommended next slice
 
-- `DOC-024` MassTransit communication: the existing activity guide is still
-  thinner than other integration topics and does not yet give operators and
-  workflow designers a single release-backed explanation of transports,
-  contracts, trigger routing, and failure handling.
+- `DOC-025` Long-running workflows: the topic now has adjacent material spread
+  across timers, blocking activities, incidents, and clustering docs, but it
+  still needs one release-backed guide that explains lifecycle, persistence,
+  resumption, and operating expectations as a single story.
 
 ### Newly discovered follow-on topics
 
@@ -79,15 +79,20 @@ acceptance criterion below is already complete.
   reference that maps `AddElsa(...)` host settings to `CShells` feature
   settings so teams can migrate between hosting models without reverse
   engineering sample apps.
+- `DOC-055` Message broker topology cookbook: add an operations-facing guide
+  for queue naming, temporary endpoint lifetime, consumer placement, and broker
+  cleanup tradeoffs across MassTransit, Azure Service Bus activities, and
+  distributed cache invalidation.
 
 ## Critical Priority (Must Have - Block Users)
 
 ### Current slice note
 
-- `DOC-021` Configuration management:
-  add a release-backed guide that connects standalone server, standalone
-  Studio, and modular-host section names, environment overrides, migration
-  toggles, and cross-host alignment pitfalls.
+- `DOC-024` MassTransit communication:
+  expand the release-backed docs beyond basic setup so workflow designers and
+  operators can understand generated activity metadata, transport behavior,
+  node roles, and the boundary between message activities and Elsa's internal
+  dispatch infrastructure.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/hosting/distributed-hosting.md
+++ b/hosting/distributed-hosting.md
@@ -93,6 +93,11 @@ elsa.UseMassTransit(massTransit =>
 });
 ```
 
+This MassTransit configuration is infrastructure for cache invalidation. It is
+separate from the [MassTransit message-type activities](../activities/masstransit/README.md),
+which expose application message contracts such as `OrderCreated` as workflow
+activities.
+
 ### 4. Quartz.NET Clustered Mode
 
 When deploying multiple Elsa instances in a distributed environment, scheduled jobs (timers, delays, cron triggers) must execute only once across the cluster to prevent duplicate executions. Quartz.NET clustering ensures this by using a shared database to coordinate job execution across nodes.


### PR DESCRIPTION
## Summary
- expand the MassTransit guide with release-backed transport, topology, and node-role behavior
- clarify the boundary between message-type activities and Elsa's MassTransit dispatcher infrastructure
- refresh the slice backlog and link distributed hosting docs to the MassTransit activity guide

## Validation
- git diff --check
- targeted relative-link existence check for edited Markdown files
- validated claims against release/3.8.0 source in elsa-extensions worktrees