### PR TITLE
docs: add distributed tracing guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -115,6 +115,7 @@
 ## Operate
 
 * [Monitoring & Observability](operate/monitoring-observability.md)
+* [Distributed Tracing](operate/distributed-tracing.md)
 * [Variables](operate/workflow-instance-variables.md)
 * [Activation Strategies](operate/workflow-activation-strategies.md)
 * [Incidents](operate/incidents/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-09)
+## Slice Inventory (2026-07-10)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -40,6 +40,7 @@ acceptance criterion below is already complete.
 - `DOC-026` Error handling and retry logic
 - `DOC-027` Execution model
 - `DOC-022` Scaling and performance
+- `DOC-038` Distributed tracing
 - `DOC-028` Studio customization
 - `DOC-029` Custom UI hints
 - `DOC-030` Custom UI components
@@ -51,7 +52,6 @@ acceptance criterion below is already complete.
 
 ### Available next slices
 
-- `DOC-038` Distributed tracing
 - `DOC-039` Performance tuning
 - `DOC-043` Hangfire integration
 - `DOC-047` API reference
@@ -59,10 +59,10 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-- `DOC-038` Distributed tracing: the execution model is now documented, but
-  production teams still lack a compact guide for following a workflow across
-  HTTP ingress, dispatched execution, bookmarks, incidents, and external
-  observability tooling.
+- `DOC-039` Performance tuning: distributed tracing is now covered, but
+  production teams still need a release-backed tuning guide that connects
+  worker count, dispatcher behavior, persistence tradeoffs, and telemetry into
+  concrete scale-up decisions.
 
 ### Newly discovered follow-on topics
 
@@ -95,19 +95,20 @@ acceptance criterion below is already complete.
 
 ### Most recent completed slice
 
-- `DOC-024` MassTransit communication:
-  completed on 2026-07-09 by tightening the MassTransit message-activity docs
-  around `release/3.8.0` runtime behavior, especially concrete contract
-  guidance, exact-type message matching, generated activity descriptors,
-  transport-backed consumer topology, and correlation flow.
+- `DOC-038` Distributed tracing:
+  completed on 2026-07-10 with a release-backed guide that separates
+  `Elsa.Workflows` instrumentation from the `Elsa.Diagnostics.OpenTelemetry`
+  collector, documents OTLP routes and permissions, and clarifies the
+  host-specific status of gRPC and `Elsa.OpenTelemetry`.
 
 ## Critical Priority (Must Have - Block Users)
 
 ### Current slice note
 
-- `DOC-038` Distributed tracing:
-  document how to correlate workflow execution, dispatcher activity, bookmarks,
-  incidents, and host telemetry in production.
+- `DOC-039` Performance tuning:
+  add a release-backed guide for runtime throughput tuning, worker counts,
+  dispatcher and queue considerations, persistence pressure, and the telemetry
+  signals operators should watch while scaling.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -87,9 +87,10 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Introduction** (`multitenancy/introduction.md`)
 - **Setup** (`multitenancy/setup.md`)
 
-### OPERATE (6 pages)
+### OPERATE (7 pages)
 
 - **Monitoring & Observability** (`operate/monitoring-observability.md`)
+- **Distributed Tracing** (`operate/distributed-tracing.md`)
 - **Incidents** (`operate/incidents/README.md`)
 - **Configuration** (`operate/incidents/configuration.md`)
 - **Strategies** (`operate/incidents/strategies.md`)
@@ -148,6 +149,7 @@ Based on the current structure, the following core concepts are documented:
 - ✅ Workflow instance variables
 - ✅ Activation strategies
 - ✅ Incidents and strategies
+- ✅ Monitoring and distributed tracing guidance
 
 ### HTTP Workflows
 - ✅ Programmatic approach
@@ -196,7 +198,7 @@ Based on the current structure, the following core concepts are documented:
 5. **Observability & Troubleshooting**
    - ❌ No debugging guide
    - ❌ No troubleshooting common issues
