### PR TITLE
docs: add Elsa API permission reference

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -40,6 +40,7 @@
 * [Authentication & Authorization](guides/authentication.md)
 * [Security & Authentication](guides/security/README.md)
   * [Disable Auth in Development](guides/security/disable-auth.md)
+  * [Elsa API Permissions](guides/security/permission-reference.md)
   * [HTTP Endpoint Security](guides/security/http-endpoint-security.md)
   * [External Identity Providers](guides/security/external-identity-providers.md)
 * [Deployment](guides/deployment/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -57,22 +57,30 @@ acceptance criterion below is already complete.
 - `DOC-051` Activity and workflow testing cookbook
 - `DOC-054` Standalone versus modular configuration matrix
 - `DOC-055` Message broker topology cookbook
+- `DOC-056` Custom resilience extensibility
+- `DOC-057` Elsa API permission reference
 
 ### Available next slices
 
 No original backlog slices remain. Continue with the prioritized follow-on
 topics below.
 
-- `DOC-057` Elsa API permission reference: add a compact map of common Elsa API
-  and Studio operations to `permissions` claim values, plus starter role
-  templates for external identity providers.
 - `DOC-058` Workflow dispatch outbox operations: add a focused guide for
   transactional-outbox delivery, retries, cleanup, and diagnosing delayed
   cross-workflow dispatch.
 
 ### Recommended next slice
 
-- `DOC-057` Elsa API permission reference
+- `DOC-058` Workflow dispatch outbox operations
+
+### Current run selection (2026-07-21)
+
+- Selected and completed `DOC-057`, the Elsa API permission reference.
+- Added a compact permission-to-operation map, Studio-facing capability
+  guidance, and least-privilege role templates grounded in the remote
+  `origin/release/3.8.0` source branches.
+- `DOC-058` remains available for the next run; no new topic was added during
+  this source review.
 
 ### Current run selection (2026-07-20)
 
@@ -81,28 +89,20 @@ topics below.
 - Added a release-backed guide for custom Polly strategies, serializer type
   registration versus catalog configuration, resilient activity integration,
   Studio behavior, and retry recorder/reader persistence tradeoffs.
-- `DOC-057` and `DOC-058` remain available for later runs; no new topic has been
-  been added during this source review.
+- `DOC-057` was selected for the 2026-07-21 run; `DOC-058` remains available.
 
 ### Newly discovered follow-on topics
 
-- `DOC-055` Message broker topology cookbook: add an operations-facing guide
-  for queue naming, temporary endpoint lifetime, consumer placement, and broker
-  cleanup tradeoffs across MassTransit, Azure Service Bus activities, and
-  distributed cache invalidation.
-- `DOC-056` Custom resilience extensibility: add a focused guide for
-  `IResilienceStrategy`, `AddResilienceStrategyType<T>()`, and
-  `WithRetryAttemptRecorder(...)` so teams can persist retry diagnostics and
-  introduce non-HTTP resilience policies without reverse engineering tests and
-  feature registration.
-- `DOC-057` Elsa API permission reference: add a compact map of common Elsa API
-  and Studio operations to `permissions` claim values, plus starter role
-  templates for external identity providers.
 - `DOC-058` Workflow dispatch outbox operations: add a focused guide for
   transactional-outbox delivery, retries, cleanup, and diagnosing delayed
   cross-workflow dispatch.
 
 ### Most recent completed slice
+
+- `DOC-057` Elsa API permission reference:
+  completed on 2026-07-21 with a release-backed map of core and module
+  permissions, Studio capability behavior, role templates, and authorization
+  boundary caveats.
 
 - `DOC-056` Custom resilience extensibility:
   completed on 2026-07-20 with a release-backed guide for custom Polly

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -67,7 +67,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (10 pages)
+### GUIDES (11 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -75,6 +75,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Programmatic** (`guides/http-workflows/programmatic.md`)
 - **Loading Workflows from JSON** (`guides/loading-workflows-from-json.md`)
 - **Standalone and Modular Hosting** (`guides/architecture/standalone-and-modular-hosting.md`)
+- **Elsa API Permissions** (`guides/security/permission-reference.md`)
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)
 - **Using a Trigger** (`guides/running-workflows/using-a-trigger.md`)
