### PR TITLE
docs: add Studio Platform integration guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -81,6 +81,7 @@
   * [Custom UI Components](guides/studio/custom-ui-components.md)
   * [Integration](guides/studio/integration/README.md)
     * [Custom Elements Embedding](guides/studio/integration/custom-elements.md)
+    * [Platform Artifact Submission](guides/studio/integration/platform-integration.md)
 * [Workflow Patterns](guides/patterns/README.md)
 * [Troubleshooting](guides/troubleshooting/README.md)
 

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-16)
+## Slice Inventory (2026-07-17)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -49,6 +49,7 @@ acceptance criterion below is already complete.
 - `DOC-041` Loading workflows from JSON
 - `DOC-042` Bulk dispatch workflows activity
 - `DOC-049` Studio custom-elements embedding cookbook
+- `DOC-050` Studio platform integration
 - `DOC-053` Alterations operational guide hardening
 - `DOC-047` API reference
 - `DOC-048` Activity reference
@@ -62,19 +63,13 @@ topics below.
 
 ### Recommended next slice
 
-- `DOC-050` Studio platform integration: add a focused guide for
-  `AddPlatformIntegrationModule`, workflow-submission widgets, and when to use
-  that integration path instead of custom-elements embedding alone.
+- `DOC-054` Standalone versus modular configuration matrix: add a compact
+  reference that maps `AddElsa(...)` host settings to `CShells` feature
+  settings so teams can migrate between hosting models without reverse
+  engineering sample apps.
 
 ### Newly discovered follow-on topics
 
-- `DOC-050` Studio platform integration: add a focused guide for
-  `AddPlatformIntegrationModule`, workflow submission widgets, and when to
-  use that integration path instead of custom-elements embedding alone.
-- `DOC-051` Activity and workflow testing cookbook: add a focused guide for
-  `Elsa.Testing.Shared`, `ActivityTestFixture`, and `WorkflowTestFixture`
-  so custom activity authors can validate behavior without reverse
-  engineering test setup from source.
 - `DOC-054` Standalone versus modular configuration matrix: add a compact
   reference that maps `AddElsa(...)` host settings to `CShells` feature
   settings so teams can migrate between hosting models without reverse
@@ -97,6 +92,10 @@ topics below.
 
 ### Most recent completed slice
 
+- `DOC-050` Studio platform integration:
+  completed on 2026-07-17 with a release-backed guide for opt-in Studio-host
+  registration, manual and automatic artifact submission, payload-reference
+  constraints, and the separation from custom-elements embedding.
 - `DOC-051` Activity and workflow testing cookbook:
   completed on 2026-07-16 with a compact, release-backed path for unit-testing
   activities, testing workflow routing through the journal, and escalating to
@@ -131,9 +130,10 @@ topics below.
 
 ### Latest slice note
 
-- `DOC-051` Activity and workflow testing cookbook: completed on 2026-07-16.
-  See [Testing & Debugging Workflows](../../guides/testing-debugging.md) for
-  the release-backed activity and workflow testing path.
+- `DOC-050` Studio platform integration: completed on 2026-07-17 with a
+  release-backed guide for opt-in Studio-host registration, workflow-artifact
+  submission, payload-reference constraints, and its separation from
+  custom-elements embedding.
 
 ### DOC-001: V2 to V3 Migration Guide
 - **Persona**: Backend Integrator, Architect

--- a/guides/studio/customization.md
+++ b/guides/studio/customization.md
@@ -150,7 +150,9 @@ Examples from the released source include:
 - workflow definition labels widgets
 - console log widgets in workflow instance views
 - dashboard widgets and dashboard companion widgets
-- platform submission widgets from `AddPlatformIntegrationModule`
+- platform submission widgets from `AddPlatformIntegrationModule`; see
+  [Platform Artifact Submission](integration/platform-integration.md) when a
+  Studio host needs to register workflow artifacts with Elsa Platform
 
 Use widgets for:
 

--- a/guides/studio/integration/README.md
+++ b/guides/studio/integration/README.md
@@ -19,6 +19,11 @@ In Elsa 3.8.0, Elsa Studio is shipped in three integration shapes:
 
 If you are integrating Elsa Studio into React, Angular, MVC, Razor Pages, or another host application, the supported route in the source tree is the custom-elements host. The repository also includes a React wrapper around those custom elements.
 
+If you own a custom Studio host and need to register workflow-definition
+artifacts with Elsa Platform, add the opt-in
+[Platform Artifact Submission](platform-integration.md) module. It is separate
+from custom-elements embedding and is not enabled by the stock Studio hosts.
+
 ## Choose the Right Host Model
 
 Use the standalone hosts when Studio should run as its own application.

