### PR TITLE
docs: ground incident and retry guidance

### DIFF
--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-03)
+## Slice Inventory (2026-07-05)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -36,6 +36,7 @@ acceptance criterion below is already complete.
 - `DOC-021` Configuration management
 - `DOC-024` MassTransit communication
 - `DOC-025` Long-running workflows
+- `DOC-026` Error handling and retry logic
 - `DOC-022` Scaling and performance
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
@@ -49,7 +50,6 @@ acceptance criterion below is already complete.
 ### Available next slices
 
 - `DOC-023` Identity provider integrations
-- `DOC-026` Error handling and retry logic
 - `DOC-027` Execution model
 - `DOC-038` Distributed tracing
 - `DOC-039` Performance tuning
@@ -58,11 +58,11 @@ acceptance criterion below is already complete.
 - `DOC-048` Activity reference
 ### Recommended next slice
 
-- `DOC-026` Error handling and retry logic: incidents, fault handling,
-  blocking resumption failures, and retry behavior are still split across
-  runtime, troubleshooting, and operations docs. A single release-backed guide
-  should show how Elsa records failures, how operators recover, and how to
-  design workflows for safe retries.
+- `DOC-023` Identity provider integrations: the repo now has broad
+  authentication coverage, but common provider setups are still split across
+  general auth, deployment, and security docs. A release-backed slice should
+  consolidate Elsa Server plus Studio setup, claim mapping, and operator
+  troubleshooting for the main OIDC provider paths.
 
 ### Newly discovered follow-on topics
 
@@ -84,15 +84,20 @@ acceptance criterion below is already complete.
   for queue naming, temporary endpoint lifetime, consumer placement, and broker
   cleanup tradeoffs across MassTransit, Azure Service Bus activities, and
   distributed cache invalidation.
+- `DOC-056` Custom resilience extensibility: add a focused guide for
+  `IResilienceStrategy`, `AddResilienceStrategyType<T>()`, and
+  `WithRetryAttemptRecorder(...)` so teams can persist retry diagnostics and
+  introduce non-HTTP resilience policies without reverse engineering tests and
+  feature registration.
 
 ## Critical Priority (Must Have - Block Users)
 
 ### Current slice note
 
-- `DOC-025` Long-running workflows:
-  harden the release-backed guide so it explains runtime prerequisites,
-  bookmark and trigger semantics, resume paths, and operational recovery as one
-  coherent workflow lifecycle story.
+- `DOC-023` Identity provider integrations:
+  consolidate the existing broad authentication material into release-backed
+  provider playbooks for Elsa Server, Studio hosts, claim mapping, and common
+  OIDC troubleshooting paths.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/api-client/README.md
+++ b/guides/api-client/README.md
@@ -521,52 +521,54 @@ Tokenized resume URLs should be treated as secrets:
 
 ### Resilience Strategies
 
-Elsa supports configuring resilience strategies for activities to handle transient failures. The exact API for configuring resilience may vary by version.
+In `release/3.8.0`, the .NET API client configures activity retry behavior with
+`ResilienceStrategyConfig` on `customProperties.resilienceStrategy`.
 
-#### Setting a Resilience Strategy (Conceptual Pattern)
+#### Setting a Resilience Strategy
 
-The following example demonstrates a conceptual pattern for configuring resilience. Consult the current Elsa documentation and source code for the actual API in your version:
+Use `ActivityExtensions.SetResilienceStrategy(...)` or assign the same payload
+directly through `CustomProperties`:
 
 ```csharp
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.Resilience.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 
 var activity = new Activity
 {
-    Type = "Elsa.HttpEndpoint",
+    Type = "Elsa.FlowSendHttpRequest",
     Id = "http-call-1"
 };
 
-// Conceptual pattern: Configure resilience via activity properties
-// The actual API may differ - check Elsa documentation for your version
-activity.CustomProperties["resilience"] = new Dictionary<string, object>
+activity.SetResilienceStrategy(new ResilienceStrategyConfig
 {
-    ["retryCount"] = 3,
-    ["backoffDelay"] = TimeSpan.FromSeconds(5).TotalMilliseconds,
-    ["backoffType"] = "Exponential"
-};
+    Mode = ResilienceStrategyConfigMode.Identifier,
+    StrategyId = "http-default"
+});
 ```
 