@@ -168,6 +169,7 @@ Based on the current structure, the following core concepts are documented:
 ### Advanced Features
 - ✅ Multitenancy setup
 - ✅ Authentication
+- ✅ Elsa API permission reference with Studio capability and role templates
 - ✅ Alterations and alteration plans
 - ✅ Log persistence and retention
 - ✅ Logging framework
@@ -220,7 +222,8 @@ Based on the current structure, the following core concepts are documented:
    - ⚠️ HTTP workflows guide exists but could be expanded
    - ❌ No workflow testing guide
    - ❌ No data persistence patterns guide
-   - ⚠️ Security guidance now includes dedicated guides for endpoint security and external identity providers, but role-oriented permission recipes are still missing
+   - ✅ Security guidance now includes endpoint security, external identity
+     providers, and role-oriented permission recipes
    - ❌ No workflow design patterns
 
 ## Documentation Quality Notes

--- a/guides/api-client/README.md
+++ b/guides/api-client/README.md
@@ -39,6 +39,8 @@ do not reuse a Studio administrator token for background services.
 Configure authentication and claims before calling these endpoints. See
 [Authentication & Authorization](../authentication.md) and
 [External Identity Providers](../security/external-identity-providers.md).
+For a route map and least-privilege role templates, see [Elsa API
+Permissions](../security/permission-reference.md).
 
 The exception is `GET`/`POST /bookmarks/resume`. Elsa deliberately allows this
 route anonymously because the encrypted `t` token identifies the bookmark and

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -196,6 +196,8 @@ ASP.NET Core role policies such as `RequireRole("Admin")` are useful for your ow
 
 Permission names are not limited to constants in `PermissionNames`. Shared constants include `*`, `ManageWorkflowRuntime`, expression execution permissions, and bookmark dead-letter permissions. Many endpoints use explicit strings through `ConfigurePermissions(...)`, and feature modules can define their own constants.
 
+For the release-backed route map and least-privilege role templates, see [Elsa API Permissions](security/permission-reference.md).
+
 | Scenario | Permissions |
 | --- | --- |
 | Full Elsa API access | `*` |
@@ -209,7 +211,7 @@ Permission names are not limited to constants in `PermissionNames`. Shared const
 | Cancel or delete workflow instances | `cancel:workflow-instances`, `delete:workflow-instances` |
 | Runtime administration | `ManageWorkflowRuntime` |
 
-For read-only workflow instance and execution result screens, start with `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. The current runtime status endpoint requires `ManageWorkflowRuntime`, which also grants pause, resume, and force-drain authority.
+For read-only workflow instance and execution result screens, start with `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. The runtime status endpoint accepts `read:workflow-runtime` or `ManageWorkflowRuntime`; pause, resume, and force-drain endpoints require `ManageWorkflowRuntime`.
 
 For workflow routes handled by the `HttpEndpoint` activity, authorization is configured separately with the activity's `Authorize` and `Policy` settings. See [HTTP Endpoint Security](security/http-endpoint-security.md).
 ## OIDC Configuration

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -148,6 +148,8 @@ ASP.NET Core policies such as `RequireRole("Admin")` protect custom host endpoin
 
 Common read-only workflow access uses `read:workflow-definitions`, `read:workflow-instances`, and `read:activity-execution`. Use `*` only for full administrative access. For workflow ingress routes handled by the `HttpEndpoint` activity, see [HTTP Endpoint Security](http-endpoint-security.md).
 
+For the route-by-route permission map, Studio capability notes, and least-privilege role templates, see [Elsa API Permissions](permission-reference.md).
+
 **Important:**
 - **Never commit secrets** to source control
 - Use environment variables or secret managers (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault)

