### PR TITLE
docs: refresh API client reference

### DIFF
--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-12)
+## Slice Inventory (2026-07-13)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -50,16 +50,17 @@ acceptance criterion below is already complete.
 - `DOC-042` Bulk dispatch workflows activity
 - `DOC-049` Studio custom-elements embedding cookbook
 - `DOC-053` Alterations operational guide hardening
+- `DOC-047` API reference
 
 ### Available next slices
 
-- `DOC-047` API reference
 - `DOC-048` Activity reference
 
 ### Recommended next slice
 
-- `DOC-047` API reference: Hangfire integration is now covered, but developers
-  still need a release-backed map of the most-used Elsa API surfaces.
+- `DOC-048` Activity reference: build a task-oriented index of the activity
+  catalogue and route readers to the existing detailed activity guides, then
+  add release-backed coverage for the most-used missing categories.
 
 ### Newly discovered follow-on topics
 
@@ -99,6 +100,10 @@ acceptance criterion below is already complete.
   completed on 2026-07-12 with a release-backed setup and operations guide that
   documents durable storage, worker settings, tenancy, optional background
   activity scheduling, and scheduler cleanup limitations.
+- `DOC-047` API reference:
+  completed on 2026-07-13 with a release-backed API & Client map covering
+  management routes, client interfaces, permission claims, and the anonymous
+  bookmark-resume callback contract.
 - `DOC-038` Distributed tracing:
   completed on 2026-07-10 with a release-backed guide that separates
   `Elsa.Workflows` instrumentation from the `Elsa.Diagnostics.OpenTelemetry`
@@ -113,9 +118,9 @@ acceptance criterion below is already complete.
 
 ### Latest slice note
 
-- `DOC-043` Hangfire integration:
-  completed on 2026-07-12; see
-  [Hangfire Integration](../../guides/running-workflows/hangfire-integration.md).
+- `DOC-047` API reference: completed on 2026-07-13. See
+  [API & Client](../../guides/api-client/README.md) for the 3.8 API map,
+  least-privilege permission guidance, and bookmark-resume contract.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/api-client/README.md
+++ b/guides/api-client/README.md
@@ -1,777 +1,200 @@
 ---
 description: >-
-  Comprehensive guide to interacting with Elsa Server programmatically via HTTP
-  APIs and the elsa-api-client library, covering workflow publishing, instance
-  management, bookmarks, and resilience pattern
+  A release-3.8 reference for Elsa's management API, .NET client interfaces,
+  endpoint permissions, and bookmark-resume callbacks.
 ---
 
 # API & Client
 
-## Executive Summary
+Use Elsa's HTTP API to automate workflow delivery and operations outside Elsa
+Studio. In .NET applications, use the `Elsa.Api.Client` interfaces instead of
+constructing request URLs and JSON by hand.
 
-This guide covers how to interact with Elsa Workflows programmatically using:
+This page is grounded in Elsa `release/3.8.0`. It is a map of the high-value
+surfaces, not a replacement for the OpenAPI document when your host exposes
+one.
 
-1. **HTTP APIs** — Direct REST calls to Elsa Server endpoints
-2. **elsa-api-client** — Official .NET client library for type-safe API interactions
+## Choose the right surface
 
-### When to Choose Direct HTTP vs Client Library
+| Need | Use | Notes |
+| --- | --- | --- |
+| Create, publish, import, export, or query workflow designs | Workflow definitions API | A definition is a versioned design, not a running workflow. |
+| Start work now or place it on the dispatcher queue | Execute or dispatch API | `execute` runs immediately; `dispatch` hands work to the runtime queue. |
+| Find, inspect, cancel, export, or diagnose executions | Workflow instances API | Use the journal and execution-state endpoints for diagnosis. |
+| Discover activity metadata for a designer or integration | Activity descriptors API | Returns the activity catalogue exposed by the server. |
+| Continue a waiting workflow from an external callback | Bookmark-resume API | This route is anonymous by design; its token is the capability. |
 
-| Approach            | Best For                                                 | Pros                                                    | Cons                                 |
-| ------------------- | -------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------ |
-| **Direct HTTP**     | Polyglot teams, non-.NET clients, simple integrations    | Language-agnostic, minimal dependencies                 | Manual serialization, no type safety |
-| **elsa-api-client** | .NET applications, complex workflows, production systems | Type-safe, automatic serialization, resilience patterns | .NET-only, additional dependency     |
+The API base path is host-configurable. The examples use
+`https://elsa.example/elsa/api`; replace that whole prefix with the API base
+URL for your deployment.
 