-> **Note:** The resilience configuration API is evolving. Check the `src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/` directory in elsa-core for current extension methods and models.
+The referenced strategy ID must exist in the host's resilience strategy
+catalog, for example from `Resilience:Strategies` configuration.
 
 ### Handling Incidents
 
-When activities fail, Elsa creates incidents. Query instance state to check for faults:
+When activities fail, inspect `WorkflowState.Incidents` on the workflow
+instance:
 
 ```csharp
 var instance = await _instancesApi.GetAsync(instanceId);
 
-if (instance.Status == WorkflowStatus.Faulted)
+if (instance.WorkflowState.Incidents.Any())
 {
-    // Check faults and incidents
-    var faults = instance.Faults;
-    foreach (var fault in faults)
+    foreach (var incident in instance.WorkflowState.Incidents)
     {
-        Console.WriteLine($"Activity {fault.ActivityId} failed: {fault.Message}");
+        Console.WriteLine($"Activity {incident.ActivityId} failed: {incident.Message}");
     }
 }
 ```
 
-For incident configuration and strategies, see the main documentation on incidents in the [Operate Guide](../operate/incidents.md).
+For workflow-level incident handling and operator retry guidance, see
+[Incidents](../../operate/incidents/README.md).
 
 ***
 

--- a/guides/api-client/examples/resilience-strategy.cs
+++ b/guides/api-client/examples/resilience-strategy.cs
@@ -1,199 +1,32 @@
-// resilience-strategy.cs
-// Example: Configuring resilience strategies for activities
-//
-// This example demonstrates conceptual patterns for setting resilience strategies
-// for activities to handle transient failures with retry and backoff.
-//
-// IMPORTANT: The exact API depends on your elsa-api-client version.
-// Check the Elsa documentation and API client source for current methods.
-// Reference: src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/
-
+using Elsa.Api.Client.Extensions;
+using Elsa.Api.Client.Resources.Resilience.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+using Elsa.Api.Client.Resources.WorkflowInstances.Models;
 
 namespace Elsa.Examples.ApiClient;
 
-/// <summary>
-/// Demonstrates conceptual patterns for configuring resilience strategies.
-/// The exact API may vary by version - consult current elsa-api-client documentation.
-/// </summary>
 public static class ResilienceStrategyExamples
 {
-    // Property key for resilience configuration in CustomProperties
-    private const string ResiliencePropertyKey = "resilience";
-    
-    /// <summary>
-    /// Creates an HTTP activity with a resilience strategy configured.
-    /// </summary>
-    /// <returns>An activity with retry configuration.</returns>
     public static Activity CreateResilientHttpActivity()
     {
         var activity = new Activity
         {
-            Type = ActivityTypes.SendHttpRequest,
+            Type = "Elsa.FlowSendHttpRequest",
             Id = "http-call-with-retry"
         };
 
-        // Configure resilience strategy for transient failure handling
-        // Note: The exact API depends on your elsa-api-client version.
-        // WARNING: The following code is a conceptual/proposed pattern and may not reflect the actual Elsa API.
-        // You MUST consult the Elsa documentation and source code for the correct way to configure resilience strategies.
-        
-        activity.CustomProperties[ResiliencePropertyKey] = new ResilienceConfiguration
+        activity.SetResilienceStrategy(new ResilienceStrategyConfig
         {
-            // Number of retry attempts
-            RetryCount = 3,
-            
-            // Initial delay between retries
-            InitialDelay = TimeSpan.FromSeconds(2),
-            
-            // Backoff multiplier (exponential backoff)
-            BackoffMultiplier = 2.0,
-            
-            // Maximum delay between retries
-            MaxDelay = TimeSpan.FromSeconds(30),
-            
-            // Jitter to prevent thundering herd
-            JitterEnabled = true
-        };
+            Mode = ResilienceStrategyConfigMode.Identifier,
+            StrategyId = "http-default"
+        });
 
         return activity;
     }
 
