### PR TITLE
docs: add standalone and modular hosting matrix

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -34,6 +34,7 @@
 * [Architecture](guides/architecture/README.md)
   * [Execution Model](guides/architecture/execution-model.md)
   * [Workflow Dispatcher Architecture](guides/architecture/workflow-dispatcher.md)
+  * [Standalone and Modular Hosting](guides/architecture/standalone-and-modular-hosting.md)
 * [Onboarding](guides/onboarding/README.md)
   * [Hosting Elsa in an Existing App](guides/onboarding/hosting-elsa-in-existing-app.md)
 * [Authentication & Authorization](guides/authentication.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-17)
+## Slice Inventory (2026-07-18)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -55,6 +55,7 @@ acceptance criterion below is already complete.
 - `DOC-048` Activity reference
 - `DOC-052` Workflow state and journal API cookbook
 - `DOC-051` Activity and workflow testing cookbook
+- `DOC-054` Standalone versus modular configuration matrix
 
 ### Available next slices
 
@@ -63,17 +64,22 @@ topics below.
 
 ### Recommended next slice
 
-- `DOC-054` Standalone versus modular configuration matrix: add a compact
-  reference that maps `AddElsa(...)` host settings to `CShells` feature
-  settings so teams can migrate between hosting models without reverse
-  engineering sample apps.
+- `DOC-055` Message broker topology cookbook: document queue naming, temporary
+  endpoint lifetime, consumer placement, and cleanup tradeoffs across the
+  broker integrations.
+
+### Current run selection (2026-07-18)
+
+- Selected and completed `DOC-054`, the highest-priority configuration gap in
+  the follow-on inventory.
+- Added a release-backed matrix for the standalone `AddElsa(...)` host and the
+  CShells-based modular server, including feature activation, shell-scoped
+  settings, identity paths, persistence, and the shipped configuration-shape
+  caveat.
+- No additional topic was discovered during source validation.
 
 ### Newly discovered follow-on topics
 
-- `DOC-054` Standalone versus modular configuration matrix: add a compact
-  reference that maps `AddElsa(...)` host settings to `CShells` feature
-  settings so teams can migrate between hosting models without reverse
-  engineering sample apps.
 - `DOC-055` Message broker topology cookbook: add an operations-facing guide
   for queue naming, temporary endpoint lifetime, consumer placement, and broker
   cleanup tradeoffs across MassTransit, Azure Service Bus activities, and
@@ -92,6 +98,10 @@ topics below.
 
 ### Most recent completed slice
 
+- `DOC-054` Standalone versus modular configuration matrix:
+  completed on 2026-07-18 with a release-backed guide mapping code-first
+  `AddElsa(...)` composition to CShells feature activation and shell-scoped
+  settings, including identity and configuration-shape caveats.
 - `DOC-050` Studio platform integration:
   completed on 2026-07-17 with a release-backed guide for opt-in Studio-host
   registration, manual and automatic artifact submission, payload-reference

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -66,13 +66,14 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (9 pages)
+### GUIDES (10 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
 - **Designer** (`guides/http-workflows/designer.md`)
 - **Programmatic** (`guides/http-workflows/programmatic.md`)
 - **Loading Workflows from JSON** (`guides/loading-workflows-from-json.md`)
+- **Standalone and Modular Hosting** (`guides/architecture/standalone-and-modular-hosting.md`)
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)
 - **Using a Trigger** (`guides/running-workflows/using-a-trigger.md`)
@@ -146,6 +147,7 @@ Based on the current structure, the following core concepts are documented:
 
 ### Hosting & Operations
 - ✅ Distributed hosting
+- ✅ Standalone and CShells-based modular host configuration matrix
 - ✅ Docker and Docker Compose examples
 - ✅ Workflow instance variables
 - ✅ Activation strategies