-**Recommendation:** For .NET applications, prefer `elsa-api-client` for type safety and built-in conveniences. For non-.NET clients or simple webhook integrations, use direct HTTP calls.
+## Authentication and permissions
 
-**Code Reference:** `src/clients/Elsa.Api.Client/` — Official API client implementation.
+Management endpoints are protected by Elsa permission claims when API security
+is enabled. For example, listing workflow definitions requires
+`read:workflow-definitions`, while listing workflow instances requires
+`read:workflow-instances`. Give an integration only the permissions it needs;
+do not reuse a Studio administrator token for background services.
 
-***
+Configure authentication and claims before calling these endpoints. See
+[Authentication & Authorization](../authentication.md) and
+[External Identity Providers](../security/external-identity-providers.md).
 
-## Architecture Overview
+The exception is `GET`/`POST /bookmarks/resume`. Elsa deliberately allows this
+route anonymously because the encrypted `t` token identifies the bookmark and
+instance. Treat a resume URL like a secret: send it only over HTTPS, do not log
+it, and use a bounded lifetime when generating it.
 
-### Core Concepts
+## .NET client setup
 
-Elsa's API is organized around three primary entities:
-
-| Entity                   | Purpose                               | Key Endpoints               |
-| ------------------------ | ------------------------------------- | --------------------------- |
-| **Workflow Definitions** | Blueprint templates for workflows     | `/api/workflow-definitions` |
-| **Workflow Instances**   | Running or completed executions       | `/api/workflow-instances`   |
-| **Bookmarks**            | Suspension points for workflow resume | `/api/bookmarks`            |
-
-### High-Level Workflow Lifecycle
-
-```
-┌────────────────────────────────────────────────────────────────────────────┐
-│                                                                            │
-│  Design ──► Publish ──► Instantiate ──► Execute ──► Suspend ──► Resume    │
-│                            │                          (bookmark)    │      │
-│                            │                              │         │      │
-│                            └──────────────────────────────┴─────────┘      │
-│                                                           │                │
-│                                                           ▼                │
-│                                                       Complete             │
-│                                                                            │
-└────────────────────────────────────────────────────────────────────────────┘
-```
-
-1. **Design** — Create workflow definition (via Studio or programmatically)
-2. **Publish** — Activate the definition for execution
-3. **Instantiate** — Create a new workflow instance
-4. **Execute** — Run activities until completion or suspension
-5. **Suspend (Bookmark)** — Workflow pauses at blocking activity, creates bookmark
-6. **Resume** — External event triggers bookmark, execution continues
-7. **Complete** — Workflow finishes with success or fault status
-
-**Code Reference:** `src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs` — Contains `CreateBookmark()` for suspending workflows.
-
-***
-
-## Authentication & Identity
-
-Elsa Server supports multiple authentication mechanisms. For comprehensive security guidance, see the [Security & Authentication Guide](../security/) (DOC-020).
-
-### Quick Reference
-
-#### Bearer Token (curl)
-
-```bash
-curl -X GET "https://your-elsa-server.com/elsa/api/workflow-definitions" \
-  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
-  -H "Content-Type: application/json"
-```
-
-#### API Key (curl)
-
-```bash
-curl -X GET "https://your-elsa-server.com/elsa/api/workflow-definitions" \
-  -H "Authorization: ApiKey YOUR_API_KEY" \
-  -H "Content-Type: application/json"
-```
-
-#### elsa-api-client Configuration
+`Elsa.Api.Client` supplies Refit-based interfaces for the management API. The
+API-key helper configures the same default clients and their base address.
 
 ```csharp
 using Elsa.Api.Client.Extensions;
 
-services.AddDefaultApiClientsUsingApiKey(options =>
+builder.Services.AddDefaultApiClientsUsingApiKey(options =>
 {
-    options.BaseAddress = new Uri("https://your-elsa-server.com/elsa/api");
-    options.ApiKey = "YOUR_API_KEY";
+    options.BaseAddress = new Uri("https://elsa.example/elsa/api");
+    options.ApiKey = builder.Configuration["Elsa:ApiKey"]!;
 });
 ```
 
-The default API-key handler sends `Authorization: ApiKey <key>`. For bearer tokens, use `AddDefaultApiClients` and set the `Authorization` header in `ConfigureHttpClient`.
+For bearer tokens or another authentication scheme, use
+`AddDefaultApiClients` and configure the underlying `HttpClient` rather than
+adding an API key. Keep the base address at the API root: client routes start
+with paths such as `/workflow-definitions` and `/workflow-instances`.
 