-    /// <summary>
-    /// Creates a workflow with multiple activities having different resilience strategies.
-    /// </summary>
-    /// <returns>Root activity with resilience-configured children.</returns>
-    public static Activity CreateWorkflowWithResilienceStrategies()
+    public static void PrintIncidents(WorkflowInstance instance)
     {
-        // Sequence with multiple HTTP calls, each with different resilience needs
-        return new Activity
-        {
-            Type = ActivityTypes.Sequence,
-            Id = "root-sequence",
-            // Child activities would be configured here based on your workflow
-        };
-    }
-
-    /// <summary>
-    /// Example of checking and handling activity failures after workflow execution.
-    /// </summary>
-    public static void HandleActivityIncidents(WorkflowInstance instance)
-    {
-        // Check if the workflow has faulted
-        if (instance.Status == WorkflowStatus.Faulted)
-        {
-            Console.WriteLine($"Workflow {instance.Id} has faulted.");
-            
-            // Check for fault information
-            if (instance.Faults != null)
-            {
-                foreach (var fault in instance.Faults)
-                {
-                    Console.WriteLine($"  Activity: {fault.ActivityId}");
-                    Console.WriteLine($"  Message: {fault.Message}");
-                    Console.WriteLine($"  Exception: {fault.ExceptionType}");
-                    Console.WriteLine();
-                }
-            }
-            
-            // Consider retry strategies:
-            // 1. Fix the issue and resume from the faulted activity
-            // 2. Cancel and restart the workflow
-            // 3. Alert operators for manual intervention
-        }
+        foreach (var incident in instance.WorkflowState.Incidents)
+            Console.WriteLine($"{incident.ActivityId}: {incident.Message}");
     }
 }
-
-/// <summary>
-/// Configuration model for resilience strategy.
-/// Note: Check the actual elsa-api-client models for the correct structure.
-/// </summary>
-public class ResilienceConfiguration
-{
-    /// <summary>
-    /// Number of retry attempts before giving up.
-    /// </summary>
-    public int RetryCount { get; set; } = 3;
-
-    /// <summary>
-    /// Initial delay between retry attempts.
-    /// </summary>
-    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// Multiplier for exponential backoff.
-    /// </summary>
-    public double BackoffMultiplier { get; set; } = 2.0;
-
-    /// <summary>
-    /// Maximum delay between retry attempts.
-    /// </summary>
-    public TimeSpan MaxDelay { get; set; } = TimeSpan.FromMinutes(1);
-
-    /// <summary>
-    /// Whether to add random jitter to delays.
-    /// </summary>
-    public bool JitterEnabled { get; set; } = true;
-}
-
-/// <summary>
-/// Constants for common activity type names.
-/// Note: Each example file includes its own constants for self-contained usage.
-/// In a real project, define these once in a shared location.
-/// </summary>
-public static class ActivityTypes
-{
-    public const string Sequence = "Elsa.Sequence";
-    public const string SendHttpRequest = "Elsa.SendHttpRequest";
-    public const string WriteLine = "Elsa.WriteLine";
-    public const string HttpEndpoint = "Elsa.HttpEndpoint";
-}
-
-// Placeholder types for compilation reference
-// In actual usage, these come from Elsa.Api.Client
-public class WorkflowInstance
-{
-    public required string Id { get; set; }
-    public WorkflowStatus Status { get; set; }
-    public List<Fault>? Faults { get; set; }
-}
-
-public class Fault
-{
-    public required string ActivityId { get; set; }
-    public required string Message { get; set; }
-    public string? ExceptionType { get; set; }
-}
-
-public enum WorkflowStatus
-{
-    Running,
-    Suspended,
-    Finished,
-    Faulted
-}
-
-// Usage Example:
-//
-// // Create an activity with resilience configuration
-// var httpActivity = ResilienceStrategyExamples.CreateResilientHttpActivity();
-//
-// // Add to workflow definition
-// var workflowModel = new WorkflowDefinitionModel
-// {
-//     DefinitionId = "resilient-workflow",
-//     Name = "Resilient API Integration",
-//     Root = httpActivity,
-//     Options = new WorkflowOptions
-//     {
-//         CommitStrategyName = "ActivityExecuted" // Persist after each activity
-//     }
-// };
-//
-// // After workflow execution, handle any incidents
-// var instance = await instancesApi.GetAsync(instanceId);
-// ResilienceStrategyExamples.HandleActivityIncidents(instance);
-//
-// See also:
-// - Elsa documentation: https://elsa-workflows.github.io/elsa-core/docs/next/guides/incidents/
-// - Incident strategies: See Elsa documentation for handling workflow incidents and strategies.