--- a/guides/architecture/standalone-and-modular-hosting.md
+++ b/guides/architecture/standalone-and-modular-hosting.md
@@ -1,0 +1,177 @@
+---
+description: >-
+  Release-backed configuration matrix for code-first Elsa hosts and the
+  CShells-based modular server in Elsa 3.8.0.
+---
+
+# Standalone and Modular Hosting
+
+Elsa 3.8.0 supports two host-composition models:
+
+- **Standalone (code-first)**: register Elsa in an ASP.NET Core application
+  with `AddElsa(...)`, then compose modules with `UseX(...)` methods.
+- **Modular**: use `Elsa.ModularServer.Web`, register CShells, and activate
+  shell features from configuration. This is useful when feature composition
+  and per-shell settings need to be changed without recompiling the host.
+
+These models use the same Elsa modules, but their configuration surfaces are
+different. Use the matrix below when moving from one host model to the other.
+
+<!-- markdownlint-disable MD013 -->
+
+## Host registration
+
+| Concern | Standalone host | Modular host |
+| --- | --- | --- |
+| Register Elsa | `services.AddElsa(elsa => { ... })` | `builder.AddShells(shells => shells.WithConfigurationProvider(configuration) ...)` |
+| Activate features | Call extension methods such as `UseIdentity()`, `UseWorkflowRuntime()`, or `UseWorkflowsApi()` | Add shell feature types in `shell.WithFeatures(...)` and configure their settings under `CShells:Shells:<name>:Features` |
+| Set feature options | Configure the feature callback or bind an options section in C# | Set the shell feature's public settings under that feature's configuration object |
+| Add a route prefix or shell path | Configure the relevant ASP.NET Core or Elsa option in code | Configure the shell's `WebRouting` settings and enable CShells web routing in the host |
+| Add or remove a capability | Change the compiled `UseX(...)` chain | Change the shell feature set and reload/restart according to the modular host's lifecycle |
+
+The release modular server wires these pieces together in
+`Elsa.ModularServer.Web/Program.cs`:
+
+```csharp
+builder.AddShells(shells => shells
+    .WithHostAssemblies()
+    .WithConfigurationProvider(configuration)
+    .WithWebRouting(options => options.EnablePathRouting = true)
+    .WithAuthenticationAndAuthorization()
+    .ConfigureAllShells(shell => shell.WithFeatures(
+        typeof(ElsaFeature),
+        typeof(WorkflowManagementFeature),
+        typeof(WorkflowRuntimeFeature),
+        typeof(WorkflowsFeature),
+        typeof(WorkflowsApiFeature))));
+```
+
+`ConfigureAllShells(...)` supplies the feature set to every shell created by
+the host. The values for an individual shell are then read from that shell's
+configuration section.
+
+## Configuration matrix
+
+The modular column separates features activated in the host's
+`WithFeatures(...)` list from settings exposed by a shell feature. A feature
+can be active without needing a configuration object.
+
+| Capability | Standalone registration | Modular feature/settings |
+| --- | --- | --- |
+| Elsa core | `elsa` module is created by `AddElsa(...)` | `"Elsa": {}` |
+| Identity services | `.UseIdentity(...)` | `"Identity": { "SigningKey": "..." }` |
+| JWT/API-key authentication | `.UseDefaultAuthentication()` | `"DefaultAuthentication": {}` |
+| Workflow management and runtime | `.UseWorkflowManagement(...)` and `.UseWorkflowRuntime(...)` | Activate `WorkflowManagementFeature` and `WorkflowRuntimeFeature` in `WithFeatures(...)`; provider-specific persistence features supply storage. The shipped `appsettings.json` does not need empty settings objects for these two features |
+| Workflow API | `.UseWorkflowsApi()` | `"WorkflowsApi": {}` |
+| HTTP activities and triggers | `.UseHttp(http => { ... })` | `"Http": { "HttpActivityOptions": { ... } }` |
+| SQLite workflow persistence | `UseEntityFrameworkCore(ef => ef.UseSqlite(...))` in the management/runtime configuration | `"SqliteWorkflowPersistence": { "ConnectionString": "..." }` |
+
+<!-- markdownlint-enable MD013 -->
+
+For example, the standalone HTTP configuration in the release server binds
+`HttpActivityOptions` in the `UseHttp(...)` callback. The modular
+`HttpFeature` exposes the same options as its `HttpActivityOptions` setting,
+so the modular equivalent is:
+
+```json
+{
+  "CShells": {
+    "Shells": {
+      "Default": {
+        "Features": {
+          "Http": {
+            "HttpActivityOptions": {
+              "BaseUrl": "https://localhost:5001"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For a code-first host, the equivalent is an explicit callback:
+
+```csharp
+services.AddElsa(elsa => elsa.UseHttp(http =>
+{
+    http.ConfigureHttpOptions = options =>
+        configuration.GetSection("Http").Bind(options);
+}));
+```
+
+The important distinction is the level at which the setting is bound: a
+standalone callback binds an Elsa options object directly, while a modular
+feature receives its own shell-scoped configuration object.
+
+## Identity and secrets
+
+The configuration path is not interchangeable between host models:
+
+- code-first `Elsa.Server.Web` binds token settings from
+  `Identity:Tokens`;
+- the modular `Identity` shell feature binds its settings from the shell's
+  `Identity` feature section, for example
+  `CShells:Shells:Default:Features:Identity:SigningKey`.
+
+For environment variables, that modular path becomes:
+
+```text
+CShells__Shells__Default__Features__Identity__SigningKey
+```
+
+Do not copy a code-first `Identity:Tokens:SigningKey` environment variable into
+a modular host and assume it will be discovered. Bind the setting at the
+configuration path used by the host model.
+
+## Choosing a model
+
+Choose a standalone host when:
+
+- Elsa is part of an existing ASP.NET Core application;
+- feature composition is owned by the application code;
+- you need arbitrary C# callbacks, custom services, or application-specific
+  startup logic.
+
+Choose a modular host when:
+
+- the deployment needs CShells and shell-scoped configuration;
+- feature sets are assembled from host or package assemblies;
+- different shells need different settings such as route paths or persistence
+  connections.
+
+The modular model does not make `AddElsa(...)` configuration automatically
+available. A `UseX(...)` call must be translated to the corresponding shell
+feature, and any callback logic must be replaced by settings that the shell
+feature actually exposes.
+
+## Configuration-shape warning
+
+The 3.8.0 source tree contains both `src/apps/Elsa.ModularServer.Web/appsettings.json`
+and `appsettings.Example.json`. They show different shell collection shapes:
+the checked-in runtime file uses an object keyed by shell name, while the
+example file uses a list of shell objects with `Name`, `Settings`, and
+`Features` fields.
+
+Treat the configuration file shipped with the exact modular host and its
+CShells package version as authoritative. Do not combine the two shapes in one
+deployment without verifying how that host's configuration provider parses
+them.
+
+## Related guides
+
+- [Hosting Elsa in an Existing App](../onboarding/hosting-elsa-in-existing-app.md)
+- [Modules and Plugins](../extensibility/modules-and-plugins.md)
+- [Configuration Management](../deployment/configuration-management.md)
+- [Authentication & Authorization](../authentication.md)
+
+## Release source references
+
+- [Standalone `AddElsa` registration](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa/Extensions/DependencyInjectionExtensions.cs)
+- [Standalone server composition](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/apps/Elsa.Server.Web/Program.cs)
+- [Modular server composition](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/apps/Elsa.ModularServer.Web/Program.cs)
+- [Modular server settings](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/apps/Elsa.ModularServer.Web/appsettings.json)
+- [Identity shell feature](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Identity/ShellFeatures/IdentityFeature.cs)
+- [HTTP shell feature](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs)
+- [Module system notes](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/doc/wiki/module-system.md)


### PR DESCRIPTION
## Summary

- add a release-backed DOC-054 guide comparing code-first `AddElsa(...)` hosts with CShells-based modular hosting
- map feature activation and shell-scoped settings for Identity, authentication, workflow APIs, HTTP, and SQLite persistence
- document identity environment-variable paths and the 3.8.0 modular configuration-shape caveat
- update navigation, coverage, and the next-slice backlog recommendation

## Validation

- `git diff --cached --check`
- `npx --yes markdownlint-cli2 SUMMARY.md guides/architecture/standalone-and-modular-hosting.md`
- local Markdown-link target check
- HTTP 200 checks for all release-source links
- source validation against `release/3.8.0` core host and shell-feature code