--- a/guides/security/permission-reference.md
+++ b/guides/security/permission-reference.md
@@ -1,0 +1,252 @@
+---
+description: >-
+  Release-backed reference for Elsa API permission claims, Studio capabilities,
+  and least-privilege role templates in Elsa 3.8.0.
+---
+
+# Elsa API permissions
+
+Elsa API authorization is claim-based. When API security is enabled, Elsa
+endpoints look for claims with the type `permissions`. Each claim value is an
+Elsa permission string, such as `read:workflow-definitions`. The `*` value
+grants all Elsa API permissions.
+
+This page is a practical map for configuring Elsa Identity roles, external
+identity providers, API-key applications, and Studio users. It covers the
+common routes in the `release/3.8.0` API; modules can add more permissions of
+their own.
+
+For authentication middleware, tokens, and external provider setup, see the
+[Authentication & Authorization Guide](../authentication.md) and [External
+Identity Providers](external-identity-providers.md). For the .NET API client,
+see [API & Client](../api-client/README.md).
+
+## How permissions are applied
+
+Elsa's API endpoint base classes call `ConfigurePermissions(...)`. With
+security enabled, this registers the endpoint with the supplied permissions
+and the `*` wildcard. With security disabled, the same helper permits
+anonymous access. The permission strings are therefore part of the API
+contract, not ASP.NET Core role names.
+
+Elsa Identity obtains permissions from roles:
+
+- JWT access tokens include the permissions of the user's assigned roles.
+- API keys include the permissions of the roles assigned to the application
+  that owns the key.
+- An external OIDC or JWT host must emit `permissions` claims itself or map
+  provider roles, groups, or scopes into that claim type during token
+  validation.
+
+An ASP.NET Core policy such as `RequireRole("WorkflowOperator")` can protect a
+custom controller or page, but it does not satisfy an Elsa endpoint that is
+checking `permissions`.
+
+### A permission is one claim value
+
+Emit one claim for each permission. For example, a service identity that can
+read definitions and execute them has claims equivalent to:
+
+```csharp
+using System.Security.Claims;
+
+var claims = new[]
+{
+    new Claim("permissions", "read:workflow-definitions"),
+    new Claim("permissions", "exec:workflow-definitions")
+};
+```
+
+When using Elsa Identity, configure the values on a role instead of creating
+these claims manually. Avoid using `*` for user-facing or machine identities
+unless full administrative access is genuinely intended.
+
+## Common API permissions
+
+The following table maps the most frequently used management operations to the
+permissions declared by the release API.
+
+| Operation | Permission | Typical routes |
+| --- | --- | --- |
+| Read workflow definitions and versions | `read:workflow-definitions` | `/workflow-definitions`, `/workflow-definitions/{id}`, `/workflow-definitions/{id}/versions` |
+| Create or update a definition | `write:workflow-definitions` | `POST /workflow-definitions`, import routes |
+| Publish a definition or update references | `publish:workflow-definitions` | `/workflow-definitions/{id}/publish`, reference updates, version revert |
+| Retract a definition | `retract:workflow-definitions` | `/workflow-definitions/{id}/retract` |
+| Delete definitions or versions | `delete:workflow-definitions` | delete and bulk-delete routes |
+| Execute or dispatch a definition | `exec:workflow-definitions` | `/workflow-definitions/{id}/execute`, `/dispatch`, bulk dispatch |
+| Read workflow instances, variables, and journal entries | `read:workflow-instances` | `/workflow-instances` and its journal, variables, and execution-state routes |
+| Update root-workflow variables or import an instance | `write:workflow-instances` | `/workflow-instances/{id}/variables`, instance import |
+| Cancel an instance | `cancel:workflow-instances` | `/cancel/workflow-instances/{id}` and bulk cancel |
+| Delete instances | `delete:workflow-instances` | delete and bulk-delete routes |
+| Read activity executions and call stacks | `read:activity-execution` | `/activity-executions` and summary routes |
+| Read activity and designer metadata | See the metadata table below | `/descriptors/*`, `/features`, `/storage-drivers`, and related routes |
+
+The route prefix is host-configurable. These route examples are relative to
+the Elsa API base, which is commonly `/elsa/api`.
+
+### Designer metadata
+
+Give a Studio designer the metadata permissions required by the modules and
+expression languages installed by the host. The release API declares these
+permissions for the corresponding endpoints:
+
+| Capability | Permission |
+| --- | --- |
+| Activity descriptors | `read:activity-descriptors` |
+| Activity descriptor options | `read:activity-descriptors-options` |
+| Expression descriptors | `read:expression-descriptors` |
+| Storage drivers | `read:storage-drivers` |
+| Variable descriptors | `read:variable-descriptors` |
+| Installed feature list | `read:installed-features` |
+| Workflow activation strategies | `read:workflow-activation-strategies` |
+| Commit strategies | `read:commit-strategies` |
+| Incident strategies | `read:incident-strategies` |
+| Log persistence strategies | `read:log-persistence-strategies` |
+
+The expression-descriptor endpoint additionally filters C# and Python
+descriptors unless the caller has `exec:csharp-expressions` or
+`exec:python-expressions`, respectively. Grant those execution permissions
+only when the role is allowed to author or execute those expression types.
+
+The descriptor and feature endpoints also accept the broader `read:*` value in
+release 3.8.0. Prefer the named permissions for least privilege.
+
+## Runtime and operational permissions
+
+| Operation | Permission | Notes |
+| --- | --- | --- |
+| Read runtime status | `read:workflow-runtime` or `ManageWorkflowRuntime` | The status endpoint advertises both values. |
+| Pause the runtime | `ManageWorkflowRuntime` | Administrative state change. |
+| Resume the runtime | `ManageWorkflowRuntime` | Administrative state change. |
+| Force-drain the runtime | `ManageWorkflowRuntime` | Administrative state change. |
+| Read bookmark queue dead letters | `read:bookmark-queue:dead-letters` | Lists or reads dead-letter items. |
+| Replay bookmark queue dead letters | `replay:bookmark-queue:dead-letters` | Requeues failed bookmark work. |
+| Delete bookmark queue dead letters | `delete:bookmark-queue:dead-letters` | Destructive cleanup. |
+| Read alterations | `read:alterations` | Inspect alteration requests. |
+| Run or submit alterations | `run:alterations` | Applies or evaluates alteration work. |
+
+`ManageWorkflowRuntime` is intentionally a distinct claim from
+`read:workflow-runtime`; do not give it to a user who only needs status
+visibility.
+
+## Module-specific permissions
+
+Install only the modules the host needs, then add their claims to the relevant
+role. These are the permission values declared by common release modules:
+
+| Module or capability | Read/view | Write or action |
+| --- | --- | --- |
+| Dashboard | `read:dashboard` | — |
+| Console logs | `read:diagnostics:console-logs` | — |
+| Structured logs | `read:diagnostics:structured-logs` | — |
+| OpenTelemetry diagnostics | `read:diagnostics:opentelemetry` | — |
+| Secrets | `read:secrets` | `write:secrets`, `delete:secrets`, `test:secrets` |
+| Labels | `read:labels` | `create:labels`, `update:labels`, `delete:labels` |
+| Workflow-definition labels | `read:workflow-definition-labels` | `update:workflow-definition-labels` |
+| Tenants | `read:tenants` | `write:tenants`, `delete:tenants`, `execute:tenants:refresh` |
+| Identity users | `read:user` | `create:user`, `update:user`, `delete:user` |
+| Identity roles | `read:role` | `create:role`, `update:role`, `delete:role` |
+| Identity applications | — | `create:application` |
+| Resilience diagnostics | `read:resilience:strategies`, `read:resilience:retries` | `exec:resilience:simulate-response` |
+| Authenticated event trigger | — | `trigger:event` |
+
+Some module endpoints also advertise namespace wildcards such as `read:*` or
+`exec:*`. Check the exact endpoint in the version you deploy before replacing
+named claims with a wildcard.
+
+The release also defines an `ingest:diagnostics:opentelemetry` constant, but
+the checked collector and diagnostics API endpoints do not declare it through
+`ConfigurePermissions(...)`. Do not assume that claim gates ingestion in
+3.8.0; the HTTP collector instead checks its configured API key header or an
+explicitly allowed loopback request. Verify the host and collector path you
+deploy.
+
+REST and live-connection checks are not identical for every module. The
+Console Logs, OpenTelemetry, and Workflow Instance hubs explicitly accept
+their read permission (plus the relevant wildcards). The Structured Logs hub
+in 3.8.0 has an authentication requirement but no module-specific permission
+authorizer, even though its REST endpoints require `read:diagnostics:structured-logs`.
+
+## Starter role templates
+
+These are starting points, not built-in Elsa roles. Put the listed strings in
+the `Permissions` array of an Elsa Identity role, then assign that role to a
+user or application. Add module-specific claims only when that role uses the
+module.
+
+| Role | Start with |
+| --- | --- |
+| **Studio viewer** | `read:workflow-definitions`, `read:workflow-instances`, `read:activity-execution`, and the required designer metadata claims |
+| **Workflow designer** | Studio viewer claims plus `write:workflow-definitions`, `publish:workflow-definitions`, `retract:workflow-definitions`, and `delete:workflow-definitions` |
+| **Workflow operator** | Studio viewer claims plus `cancel:workflow-instances`, `delete:workflow-instances`, and `read:workflow-runtime` |
+| **Runtime administrator** | `read:workflow-runtime` and `ManageWorkflowRuntime` |
+| **Workflow service runner** | Only the definition permissions needed by the service, commonly `read:workflow-definitions` and `exec:workflow-definitions`; add instance read/write claims only if it inspects or changes instances |
+| **Identity administrator** | The `read/create/update/delete` claims for users and roles, plus `create:application` if it provisions API-key applications |
+
+The Studio viewer and designer templates are intentionally separate from the
+runtime administrator template. A user can design workflows without being
+able to pause or force-drain the runtime.
+
+### Role-management safeguard
+
+Elsa Identity checks the caller's `permissions` claims when roles are created,
+updated, or assigned. A caller cannot use its identity-management access to
+grant permissions that it does not itself possess. Keep this in mind when
+delegating role administration: the administrator must already have every
+permission it needs to assign.
+
+## What Studio users see
+
+Studio is a client of the Elsa API; it is not a second authorization system.
+The server remains the authority for each operation:
+
+- In the workflow editor, release Studio treats a workflow as editable when
+  the returned workflow resource includes a `publish` link. Without that
+  capability, version-management actions are read-only or disabled.
+- Diagnostics modules are gated by both the corresponding backend feature and
+  permission. For example, missing `read:diagnostics:console-logs` hides the
+  Console navigation item and makes direct navigation unavailable or
+  unauthorized.
+- A successful Studio login therefore does not prove that the token can load
+  definitions, instances, designer metadata, or diagnostics. Those calls can
+  still return `403 Forbidden` when the required Elsa claim is missing.
+
+When a Studio screen is incomplete, identify the failing API request first and
+add the permission for that operation. Do not grant `*` just to make a single
+screen load.
+
+## Boundaries that use different authorization
+
+Elsa API permissions do not apply to every URL hosted by an Elsa application:
+
+- Workflow routes handled by the `HttpEndpoint` activity use the activity's
+  `Authorize` and `Policy` settings. See [HTTP Endpoint
+  Security](http-endpoint-security.md).
+- Bookmark-resume endpoints are intentionally anonymous in the release API;
+  the encrypted resume token is the capability. Treat it as a secret and
+  generate it with a bounded lifetime. See [API & Client](../api-client/README.md)
+  and [resume-token guidance](examples/resume-endpoint-notes.md).
+- Custom host controllers and pages can use ordinary ASP.NET Core policies,
+  roles, or claims independently of Elsa API permissions.
+
+## Troubleshooting missing access
+
+1. Confirm API security is enabled or disabled as intended. When disabled,
+   Elsa endpoint permission checks are bypassed.
+2. Identify the exact API route returning `401` or `403`.
+3. Check the final authenticated principal on the Elsa Server and verify that
+   its claims use the literal type `permissions`.
+4. Add the exact permission declared by that endpoint, or map the external
+   provider's role/group/scope to it.
+5. If the endpoint is a Studio metadata route, check the corresponding
+   designer permission table above. If it is a module route, check the
+   module-specific table and whether the module is installed.
+
+`401` usually means the request was not authenticated. `403` usually means it
+was authenticated but lacked an accepted permission or failed another policy.
+
+### Release source checked
+
+This reference was checked against the remote `origin/release/3.8.0` commits in
+`elsa-core` and `elsa-studio`. The local `elsa-core` branch with the same name
+had diverged, so it was not used as release evidence.


### PR DESCRIPTION
## Summary
- add a release-backed Elsa API permission reference for core routes and modules
- document Studio capability behavior, authorization boundaries, and least-privilege role templates
- update security/API navigation, coverage, and the documentation slice backlog

## Validation
- checked against remote `origin/release/3.8.0` in elsa-core and elsa-studio
- verified permission strings, links, code fences, and markdown structure
- `git diff --check` passed

The local elsa-core branch named `release/3.8.0` had diverged, so the remote release ref was used as evidence.