--- a/guides/patterns/README.md
+++ b/guides/patterns/README.md
@@ -434,27 +434,52 @@ For activities that call external services, configure retry policies:
 **Reference:** `elsa-api-client` - `ActivityExtensions.SetResilienceStrategy` / `GetResilienceStrategy`
 
 ```csharp
-// Configure resilience in activity settings
-var activitySettings = new Dictionary<string, object>
+activity.SetResilienceStrategy(new ResilienceStrategyConfig
 {
-    ["resilienceStrategy"] = new
-    {
-        retryCount = 3,
-        retryInterval = "00:00:30",
-        useExponentialBackoff = true
-    }
-};
+    Mode = ResilienceStrategyConfigMode.Identifier,
+    StrategyId = "http-default"
+});
 ```
+
+That strategy ID must exist in the host's resilience strategy catalog, for
+example:
+
+```json
+{
+  "Resilience": {
+    "Strategies": [
+      {
+        "$type": "HttpResilienceStrategy",
+        "Id": "http-default",
+        "DisplayName": "Default HTTP Retry",
+        "MaxRetryAttempts": 3,
+        "Delay": "00:00:02",
+        "UseJitter": true,
+        "BackoffType": "Exponential"
+      }
+    ]
+  }
+}
+```
+
+For HTTP activities, Elsa `3.8.0` ships `HttpResilienceStrategy` out of the
+box. Use resilience when a transient downstream call should retry before Elsa
+records a final incident.
 
 ### Incident Model
 
-Elsa tracks failures via the **Incident** model. When an activity faults:
+Elsa tracks failures through `WorkflowState.Incidents`. When an activity faults:
 
-1. An incident is recorded with the exception details
-2. The workflow enters a faulted state
-3. You can configure incident strategies (Fault, ContinueWithIncident, etc.)
+1. The activity is marked faulted.
+2. An incident is recorded with the failing activity ID, node ID, message, and
+   exception state.
+3. The configured incident strategy decides whether the overall workflow
+   transitions to `Faulted`.
 
-See [Incidents](../../operate/incidents/) for configuration options.
+Operational retry of an already faulted workflow instance is a separate action.
+Use `POST /alterations/workflows/retry` after the underlying problem is fixed.
+
+See [Incidents](../../operate/incidents/README.md) for the full flow.
 
 ### Pitfalls
 

--- a/guides/troubleshooting/README.md
+++ b/guides/troubleshooting/README.md
@@ -265,14 +265,15 @@ Before diving into specific symptoms, verify these foundational items:
    AND updated_at < NOW() - INTERVAL '1 hour';
    ```
 
-2. **Check for incidents:**
-   ```sql
-   SELECT * FROM elsa.workflow_incidents
-   WHERE workflow_instance_id = '<instance-id>';
-   ```
+2. **Inspect the workflow instance's incidents:**
+   Open the instance in Elsa Studio or retrieve
+   `GET /workflow-instances/<instance-id>` and inspect
+   `workflowState.incidents`.
 
-3. **Review activity execution context:**
-   Look for exceptions in logs around the time the workflow became stuck.
+3. **Review the workflow journal and activity executions:**
+   Check `GET /workflow-instances/<instance-id>/journal` or the filtered
+   `POST` variant, then inspect the failing activity execution in Studio if you
+   need per-activity state or retry metadata.
 
 4. **Check for orphaned locks:**
    If a node crashes while holding a lock, the workflow may appear stuck:
@@ -299,14 +300,15 @@ Before diving into specific symptoms, verify these foundational items:
   ```
 
 - **Retry faulted activities:**
-  Use Elsa Studio's incident handling UI to retry or skip faulted activities
+  Use `POST /alterations/workflows/retry` with one or more
+  `workflowInstanceIds`, and optionally `activityIds`, after fixing the root
+  cause.
 
 - **Configure incident strategies:**
   ```csharp
-  elsa.UseIncidentStrategies(strategies =>
+  builder.Services.Configure<IncidentOptions>(options =>
   {
-      strategies.Add<RetryIncidentStrategy>();
-      strategies.Add<ContinueWithDefaultIncidentStrategy>();
+      options.DefaultIncidentStrategy = typeof(ContinueWithIncidentsStrategy);
   });
   ```
 

--- a/operate/incidents/README.md
+++ b/operate/incidents/README.md
@@ -1,5 +1,165 @@
+---
+description: >-
+  Release-backed guide to faults, incidents, retries, and operator recovery in
+  Elsa 3.8.0.
+---
+
 # Incidents
 
