### PR TITLE
docs: harden MassTransit communication guide

### DIFF
--- a/activities/masstransit/README.md
+++ b/activities/masstransit/README.md
@@ -7,6 +7,10 @@ the types you register with the MassTransit feature.
 Use this integration when workflows need to publish strongly typed application
 messages or wait for messages that arrive through a MassTransit bus.
 
+For `release/3.8.0`, prefer concrete class or record contracts for the message
+types you register. Elsa's generated receive activity accepts a message only
+when the runtime type exactly matches the configured `MessageType`.
+
 ## What this feature adds
 
 After you call `UseMassTransit(...)` and register one or more message types
@@ -173,6 +177,22 @@ This matters operationally because the same broker can host both your
 application messages and Elsa's own internal dispatcher traffic without those
 concerns being the same feature.
 
+## Contract guidance
+
+`AddMessageType<T>()` accepts reference types, but the runtime behavior is more
+specific than that:
+
+* `MassTransitActivityTypeProvider` creates a receive trigger for every
+  registered message type
+* `Publish {MessageType}` is created only when the registered type is a class
+* `MessageReceived` resumes only when `message.GetType() == MessageType`
+
+In practice, that means concrete classes and records are the safest contracts
+for both publishing and receiving in `release/3.8.0`. If you register an
+interface or other abstraction, Elsa still creates the receive activity
+descriptor, but the runtime message must still match the configured type
+exactly.
+
 ## How receiving works
 
 When MassTransit receives a registered message type, Elsa's generated
@@ -194,8 +214,10 @@ start every workflow that contains it. To start new workflow instances from a
 message, configure the activity as a start trigger, just as you would with
 other Elsa triggers.
 
-MassTransit correlation IDs are passed through in the stimulus metadata, so
-message-bus correlation can flow into your workflow design when needed.
+For new workflow instances, the MassTransit `CorrelationId` is forwarded in the
+stimulus metadata and becomes the trigger invocation's correlation ID. For
+existing waiting workflows, Elsa uses that correlation ID to narrow bookmark
+matching when one is present.
 
 ## How publishing works
 
@@ -205,7 +227,8 @@ calls `bus.Publish(...)` with the configured message payload.
 Two details matter in practice:
 
 * the publish activity exists only for class message types; if you register an
-  interface, Elsa creates the receive trigger but not the publish activity
+  interface or other non-class reference type, Elsa does not generate the
+  publish activity
 * the message input is converted to the configured CLR type before publishing,
   so the payload must be compatible with the registered message type
 

--- a/activities/masstransit/tutorial.md
+++ b/activities/masstransit/tutorial.md
@@ -17,8 +17,12 @@ public record OrderCreated(string OrderId, string ProductId, int Quantity);
 
 {% endcode %}
 
-`OrderCreated` is a class, so Elsa will generate both a receive trigger and a
-publish activity for it.
+`OrderCreated` is a concrete record class, so Elsa will generate both a receive
+trigger and a publish activity for it.
+
+That detail matters in `release/3.8.0`: the generated `MessageReceived`
+activity compares the incoming message's exact runtime type to the configured
+`MessageType`, so concrete record or class contracts are the safest choice.
 
 ## 2. Register the message type and configure MassTransit
 
@@ -137,8 +141,7 @@ public class PublishOrderWorkflow : WorkflowBase
 In Studio, the equivalent activity is `Publish Order Created`.
 
 Because `OrderCreated` is a class, Elsa generates both the trigger and publish
-activities. If you register an interface instead, Elsa generates only the
-receive trigger.
+activities.
 
 ## 5. Deployment notes
 
@@ -158,6 +161,8 @@ receive trigger.
   runs during startup.
 * If messages publish but workflows do not start, verify consumers are enabled
   on the running node and that the trigger is marked as a start trigger.
+* If a message reaches MassTransit but Elsa does not resume the workflow,
+  verify the registered contract is the concrete runtime type being consumed.
 * If you use a real broker, verify the relevant RabbitMQ or Azure Service Bus
   transport package is installed and configured.
 * If correlation matters, confirm the producer sets a MassTransit

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-08)
+## Slice Inventory (2026-07-09)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -56,6 +56,7 @@ acceptance criterion below is already complete.
 - `DOC-043` Hangfire integration
 - `DOC-047` API reference
 - `DOC-048` Activity reference
+
 ### Recommended next slice
 
 - `DOC-038` Distributed tracing: the execution model is now documented, but
@@ -91,6 +92,14 @@ acceptance criterion below is already complete.
 - `DOC-057` Elsa API permission reference: add a compact map of common Elsa API
   and Studio operations to `permissions` claim values, plus starter role
   templates for external identity providers.
+
+### Most recent completed slice
+
+- `DOC-024` MassTransit communication:
+  completed on 2026-07-09 by tightening the MassTransit message-activity docs
+  around `release/3.8.0` runtime behavior, especially concrete contract
+  guidance, exact-type message matching, generated activity descriptors,
+  transport-backed consumer topology, and correlation flow.
 
 ## Critical Priority (Must Have - Block Users)
 


### PR DESCRIPTION
## Summary
- tighten the MassTransit guide around exact runtime type matching in `release/3.8.0`
- remove the loose interface-contract guidance from the tutorial and troubleshooting
- update the slice inventory to mark `DOC-024` complete and keep `DOC-027` as the next recommended slice

## Validation
- checked the docs against `release/3.8.0` in `elsa-extensions` and `elsa-core`
- `git diff --check`
- targeted relative-link validation for the touched markdown files