-**Code Reference:** `src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs` — Client registration extensions.
-
-***
-
-## Publishing Workflow Definitions
-
-### Using elsa-api-client (C#)
-
-The client library provides a type-safe way to create and publish workflow definitions.
+Inject the narrowest interface that matches the job:
 
 ```csharp
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
-using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
 
-public class WorkflowPublisher
+public sealed class WorkflowCatalog(IWorkflowDefinitionsApi definitions)
 {
-    private readonly IWorkflowDefinitionsApi _api;
-
-    public WorkflowPublisher(IWorkflowDefinitionsApi api)
+    public async Task ListAsync(CancellationToken cancellationToken)
     {
-        _api = api;
+        await definitions.ListAsync(
+            new ListWorkflowDefinitionsRequest { Page = 0, PageSize = 25 },
+            cancellationToken: cancellationToken);
     }
+}
+```
 
-    public async Task<WorkflowDefinition> PublishWorkflowAsync()
+## Core management API map
+
+| Area | HTTP method and route (relative to the API base) | .NET client interface | Typical permission |
+| --- | --- | --- | --- |
+| List definitions | `GET /workflow-definitions` | `IWorkflowDefinitionsApi.ListAsync` | `read:workflow-definitions` |
+| Get a definition by stable ID | `GET /workflow-definitions/by-definition-id/{definitionId}` | `IWorkflowDefinitionsApi.GetByDefinitionIdAsync` | `read:workflow-definitions` |
+| Save a definition | `POST /workflow-definitions` | `IWorkflowDefinitionsApi.SaveAsync` | `write:workflow-definitions` |
+| Publish a definition | `POST /workflow-definitions/{definitionId}/publish` | `IWorkflowDefinitionsApi.PublishAsync` | `publish:workflow-definitions` |
+| Run a definition now | `POST /workflow-definitions/{definitionId}/execute` | `IExecuteWorkflowApi.ExecuteAsync` | `exec:workflow-definitions` |
+| Queue a definition to run | `POST /workflow-definitions/{definitionId}/dispatch` | `IExecuteWorkflowApi.DispatchAsync` | `exec:workflow-definitions` |
+| List instances | `GET` or `POST /workflow-instances` | `IWorkflowInstancesApi.ListAsync` | `read:workflow-instances` |
+| Get an instance | `GET /workflow-instances/{id}` | `IWorkflowInstancesApi.GetAsync` | `read:workflow-instances` |
+| Read an instance journal | `GET /workflow-instances/{id}/journal` | `IWorkflowInstancesApi.GetJournalAsync` | `read:workflow-instances` |
+| Read filtered journal records | `POST /workflow-instances/{id}/journal` | `IWorkflowInstancesApi.GetFilteredJournalAsync` | `read:workflow-instances` |
+| Read execution state | `GET /workflow-instances/{id}/execution-state` | `IWorkflowInstancesApi.GetExecutionStateAsync` | `read:workflow-instances` |
+| Cancel an instance | `POST /cancel/workflow-instances/{id}` | `IWorkflowInstancesApi.CancelAsync` | `cancel:workflow-instances` |
+| List activity descriptors | `GET /descriptors/activities` | `IActivityDescriptorsApi.ListAsync` | `read:activity-descriptors` |
+
+The table lists the principal routes rather than every bulk, import, export,
+reload, and administration endpoint. When your host exposes OpenAPI, use the
+document from the exact Elsa version you run for full schemas, optional fields,
+and the complete route set.
+
+## Execute versus dispatch
+
+Both operations create work from a workflow definition, but they have different
+operational intent:
+
+- Use `execute` when the caller expects Elsa to start the workflow immediately.
+- Use `dispatch` when the caller should hand off the request and let the
+  configured workflow runtime consume it asynchronously.
+
+Both client methods return `HttpResponseMessage`; inspect the status code and
+response before assuming an instance was created. Send input and correlation
+data through `ExecuteWorkflowDefinitionRequest` or
+`DispatchWorkflowDefinitionRequest`.
+
+```csharp
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
+
+public sealed class OrderWorkflowStarter(IExecuteWorkflowApi workflows)
+{
+    public async Task StartAsync(string orderId, CancellationToken cancellationToken)
     {
-        var request = new SaveWorkflowDefinitionRequest
-        {
-            Model = new WorkflowDefinitionModel
+        var response = await workflows.DispatchAsync(
+            "process-order",
+            new DispatchWorkflowDefinitionRequest
             {
-                DefinitionId = "my-workflow",
-                Name = "My Workflow",
-                Description = "A sample workflow",
-                Version = 1,
-                IsPublished = true,
-                Root = new Activity
-                {
-                    Type = "Elsa.WriteLine",
-                    Id = "write-line-1"
-                    // Configure activity properties as needed
-                },
-                Options = new WorkflowOptions
-                {
-                    CommitStrategyName = "WorkflowExecuted",
-                    ActivationStrategyType = "Singleton",
-                    AutoUpdateConsumingWorkflows = true
-                }
+                CorrelationId = orderId,
+                Input = new Dictionary<string, object> { ["OrderId"] = orderId }
             },
-            Publish = true
-        };
+            cancellationToken);
 
-        var response = await _api.SaveAsync(request);
-        return response.WorkflowDefinition;
-    }
-}
-```
-
-**Key Properties:**
-
-| Property                               | Description                                                           |
-| -------------------------------------- | --------------------------------------------------------------------- |
-| `DefinitionId`                         | Unique identifier for the workflow definition                         |
-| `Version`                              | Version number (increments with each publish)                         |
-| `Root`                                 | The root activity of the workflow                                     |
-| `Options.CommitStrategyName`           | How often workflow state is persisted (see DOC-021)                   |
-| `Options.ActivationStrategyType`       | Controls how new instances are created (e.g., `Singleton`, `Default`) |
-| `Options.AutoUpdateConsumingWorkflows` | Whether to update workflows that reference this one                   |
-
-**Code Reference:** `src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/WorkflowOptions.cs`
-
-### HTTP Variant (POST)
-
-```bash
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-definitions" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": {
-      "definitionId": "my-workflow",
-      "name": "My Workflow",
-      "description": "A sample workflow",
-      "version": 1,
-      "isPublished": true,
-      "root": {
-        "type": "Elsa.WriteLine",
-        "id": "write-line-1",
-        "text": "Hello, World!"
-      },
-      "options": {
-        "commitStrategyName": "WorkflowExecuted",
-        "activationStrategyType": "Default",
-        "autoUpdateConsumingWorkflows": true
-      }
-    },
-    "publish": true
-  }'
-```
-
-**Response (Success - 201 Created):**
-
-```json
-{
-  "workflowDefinition": {
-    "id": "abc123",
-    "definitionId": "my-workflow",
-    "name": "My Workflow",
-    "version": 1,
-    "isPublished": true,
-    "createdAt": "2025-01-01T00:00:00Z"
-  },
-  "alreadyPublished": false,
-  "consumingWorkflowCount": 0
-}
-```
-
-***
-
-## Versioning & Publishing Semantics
-
-### Draft vs Published
-
-Workflow definitions have two states:
-
-| State         | Description                 | Can Execute? |
-| ------------- | --------------------------- | ------------ |
-| **Draft**     | Work-in-progress definition | No           |
-| **Published** | Active, executable version  | Yes          |
-
-Multiple versions can exist, but only one version is the "latest published" version at any time.
-
-### Publishing Options
-
-When saving a workflow definition, set `Publish = true` to immediately publish:
-
-```csharp
-var request = new SaveWorkflowDefinitionRequest
-{
-    Model = new WorkflowDefinitionModel { /* ... */ },
-    Publish = true  // Immediately publish this version
-};
-```
-
-### AutoUpdateConsumingWorkflows
-
-When set to `true`, workflows that reference this definition (via Dispatch Workflow activity) will automatically use the new version:
-
-```csharp
-Options = new WorkflowOptions
-{
-    AutoUpdateConsumingWorkflows = true
-}
-```
-
-**Code Reference:** `src/modules/Elsa.Workflows.Core/Models/WorkflowOptions.cs`
-
-### Activation Strategies
-
-Control how new workflow instances are created:
-
-| Strategy    | Behavior                                 |
-| ----------- | ---------------------------------------- |
-| `Default`   | Each trigger creates a new instance      |
-| `Singleton` | Only one running instance per definition |
-
-See the documentation on Activation Strategies in the main Elsa docs for detailed guidance.
-
-**Code Reference:** `src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/WorkflowOptions.cs` — `ActivationStrategyType` property.
-
-***
-
-## Executing / Dispatching Workflows
-
-### Using elsa-api-client (C#)
-
-```csharp
-using System.Net.Http;
-using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
-using Elsa.Api.Client.Resources.WorkflowDefinitions.Requests;
-
-public class WorkflowRunner
-{
-    private readonly IExecuteWorkflowApi _api;
-
-    public WorkflowRunner(IExecuteWorkflowApi api)
-    {
-        _api = api;
-    }
-
-    public async Task<HttpResponseMessage> ExecuteWorkflowAsync(
-        string definitionId,
-        string? correlationId = null,
-        Dictionary<string, object>? input = null)
-    {
-        var request = new ExecuteWorkflowDefinitionRequest
-        {
-            CorrelationId = correlationId,
-            Input = input
-        };
-
-        var response = await _api.ExecuteAsync(definitionId, request);
         response.EnsureSuccessStatusCode();
-        return response;
     }
 }
 ```
 