-An [incident](../../getting-started/concepts/#incident) is an error event that occurred in the workflow. For example, if an activity faults, an incident is recorded as part of the workflow execution.
+In Elsa `release/3.8.0`, an **incident** is the runtime record created when an
+activity or workflow faults. Incidents answer "what failed, where, and with
+which exception details?" They are separate from retry policy and separate from
+operator recovery actions.
 
-Errors occur when an unhandled exception is thrown when an activity executes. The workflow runtime catches the exception and creates an incident record. The incident record is stored in the `Incidents` collection of the `WorkflowExecutionContext`, which is ultimately persisted as a `WorkflowInstance` record in the database.
+Use this page to understand:
+
+- what Elsa records when work faults
+- how incident strategies affect the workflow sub-status
+- where to inspect incidents in Studio and the API
+- when to use resilience retries versus operational retries
+
+For the configuration surface, see [Configuration](configuration.md). For the
+built-in strategies, see [Strategies](strategies.md).
+
+## What Elsa records when an activity faults
+
+When an unhandled exception escapes an activity, Elsa's activity exception
+middleware:
+
+1. marks the activity execution as `Faulted`
+2. captures an `ExceptionState`
+3. appends an `ActivityIncident` to `WorkflowExecutionContext.Incidents`
+4. resolves the configured incident strategy and invokes it
+
+Each incident includes:
+
+- `ActivityId`
+- `ActivityNodeId`
+- `ActivityType`
+- `Message`
+- `Exception`
+- `Timestamp`
+
+Elsa also writes execution-log entries such as `Started`, `Suspended`, and
+`Faulted`, so incidents and journal entries complement each other instead of
+duplicating each other.
+
+## Workflow faults versus activity incidents
+
+Activity-level incident strategies do not decide everything about workflow
+failure.
+
+- If an activity throws, the activity is already marked faulted and the
+  incident is already recorded before the strategy runs.
+- The strategy mainly decides whether the overall workflow transitions to
+  `WorkflowSubStatus.Faulted` or keeps running.
+- If an exception escapes the workflow pipeline itself, Elsa records an
+  incident and transitions the workflow to `Faulted` directly.
+
+In practice, that means `ContinueWithIncidentsStrategy` is not an automatic
+retry mechanism. It only prevents the workflow from being faulted immediately
+for activity-level incidents.
+
+## Where incidents are stored and surfaced
+
+In `release/3.8.0`, incidents are stored on `WorkflowState.Incidents` and flow
+through the normal workflow instance APIs and Studio runtime views.
+
+### Elsa Studio
+
+Studio exposes incidents in two main places:
+
+- the workflow instance list can filter by `Has Incidents`
+- the workflow instance viewer shows an **Incidents** tab with the recorded
+  message and exception payload
+
+When resilience retries are enabled for an activity, Studio also surfaces a
+**Retries** tab for activity executions that recorded retry attempts.
+
+### Runtime APIs
+
+Use these runtime surfaces during troubleshooting:
+
+- `GET /workflow-instances/{id}` to inspect `workflowState.incidents`
+- `GET /workflow-instances/{id}/journal`
+- `POST /workflow-instances/{id}/journal` to filter journal events
+- `GET /resilience/retries/{activityInstanceId}` when the resilience feature is
+  enabled and retry attempts were recorded
+
+Use incidents for the failing activity and exception details. Use the journal
+for the sequence of events around the failure.
+
+## Choosing the right recovery path
+
+Elsa has three different recovery stories in `3.8.0`.
+
+### 1. Change incident strategy
+
+Use an incident strategy when you want to control whether an activity fault
+should fault the whole workflow immediately or let the workflow continue with a
+recorded incident.
+
+This is a workflow-behavior decision, not a retry policy.
+
+### 2. Use resilience retries for transient activity failures
+
+Use resilience when an activity should retry automatically inside the same
+execution attempt before it becomes an incident.
+
+In `release/3.8.0`:
+
+- the resilience feature evaluates an activity's `resilienceStrategy`
+  configuration
+- retry attempts are recorded only when a configured resilience pipeline
+  actually retries
+- the HTTP module registers `HttpResilienceStrategy` as an available strategy
+  type
+
+This is the right fit for transient downstream failures such as `429`,
+`503`, timeouts, or short network interruptions.
+
+### 3. Retry faulted workflow instances operationally
+
+Use the Alterations retry endpoint when the workflow instance has already
+faulted and you want to retry the faulted activities after investigation or a
+fix.
+
+`release/3.8.0` exposes:
+
+```http
+POST /alterations/workflows/retry
+```
+
+The request requires `workflowInstanceIds` and optionally `activityIds`. When
+`activityIds` is omitted, Elsa retries all incident activity IDs from the
+workflow state's incident list.
+
+This endpoint belongs to the Alterations module and requires the
+`run:alterations` permission. See
+[Applying Alterations REST API](../../features/alterations/applying-alterations/rest-api.md).
+
+## Practical troubleshooting flow
+
+For most production incidents:
+
+1. Open the workflow instance in Studio or retrieve the workflow instance from
+   the API.
+2. Inspect `workflowState.incidents` to identify the failing activity and
+   exception.
+3. Check the workflow journal for the surrounding `Faulted`, `Suspended`, and
+   resume events.
+4. If the failure was transient and resilience should have handled it, inspect
+   the activity execution retries.
+5. Decide whether to:
+   - fix the root cause and retry the faulted activity with alterations
+   - cancel the workflow instance
+   - change the workflow's incident strategy or resilience configuration for
+     future runs
+
+## Related docs
+
+- [Configuration](configuration.md)
+- [Strategies](strategies.md)
+- [Monitoring & Observability](../monitoring-observability.md)
+- [Troubleshooting](../../guides/troubleshooting/README.md)
+- [Applying Alterations REST API](../../features/alterations/applying-alterations/rest-api.md)

--- a/operate/incidents/configuration.md
+++ b/operate/incidents/configuration.md
@@ -1,25 +1,49 @@
+---
+description: >-
+  Release-backed incident strategy configuration for Elsa 3.8.0 hosts and
+  workflow definitions.
+---
+
 # Configuration
 
-We can configure what the workflow engine should do in case of an incident through Incident Strategies.
+In `release/3.8.0`, incident strategy resolution happens in this order:
 
-## Global <a href="#global" id="global"></a>
+1. the workflow definition's `WorkflowOptions.IncidentStrategyType`
+2. the host-level `IncidentOptions.DefaultIncidentStrategy`
+3. Elsa's built-in fallback: `FaultStrategy`
 
-The default strategy is `FaultStrategy`, but we can change it by setting the `IncidentStrategy` property of the `WorkflowOptions` class:
+This resolution order is implemented by `DefaultIncidentStrategyResolver`.
+
+## Configure a global default
+
+Set a host-wide default when you want most workflows to behave the same way on
+activity faults:
 
 ```csharp
-services.Configure<IncidentOptions>(options =>
+using Elsa.Workflows.Core.IncidentStrategies;
+using Elsa.Workflows.Core.Options;
+
+builder.Services.Configure<IncidentOptions>(options =>
 {
     options.DefaultIncidentStrategy = typeof(ContinueWithIncidentsStrategy);
 });
 ```
 
-The default strategy will be used for all workflows that do not have a strategy configured explicitly.
+If a workflow does not specify its own incident strategy, Elsa uses this
+default.
 
-## Workflow Specific <a href="#workflow-specific" id="workflow-specific"></a>
+If you do not configure `IncidentOptions.DefaultIncidentStrategy`, Elsa falls
+back to `FaultStrategy`.
 
-We can configure the incident strategy for a workflow by setting the `WorkflowOptions` property of the `Workflow` class:
+## Configure a specific workflow
+
+Set `builder.WorkflowOptions.IncidentStrategyType` inside the workflow when one
+workflow needs behavior different from the host default:
 
 ```csharp
+using Elsa.Workflows;
+using Elsa.Workflows.Core.IncidentStrategies;
+
 public class MyWorkflow : WorkflowBase
 {
     protected override void Build(IWorkflowBuilder builder)
@@ -29,7 +53,42 @@ public class MyWorkflow : WorkflowBase
 }
 ```
 
-We can also configure the incident strategy for a workflow via Elsa Studio:
+This setting is serialized with the workflow definition and wins over the
+host-level default.
+
+## Configure it in Elsa Studio
+
+Studio loads the available strategies from:
+
+```http
+GET /descriptors/incident-strategies
+```
+
+That endpoint returns the registered `IIncidentStrategy` implementations and
+their display metadata. When you pick one in the workflow definition settings,
+Studio stores the selected type alias or type name in
+`WorkflowDefinition.Options.IncidentStrategyType`.
 
 <figure><img src="../../.gitbook/assets/workflow-definition-incident-settings.png" alt=""><figcaption></figcaption></figure>
 
+## Register custom strategies
+
+If you create your own `IIncidentStrategy`, register it with dependency
+injection so Elsa can resolve it and so Studio can list it from the descriptors
+endpoint:
+
+```csharp
+builder.Services.AddTransient<IIncidentStrategy, MyIncidentStrategy>();
+```
+
+If you want that custom strategy to become the default, also assign its type to
+`IncidentOptions.DefaultIncidentStrategy`.
+
+## What this setting does not configure
+
+Incident strategies do not replace activity-level retry policies.
+
+- Use [resilience strategies](README.md#2-use-resilience-retries-for-transient-activity-failures)
+  when an activity should retry automatically before faulting.
+- Use the [alterations retry endpoint](../../features/alterations/applying-alterations/rest-api.md)
+  when an already faulted workflow instance needs operator-driven retry.

--- a/operate/incidents/strategies.md
+++ b/operate/incidents/strategies.md
@@ -1,22 +1,66 @@
+---
+description: Built-in incident strategies and their real 3.8.0 behavior.
+---
+
 # Strategies
 
-An incident strategy is represented by the `IIncidentStrategy` interface:
+An incident strategy implements `IIncidentStrategy`:
 
 ```csharp
-/// <summary>
-/// A strategy for handling workflow incidents
-/// </summary>
 public interface IIncidentStrategy
 {
-    /// <summary>
-    /// Handles an incident.
-    /// </summary>
-    /// <param name="context">The activity execution context where the incident occurred.</param>
     void HandleIncident(ActivityExecutionContext context);
 }
 ```
 
-Out of the box, there are two strategies available:
+In `release/3.8.0`, Elsa registers two built-in strategies.
 
-1. `FaultStrategy`: The workflow engine will stop the workflow and mark it as faulted.
-2. `ContinueWithIncidentsStrategy`: The workflow engine will continue executing the workflow and create an incident record for each error that occurs.
+## `FaultStrategy`
+
+`FaultStrategy` transitions the workflow to `WorkflowSubStatus.Faulted` when
+the workflow can still move to that state.
+
+Use it when:
+
+- a fault in one activity should stop the overall workflow
+- operators should investigate before any more work is scheduled
+- you want the workflow instance to present as faulted immediately in runtime
+  and Studio
+
+This is Elsa's effective default when neither the workflow nor the host
+configured another strategy.
+
+## `ContinueWithIncidentsStrategy`
+
+`ContinueWithIncidentsStrategy` is intentionally a no-op.
+
+That does **not** mean "ignore the error". By the time the strategy runs:
+
+- the activity has already been marked faulted
+- the incident has already been appended to `WorkflowExecutionContext.Incidents`
+- the exception has already been captured on the activity execution context
+
+The strategy simply leaves the workflow sub-status unchanged so the workflow
+can continue if the surrounding workflow structure allows it.
+
+Use it when:
+
+- you want to collect incident data without faulting the whole workflow
+- later branches, compensation, or manual review can still provide value
+- the failing activity is not always fatal to the business process
+
+Do not use it as a substitute for retry logic. If the real requirement is
+"retry transient failures before faulting", configure a resilience strategy
+instead.
+
+## Custom strategies
+
+You can implement your own `IIncidentStrategy` when you need custom behavior.
+
+In `3.8.0`, a custom strategy becomes visible to Studio automatically when:
+
+1. it is registered as `IIncidentStrategy`
+2. the descriptors endpoint can resolve it from DI
+
+If you add `DisplayName`, `Display`, or `Description` attributes, Studio uses
+those values when it renders the incident strategy picker.


### PR DESCRIPTION
## Summary
- rewrite the incidents docs around real 3.8.0 fault, resilience, and operational retry behavior
- fix stale troubleshooting and api-client retry guidance to match release code
- advance the documentation slice inventory and add a follow-on resilience extensibility topic

## Validation
- validated incident, retry, resilience, Studio, and alteration behaviors against release/3.8.0 source in elsa-core and elsa-studio
- ran `git diff --check`
- ran a targeted relative-link existence check for touched markdown files