-   - ⚠️ Monitoring/observability guide now exists, but related guides still need deeper consistency work
+   - ⚠️ Monitoring and distributed tracing guides now exist, but related guides still need deeper consistency work
 
 6. **Migration & Versioning**
    - ❌ No migration guide from v2 to v3
@@ -212,7 +214,7 @@ Based on the current structure, the following core concepts are documented:
    - ⚠️ HTTP workflows guide exists but could be expanded
    - ❌ No workflow testing guide
    - ❌ No data persistence patterns guide
-   - ❌ No security best practices
+   - ⚠️ Security guidance now includes dedicated guides for endpoint security and external identity providers, but role-oriented permission recipes are still missing
    - ❌ No workflow design patterns
 
 ## Documentation Quality Notes

--- a/operate/distributed-tracing.md
+++ b/operate/distributed-tracing.md
@@ -1,0 +1,267 @@
+---
+description: >-
+  Release-backed guide to tracing Elsa 3.8.0 workflows with
+  Elsa.Workflows instrumentation and the OpenTelemetry diagnostics collector.
+---
+
+# Distributed Tracing
+
+In `release/3.8.0`, Elsa has two distinct OpenTelemetry stories:
+
+- `Elsa.Workflows` emits workflow and activity spans plus workflow metrics.
+- `Elsa.Diagnostics.OpenTelemetry` ingests OTLP data so Elsa Studio can query
+  and stream traces, metrics, and logs.
+
+Treat those as complementary parts of one tracing setup:
+
+1. your Elsa host emits telemetry;
+2. your OTLP backend stores and correlates it;
+3. Elsa's diagnostics collector can optionally receive the same OTLP traffic
+   for Studio diagnostics.
+
+## What Elsa emits directly
+
+The release-backed instrumentation surface is `Elsa.Workflows`.
+
+- `ActivitySource`: `Elsa.Workflows`
+- `Meter`: `Elsa.Workflows`
+
+`WorkflowInstrumentation` in `elsa-core` emits:
+
+- workflow spans with operation name `workflow.execute`;
+- activity spans with operation name `activity.execute`;
+- counters for `elsa.workflow.started`, `elsa.workflow.completed`, and
+  `elsa.workflow.faulted`;
+- a histogram for `elsa.activity.duration`.
+
+Key workflow span tags include:
+
+- `workflow.instance.id`
+- `workflow.definition.id`
+- `workflow.definition.version`
+- `workflow.definition.version.id`
+- `workflow.status`
+- `workflow.substatus`
+- `workflow.name`
+- `workflow.parent.instance.id`
+- `workflow.correlation.id`
+- `elsa.tenant.id`
+
+Key activity span tags include:
+
+- `workflow.activity.id`
+- `workflow.activity.name`
+- `workflow.activity.type`
+- `workflow.activity.version`
+- `workflow.activity.execution.id`
+- `workflow.activity.status`
+- `workflow.activity.parent.execution.id`
+- `workflow.activity.scheduled.by.execution.id`
+- `workflow.activity.outcome`
+
+When execution faults, the instrumentation marks the span as error and adds a
+standard `exception.type` tag.
+
+## Basic exporter setup
+
+To export Elsa workflow spans and metrics from your host, subscribe to the
+`Elsa.Workflows` source and meter:
+
+```csharp
+using Elsa.Workflows.Telemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddSource(WorkflowInstrumentation.ActivitySourceName)
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddMeter(WorkflowInstrumentation.MeterName)
+        .AddOtlpExporter());
+```
+
+Use this path when you want traces in systems such as Jaeger, Grafana Tempo,
+Honeycomb, Datadog, or any other OTLP-compatible backend.
+
+## What to expect in traces
+
+For the built-in `Elsa.Workflows` instrumentation:
+
+- one workflow execution cycle creates one workflow span;
+- each executed activity creates an activity span;
+- faulted executions set the span status to error;
+- cancellations are treated separately from faults;
+- parent workflow instance IDs and correlation IDs flow into span tags when
+  present.
+
+This makes `CorrelationId`, parent-child workflow dispatch, and activity
+timings directly queryable in your tracing backend.
+
+## Elsa Studio collector and trace viewer
+
+`Elsa.Diagnostics.OpenTelemetry` does not replace the `Elsa.Workflows`
+instrumentation. It adds a diagnostics collector and Studio-facing query
+surface.
+
+In `release/3.8.0`, the collector maps these HTTP/protobuf ingestion routes by
+default:
+
+- `POST /elsa/otlp/v1/traces`
+- `POST /elsa/otlp/v1/metrics`
+- `POST /elsa/otlp/v1/logs`
+
+It also exposes Studio-facing read endpoints:
+
+- `POST /diagnostics/opentelemetry/resources/search`
+- `POST /diagnostics/opentelemetry/traces/search`
+- `GET /diagnostics/opentelemetry/traces/{traceId}`
+- `POST /diagnostics/opentelemetry/metrics/search`
+- `POST /diagnostics/opentelemetry/logs/search`
+- `GET /diagnostics/opentelemetry/storage`
+- `GET /diagnostics/opentelemetry/collector-configuration`
+
+For live updates, the diagnostics module also maps the SignalR hub route:
+
+- `/elsa/hubs/diagnostics/opentelemetry`
+
+Read access is protected by `read:diagnostics:opentelemetry`.
+
+## Securing OTLP ingestion
+
+The diagnostics collector has a separate ingestion permission concept.
+
+- Read endpoints use `read:diagnostics:opentelemetry`.
+- OTLP ingestion uses `ingest:diagnostics:opentelemetry` internally.
+
+For HTTP/protobuf ingestion, `OpenTelemetryDiagnosticsOptions` supports API key
+protection. Configure it through standard options binding:
+
+```csharp
+builder.Services.Configure<OpenTelemetryDiagnosticsOptions>(options =>
+{
+    options.ApiKey = "replace-me";
+    options.ApiKeyHeaderName = "x-otlp-api-key";
+});
+```
+
+If you configure an API key, callers send it in the `x-otlp-api-key` header by
+default. The collector configuration endpoint intentionally returns
+`<configured>` instead of the secret value.
+
+## Collector configuration and endpoint options
+
+`OpenTelemetryDiagnosticsOptions` lets you tune collector behavior, including:
+
+- `HttpEndpointPath`, default `/elsa/otlp/v1`
+- `HubRoute`, default `/elsa/hubs/diagnostics/opentelemetry`
+- `TraceCapacity`
+- `SpanCapacity`
+- `MetricPointCapacity`
+- `LogRecordCapacity`
+- `ResourceCapacity`
+- `SubscriberChannelCapacity`
+- `MaxQuerySize`
+- `MaxHttpRequestBodySize`
+- `EnableGrpc`
+- `GrpcEndpointPath`
+
+When you enable the diagnostics shell feature through
+`UseOpenTelemetryDiagnostics`, the feature itself exposes the in-memory
+capacity and max-request-body settings. For endpoint paths, hub route, API key,
+and related collector behavior, configure `OpenTelemetryDiagnosticsOptions`
+directly.
+
+The `GET /diagnostics/opentelemetry/collector-configuration` endpoint reports
+the active HTTP and gRPC collector metadata plus the expected OTEL environment
+variables:
+
+- `OTEL_SERVICE_NAME`
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_PROTOCOL`
+
+## About gRPC ingestion in 3.8.0
+
+This release exposes shared gRPC collector metadata, but the shared
+`Elsa.Diagnostics.OpenTelemetry` module does not itself bind a concrete gRPC
+collector service.
+
+What the code does in `release/3.8.0`:
+
+- if `EnableGrpc` is `false`, no gRPC collector path is exposed;
+- if `EnableGrpc` is `true` but `GrpcEndpointPath` is empty, Elsa throws during
+  endpoint mapping;
+- the shared module documents that actual gRPC service binding is host-specific.
+
+So for a portable setup across Elsa hosts, use the HTTP/protobuf OTLP routes
+unless your host explicitly adds the gRPC binding.
+
+## Older `Elsa.OpenTelemetry` extension package
+
+The `elsa-extensions` repository still contains an `Elsa.OpenTelemetry` module
+that adds workflow and activity execution middleware with its own
+`ActivitySource`.
+
+That middleware:
+
+- creates workflow spans named `execute workflow {name}`;
+- creates activity spans named `execute activity {type}`;
+- records incident details and correlation IDs on spans;
+- supports `UseNewRootActivityForRemoteParent` and
+  `UseDummyParentActivityAsRootSpan`.
+
+You will still see it used in the `Elsa.Server.Web` workbench host in
+`elsa-extensions`, but for general `release/3.8.0` guidance the stable
+baseline is still `Elsa.Workflows` instrumentation plus, optionally, the
+diagnostics collector.
+
+Use the extension middleware only when you are intentionally adopting that
+host-specific tracing behavior and understand its trace-root options.
+
+## Recommended deployment patterns
+
+Use one of these patterns:
+
+### Backend-only tracing
+
+Use this when operators work primarily in your external observability stack.
+
+- Export `Elsa.Workflows` spans and metrics directly to your OTLP backend.
+- Use Elsa incidents and activity records for workflow-local diagnosis.
+- Keep Studio diagnostics focused on structured logs and runtime inspection.
+
+### Backend plus Studio trace diagnostics
+
+Use this when Elsa Studio users also need an in-product trace view.
+
+- Export `Elsa.Workflows` telemetry to your OTLP backend.
+- Send OTLP telemetry to Elsa's diagnostics collector as well.
+- Grant operators `read:diagnostics:opentelemetry`.
+- Tune in-memory capacities so Studio diagnostics stay bounded.
+
+## Troubleshooting
+
+If traces do not appear where you expect, check these points in order:
+
+1. Confirm your OpenTelemetry pipeline subscribes to
+   `WorkflowInstrumentation.ActivitySourceName`.
+2. Confirm your metrics pipeline subscribes to
+   `WorkflowInstrumentation.MeterName`.
+3. Verify the OTLP exporter endpoint from the host process, not only from your
+   workstation.
+4. If Studio diagnostics are empty, verify the collector routes under
+   `/elsa/otlp/v1` and the `x-otlp-api-key` header when enabled.
+5. If SignalR trace streaming fails, verify the user has
+   `read:diagnostics:opentelemetry`.
+6. If you enabled gRPC ingestion, confirm your host actually bound the gRPC
+   collector service instead of only setting collector metadata.
+
+## Related guides
+
+- [Monitoring & Observability](monitoring-observability.md)
+- [Incidents](incidents/README.md)
+- [Log Persistence](../optimize/log-persistence.md)

--- a/operate/monitoring-observability.md
+++ b/operate/monitoring-observability.md
@@ -21,6 +21,9 @@ Use this mapping:
 - For readiness and liveness, use health checks such as `/health/live` and
   `/health/ready` in `Elsa.Server.Web`.
 
+If you need a dedicated tracing setup guide, see
+[Distributed Tracing](distributed-tracing.md).
+
 ## Start with the workflow runtime signals
 
 When you investigate one workflow instance, start with Elsa's own runtime
@@ -257,6 +260,7 @@ answer:
 
 ## Related guides
 
+- [Distributed Tracing](distributed-tracing.md)
 - [Incidents](incidents/README.md)
 - [Log Persistence](../optimize/log-persistence.md)
 - [Performance & Scaling Guide](../guides/performance/README.md)


### PR DESCRIPTION
## Summary
- add a release-backed distributed tracing guide for Elsa 3.8.0
- link it from monitoring and observability navigation
- update the documentation slice inventory and coverage metadata

## Validation
- validated tracing and collector claims against release/3.8.0 in elsa-core and elsa-extensions
- ran `git diff --check`
- verified changed local markdown link targets exist