-### HTTP Variant (POST)
+## Inspect a running or failed workflow
+
+Start with the instance list and filter by definition ID, correlation ID,
+status, sub-status, incident presence, or timestamps. Then choose the detail
+view that answers the question:
+
+- **Instance**: current status and high-level instance data.
+- **Journal**: chronological execution records; use the filtered journal for
+  focused activity or incident investigation.
+- **Execution state**: the persisted execution state for deeper runtime
+  diagnosis.
+- **Export**: a portable diagnostic or migration artifact.
+
+Elsa Studio's workflow-instance viewer uses the same instance and journal
+surfaces. Prefer Studio for an interactive investigation; use the API for an
+operations integration, report, or controlled automation. For the operating
+workflow, see [Troubleshooting](../troubleshooting/README.md) and
+[Long-Running Workflows](../running-workflows/long-running-workflows.md).
+
+## Resume a bookmark callback
+
+An activity can generate a bookmark token URL for an approval or external
+callback. Resume it with the `t` query value and, optionally, input for the
+workflow. `POST` accepts an object containing `input`; `GET` accepts JSON in
+the `in` query parameter. The request body is limited to 1 MiB in Elsa 3.8.
 
 ```bash
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-definitions/my-workflow/execute" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
+curl -X POST "https://elsa.example/elsa/api/bookmarks/resume?t=YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "correlationId": "order-12345",
-    "input": {
-      "orderId": "12345",
-      "customerEmail": "customer@example.com"
-    }
-  }'
+  --data '{"input":{"Decision":"Approved"}}'
 ```
 