--- a/guides/studio/integration/platform-integration.md
+++ b/guides/studio/integration/platform-integration.md
@@ -1,0 +1,148 @@
+---
+description: >-
+  Release-backed guidance for submitting Elsa Studio workflow definitions as
+  Elsa Platform artifacts in Elsa Studio 3.8.0.
+---
+
+# Submit Workflow Definitions to Elsa Platform
+
+Use the Platform integration when a Studio host you control must register
+workflow-definition artifacts with Elsa Platform. It adds submission actions to
+Studio and can submit after an individual workflow is published.
+
+This is a Studio-host module, not a custom-elements feature. The released
+3.8.0 Server, WebAssembly, and custom-elements hosts do **not** call
+`AddPlatformIntegrationModule`. Your host must reference the
+`Elsa.Studio.PlatformIntegration` module and register it explicitly.
+
+If you only need to embed a designer or instance view in an existing
+application, use [Custom Elements Embedding](custom-elements.md) instead.
+
+## What Is Submitted
+
+Platform submission registers an artifact envelope and a reference to the
+workflow-definition payload. It does **not** upload the workflow JSON to
+Platform.
+
+The module serializes the workflow definition, derives a SHA-256 digest, and
+registers an `elsa.workflow-definition` artifact at:
+
+```
+{PlatformEndpoint}/api/workspaces/{WorkspaceId}/artifacts
+```
+
+By default, the payload reference uses provider `producer-managed` and a URI
+like `studio://workflows/{definition-id}/snapshots/{digest}`. Before enabling
+the integration, make sure your Platform deployment can resolve that reference
+through a producer-managed payload mechanism. This module does not provide a
+payload host or resolver.
+
+## When To Use It
+
+Use this module when a technical Studio host owns the relationship with Elsa
+Platform and needs a workflow artifact catalog or handoff process.
+
+Do not use it merely to embed Studio screens. It does not add Platform
+submission to the prebuilt custom-elements bundle, and it does not deploy a
+workflow from Platform to an Elsa runtime.
+
+## Register the Module
+
+Add the module where you compose your custom Studio host:
+
+```csharp
+using System.Net.Http.Headers;
+using Elsa.Studio.PlatformIntegration.Extensions;
+
+var platformAccessToken = builder.Configuration["Platform:AccessToken"]
+    ?? throw new InvalidOperationException("Platform access token is required.");
+
+builder.Services.AddPlatformIntegrationModule(options =>
+{
+    options.PlatformEndpoint = new Uri("https://platform.example.com");
+    options.WorkspaceId = Guid.Parse("00000000-0000-0000-0000-000000000000");
+    options.ConfigureRequestAsync = (request, _) =>
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer", platformAccessToken);
+        return Task.CompletedTask;
+    };
+});
+```
+
+`PlatformEndpoint` is the Platform base address, not the artifact route; the
+client appends the workspace route shown above. A non-empty `PlatformEndpoint`
+and `WorkspaceId` make the integration configured. `ConfigureRequestAsync` is
+the module's deliberate request-authentication hook, so supply the Platform
+credential there rather than assuming Studio's Elsa Server credential is
+reused.
+
+Keep secrets out of source code. Use your host's configuration or secret store
+for the Platform credential.
+
+## Submission Modes
+
+`Enabled` and `SubmitOnWorkflowPublished` both default to `true`.
+
+| Mode | What happens |
+| --- | --- |
+| Manual | Studio shows a **Submit to Platform** action in the workflow editor toolbar, each workflow-list row, and the workflow-list bulk actions. |
+| Automatic | After Studio successfully publishes one workflow definition, the module submits its artifact when it is enabled and configured. |
+
+Choose manual-only submission when an operator must approve each Platform
+registration. Start with the complete registration above, including its
+Platform authentication callback, then set:
+
+```csharp
+builder.Services.AddPlatformIntegrationModule(options =>
+{
+    // Configure PlatformEndpoint, WorkspaceId, and ConfigureRequestAsync.
+    options.PlatformEndpoint = new Uri("https://platform.example.com");
+    options.WorkspaceId = Guid.Parse("00000000-0000-0000-0000-000000000000");
+    options.SubmitOnWorkflowPublished = false;
+});
+```
+
+The editor action can submit its current in-memory workflow snapshot, including
+unsaved designer changes. List actions load the latest version for each selected
+definition ID; they are not a historical-version or published-only selector.
+Bulk actions submit definitions one at a time and can report a partial failure.
+
+Automatic submission is best effort. The publish notification handler logs a
+submission failure instead of failing or rolling back the workflow publication.
+It runs for individual Studio publish notifications. Studio bulk publishing
+uses a separate bulk notification, so do not rely on it to automatically submit
+every workflow in a bulk publish operation.
+
+## Verify the Integration
+
+1. Configure a Platform endpoint, a non-empty workspace ID, and request auth.
+2. Open a workflow in the Studio host. The submit action remains disabled until
+   the required Platform options are configured.
+3. Submit a workflow manually, or publish one workflow with automatic
+   submission enabled.
+4. Confirm the Platform workspace contains an artifact with the expected
+   workflow identity and SHA-256 digest.
+5. Submit the unchanged snapshot again. A `200 OK` response is treated as a
+   successful duplicate, while `201 Created` means a new submission.
+
+For a failed submission, inspect the Studio-host logs and the Platform response:
+
+| Response | Meaning in the module |
+| --- | --- |
+| `401` or `403` | The Platform credential was rejected. |
+| `400` | The submission failed validation. |
+| `409` | The artifact conflicts with an existing Platform record. |
+| `5xx` | The failure is marked retryable. |
+
+Also verify that Platform can resolve the registered payload URI. Seeing an
+artifact record alone does not prove the workflow payload is available to a
+consumer.
+
+## Related Guidance
+
+- [Studio Integration](README.md) explains the available Studio host models.
+- [Customizing Elsa Studio](../customization.md) explains widgets and other
+  host extension seams.
+- [Custom Elements Embedding](custom-elements.md) is the supported path for
+  embedding selected Studio surfaces without adding this host module.


### PR DESCRIPTION
## Summary\n- add a release-backed guide for opt-in Studio-to-Platform artifact submission\n- document manual versus automatic submission, authentication, and response handling\n- clarify that registration does not upload workflow JSON and requires a payload resolver\n\n## Validation\n- MSBUILD : error MSB1009: Project file does not exist.
Switch: src/modules/Elsa.Studio.PlatformIntegration.Tests/Elsa.Studio.PlatformIntegration.Tests.csproj\n- staged whitespace, local-link, and fenced-code checks