-**Response (Success - 200 OK):**
-
-```json
-{
-  "workflowInstanceId": "inst-abc123",
-  "status": "Running"
-}
-```
-
-Use `/workflow-definitions/{definitionId}/dispatch` with the same request body to enqueue execution asynchronously.
-
-### Key Parameters
-
-| Parameter        | Description                                        | Required |
-| ---------------- | -------------------------------------------------- | -------- |
-| `definitionId`   | ID of the workflow definition in the route         | Yes      |
-| `correlationId`  | External identifier for correlation                | No       |
-| `input`          | Dictionary of input values                         | No       |
-| `versionOptions` | Which version to run (Latest, Published, Specific) | No       |
-
-> **Note:** In 3.7.0, the API client executes workflow definitions through `IExecuteWorkflowApi.ExecuteAsync` and `IExecuteWorkflowApi.DispatchAsync`. `IWorkflowInstancesApi` is for listing, reading, cancelling, deleting, importing, and exporting workflow instances.
-
-**Code Reference:** `src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Contracts/IExecuteWorkflowApi.cs`.
-
-***
-
-## Querying Workflow Definitions & Instances
-
-### Filtering Workflow Instances
-
-The API supports filtering by status, correlationId, definitionId, and version with pagination.
-
-#### Using elsa-api-client (C#)
-
-```csharp
-using Elsa.Api.Client.Resources.WorkflowInstances.Contracts;
-using Elsa.Api.Client.Resources.WorkflowInstances.Requests;
-using Elsa.Api.Client.Resources.WorkflowInstances.Enums;
-
-public class WorkflowQuerier
-{
-    private readonly IWorkflowInstancesApi _api;
-
-    public WorkflowQuerier(IWorkflowInstancesApi api)
-    {
-        _api = api;
-    }
-
-    public async Task<PagedListResponse<WorkflowInstanceSummary>> QueryByCorrelationAsync(
-        string correlationId,
-        WorkflowStatus? status = null,
-        int page = 0,
-        int pageSize = 25)
-    {
-        var request = new ListWorkflowInstancesRequest
-        {
-            CorrelationId = correlationId,
-            Status = status,
-            Page = page,
-            PageSize = pageSize
-        };
-
-        return await _api.ListAsync(request);
-    }
-}
-```
-
-#### HTTP Variant (curl)
-
-```bash
-# Query by correlationId
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-instances" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"correlationId":"order-12345","page":0,"pageSize":25}'
-
-# Query by status
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-instances" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"status":"Running","page":0,"pageSize":25}'
-
-# Query by definitionId and version
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-instances" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"definitionId":"my-workflow","version":2}'
-```
-
-### Query Parameters
-
-| Parameter       | Description                                                       | Type    |
-| --------------- | ----------------------------------------------------------------- | ------- |
-| `status`        | Filter by workflow status (Running, Suspended, Finished, Faulted) | Enum    |
-| `correlationId` | Filter by correlation ID                                          | String  |
-| `definitionId`  | Filter by workflow definition ID                                  | String  |
-| `version`       | Filter by specific version                                        | Integer |
-| `page`          | Page number (0-indexed)                                           | Integer |
-| `pageSize`      | Number of results per page (default: 25, max: 100)                | Integer |
-
-***
-
-## Bookmarks & Resuming
-
-### How Bookmarks Work
-
-Bookmarks are created when a workflow reaches a blocking activity (e.g., waiting for HTTP callback, human approval, or external event). The workflow suspends until resumed via the bookmark.
-
-**Code Reference:** `src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs` — `CreateBookmark()` method.
-
-### Bookmark Creation
-
-Activities create bookmarks using `ActivityExecutionContext.CreateBookmark()`:
-
-```csharp
-// Internal to activity implementation
-var bookmark = context.CreateBookmark(
-    callback: ResumeAsync,
-    payload: new MyBookmarkPayload { Data = "value" },
-    options: new CreateBookmarkArgs { AutoBurn = true }
-);
-```
-
-### Stimulus Hashing
-
-Bookmarks are matched using a deterministic hash based on:
-
-* Activity type name
-* Stimulus payload data
-
-This allows the runtime to efficiently find matching bookmarks without knowing the instance ID.
-
-**Code Reference:** `src/modules/Elsa.Workflows.Core/Bookmarks/` — Stimulus hashing implementation (e.g., `StimulusHasher`).
-
-### Resuming Workflows
-
-#### Token-Based Resume (URL)
-
-HTTP triggers generate tokenized URLs for easy resumption:
-
-```bash
-# Token-based resume (generated URL)
-curl -X POST "https://your-elsa-server.com/elsa/api/bookmarks/resume?t=ENCRYPTED_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"input":{"status":"approved"}}'
-```
-
-**Code Reference:** `src/modules/Elsa.Http/Extensions/BookmarkExecutionContextExtensions.cs` — `GenerateBookmarkTriggerUrl` method.
-
-The HTTP endpoint expects the encrypted `t` query-string token generated by Elsa. The token payload contains the bookmark ID and workflow instance ID; it is not a general stimulus-resume API.
-
-See [resume-bookmark.curl.md](examples/resume-bookmark.curl.md) for complete examples.
-
-#### Runtime Service Resume
-
-```csharp
-using Elsa.Workflows.Runtime;
-
-await workflowResumer.ResumeAsync(new ResumeBookmarkRequest
-{
-    WorkflowInstanceId = instanceId,
-    BookmarkId = bookmarkId,
-    Input = new Dictionary<string, object>
-    {
-        ["status"] = "approved"
-    }
-});
-```
-
-There is no 3.7.0 `elsa-api-client` resume method on `IWorkflowInstancesApi`; use the generated tokenized URL over HTTP or the runtime services inside the server process.
-
-### Resume Flow & Locking
-
-The `WorkflowResumer` service:
-
-1. Acquires a distributed lock for the bookmark filter
-2. Loads the workflow state from the database
-3. Finds the matching bookmark
-4. Resumes execution from the bookmarked activity
-5. Burns (deletes) the bookmark if `AutoBurn = true`
-
-**Code Reference:** `src/modules/Elsa.Workflows.Runtime/Services/WorkflowResumer.cs` — Resume logic and locking.
-
-### Security Note
-
-Tokenized resume URLs should be treated as secrets:
-
-* Use HTTPS to prevent interception
-* Tokens expire when the bookmark is burned or workflow is cancelled
-* See [Security & Authentication Guide](../security/) (DOC-020) for token security best practices
-
-***
-
-## Incidents & Retry / Resilience
-
-### Resilience Strategies
-
-In `release/3.8.0`, the .NET API client configures activity retry behavior with
-`ResilienceStrategyConfig` on `customProperties.resilienceStrategy`.
-
-#### Setting a Resilience Strategy
-
-Use `ActivityExtensions.SetResilienceStrategy(...)` or assign the same payload
-directly through `CustomProperties`:
-
-```csharp
-using Elsa.Api.Client.Extensions;
-using Elsa.Api.Client.Resources.Resilience.Models;
-using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
-
-var activity = new Activity
-{
-    Type = "Elsa.FlowSendHttpRequest",
-    Id = "http-call-1"
-};
-
-activity.SetResilienceStrategy(new ResilienceStrategyConfig
-{
-    Mode = ResilienceStrategyConfigMode.Identifier,
-    StrategyId = "http-default"
-});
-```
-
-The referenced strategy ID must exist in the host's resilience strategy
-catalog, for example from `Resilience:Strategies` configuration.
-
-### Handling Incidents
-
-When activities fail, inspect `WorkflowState.Incidents` on the workflow
-instance:
-
-```csharp
-var instance = await _instancesApi.GetAsync(instanceId);
-
-if (instance.WorkflowState.Incidents.Any())
-{
-    foreach (var incident in instance.WorkflowState.Incidents)
-    {
-        Console.WriteLine($"Activity {incident.ActivityId} failed: {incident.Message}");
-    }
-}
-```
-
-For workflow-level incident handling and operator retry guidance, see
-[Incidents](../../operate/incidents/README.md).
-
-***
-
-## Commit Strategies
-
-Commit strategies control when workflow state is persisted to the database. This affects durability and performance.
-
-### Selecting a Strategy
-
-When creating a workflow definition, specify the commit strategy:
-
-```csharp
-Options = new WorkflowOptions
-{
-    CommitStrategyName = "WorkflowExecuted"  // Minimal commits, highest throughput
-}
-```
-
-### Available Strategies
-
-| Strategy           | Behavior                         | Use Case                         |
-| ------------------ | -------------------------------- | -------------------------------- |
-| `WorkflowExecuted` | Commits after workflow completes | High throughput, short workflows |
-| `ActivityExecuted` | Commits after each activity      | Maximum durability               |
-| `Periodic`         | Commits at regular intervals     | Long-running workflows           |
-
-For detailed guidance on commit strategies and performance tuning, see [Performance & Scaling Guide](../performance/) (DOC-021).
-
-**Code Reference:** `src/modules/Elsa.Workflows.Core/CommitStates/CommitStrategiesFeature.cs` — Strategy registration.
-
-***
-
-## Pagination & Performance
-
-### Pagination Parameters
-
-All list endpoints support pagination:
-
-| Parameter  | Description              | Default | Max |
-| ---------- | ------------------------ | ------- | --- |
-| `page`     | Zero-indexed page number | 0       | -   |
-| `pageSize` | Results per page         | 25      | 100 |
-
-### Example with Pagination
-
-```bash
-# First page
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-instances" \
-  -H "Content-Type: application/json" \
-  -d '{"page":0,"pageSize":50}'
-
-# Second page
-curl -X POST "https://your-elsa-server.com/elsa/api/workflow-instances" \
-  -H "Content-Type: application/json" \
-  -d '{"page":1,"pageSize":50}'
-```
-
-### Performance Recommendations
-
-1.  **Use Server-Side Filtering:** Always filter on the server rather than fetching all results and filtering client-side.
-
-    ```bash
-    # Good: Server-side filtering
-    curl -X POST "https://your-elsa-server.com/elsa/api/workflow-instances" \
-      -H "Content-Type: application/json" \
-      -d '{"status":"Running","correlationId":"order-123"}'
-
-    # Avoid: Fetching all and filtering client-side
-    ```
-2. **Limit Page Size:** Use the smallest page size that meets your needs to reduce response time and memory usage.
-3. **Avoid Large Instance Graphs:** When querying instances, request only summary data unless you need the full execution history.
-4. **Consider Field Selection (Future):** Future versions may support field selection to reduce payload size. Check release notes for updates.
-
-***
-
-## Error Handling & Troubleshooting
-
-### Common HTTP Status Codes
-
-| Status               | Meaning               | Common Cause                                                   |
-| -------------------- | --------------------- | -------------------------------------------------------------- |
-| **200 OK**           | Success               | -                                                              |
-| **201 Created**      | Resource created      | -                                                              |
-| **400 Bad Request**  | Validation error      | Missing required field (e.g., `root` activity), malformed JSON |
-| **401 Unauthorized** | Authentication failed | Invalid or expired token                                       |
-| **404 Not Found**    | Resource not found    | Definition ID doesn't exist                                    |
-| **409 Conflict**     | Publish conflict      | Version conflict during concurrent publish                     |
-
-### Validation Errors (400)
-
-```json
-{
-  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
-  "title": "One or more validation errors occurred.",
-  "status": 400,
-  "errors": {
-    "root": ["The Root field is required."],
-    "definitionId": ["The DefinitionId field is required."]
-  }
-}
-```
-
-### Bookmark Resume Does Not Continue
-
-Common causes:
-
-* Bookmark already burned (consumed)
-* Workflow instance was cancelled
-* Token expired or invalid
-
-**Resolution:**
-
-1. Verify the workflow instance still exists and is suspended
-2. Check if the bookmark was already consumed
-3. Verify the resume URL includes the encrypted `t` token generated for that bookmark
-
-### Troubleshooting Checklist
-
-1. **Check logs** for detailed error messages
-2. **Verify authentication** with a simple GET request
-3. **Validate JSON** syntax before sending
-4. **Check workflow state** via instance query
-5. **Review bookmark existence** in database
-
-For comprehensive troubleshooting, see [Troubleshooting Guide](../troubleshooting/) (DOC-017).
-
-***
-
-## Best Practices Summary
-
-### Correlation IDs
-
-* **Use correlation IDs** for multi-event workflows to track related activities
-* Choose meaningful, unique identifiers (e.g., order ID, customer ID)
-* Query by correlation ID for efficient instance lookup
-
-```csharp
-var request = new ExecuteWorkflowDefinitionRequest
-{
-    CorrelationId = $"order-{orderId}"  // Use meaningful ID
-};
-
-await executeWorkflowApi.ExecuteAsync("order-processing", request);
-```
-
-### Idempotent Resume Handlers
-
-Design resume handlers to be idempotent (safe to call multiple times):
-
-```csharp
-// Check if action already performed
-if (await HasAlreadyProcessedAsync(bookmarkId))
-{
-    return; // Skip duplicate processing
-}
-
-await ProcessAsync(input);
-await MarkAsProcessedAsync(bookmarkId);
-```
-
-### Commit Strategy Selection
-
-Choose commit strategy based on your durability vs throughput requirements:
-
-| Requirement                          | Recommended Strategy |
-| ------------------------------------ | -------------------- |
-| High throughput, short workflows     | `WorkflowExecuted`   |
-| Long-running, must not lose progress | `ActivityExecuted`   |
-| Balanced for most use cases          | `Periodic`           |
-
-### Client Instrumentation
-
-For custom metrics and monitoring:
-
-* **User-defined metrics** for throughput, latency, error rates
-* **Built-in OpenTelemetry instrumentation** via `Elsa.Workflows` for workflow execution visibility
-
-See [Performance & Scaling Guide](../performance/) and [Monitoring & Observability](../../operate/monitoring-observability.md) for observability patterns.
-
-### General Recommendations
-
-1. **Prefer elsa-api-client** for .NET applications
-2. **Handle transient failures** with retry policies
-3. **Use HTTPS** for all API calls
-4. **Paginate results** to avoid memory issues
-5. **Monitor workflow health** via status queries
-6. **Clean up completed instances** via retention policies
-
-***
-
-## Example Files
-
-* [resume-bookmark.curl.md](examples/resume-bookmark.curl.md) — Resume workflow via tokenized bookmark URL
-* [Source File References](README-REFERENCES.md) — elsa-core source paths for grounding
-
-## Related Documentation
-
-* [Security & Authentication Guide](../security/) (DOC-020) — Authentication, tokenized URLs, security
-* [Performance & Scaling Guide](../performance/) (DOC-021) — Commit strategies, observability
-* [Persistence Guide](../persistence/) (DOC-022) — Database configuration
-* [Troubleshooting Guide](../troubleshooting/) (DOC-017) — Diagnosing common issues
-* [Clustering Guide](../clustering/) (DOC-015) — Distributed deployment
-
-***
-
-**Last Updated:** 2025-11-28
+Add `async=true` to enqueue the resume request through Elsa's bookmark queue;
+without it, Elsa calls the workflow resumer directly. A successful accepted
+request returns `200 OK`. An invalid or undecryptable token returns a validation
+error.
+
+Do not invent a bookmark token from an instance ID. Generate the token from the
+activity's bookmark, and make handlers idempotent because network callers can
+retry a callback.
+
+## Before you automate
+
+- Verify the host's API base path and authentication scheme.
+- Give the client a least-privilege permission set.
+- Use definition IDs for stable automation; versions and internal IDs change as
+  designs are published.
+- Persist the instance ID and correlation ID returned or supplied by your
+  integration so operators can find the execution later.
+- Prefer `dispatch` for fire-and-forget integrations and inspect the response
+  for either path.
+- Protect bookmark tokens as credentials, including in logs, browser history,
+  support tickets, and analytics.
+
+For release-specific request and response schemas, use the interfaces in the
+matching `Elsa.Api.Client` package and, when available, the OpenAPI document
+served by your host.


### PR DESCRIPTION
## What changed
- Replaced the release-drifted API & Client guide with a concise Elsa 3.8 API map.
- Documented core management routes, generated .NET client interfaces, relevant permission claims, and token-based bookmark resume.
- Updated the documentation slice inventory and selected DOC-048 as the next slice.

## Why
The previous guide mixed unsupported assumptions and stale examples with reference material. This gives developers and operators a smaller, source-backed starting point.

## Validation
- Checked release/3.8.0 endpoint routes, client contracts, and permissions in elsa-core.
- Ran `git diff --check`, verified changed internal Markdown links, and linted the rewritten guide's structural Markdown rules.
- Full backlog lint retains pre-existing formatting violations outside this slice.