### PR TITLE
docs: add workflow dispatch outbox guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -34,6 +34,7 @@
 * [Architecture](guides/architecture/README.md)
   * [Execution Model](guides/architecture/execution-model.md)
   * [Workflow Dispatcher Architecture](guides/architecture/workflow-dispatcher.md)
+  * [Workflow Dispatch Outbox](guides/architecture/workflow-dispatch-outbox.md)
   * [Standalone and Modular Hosting](guides/architecture/standalone-and-modular-hosting.md)
 * [Onboarding](guides/onboarding/README.md)
   * [Hosting Elsa in an Existing App](guides/onboarding/hosting-elsa-in-existing-app.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-19)
+## Slice Inventory (2026-07-22)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -59,19 +59,32 @@ acceptance criterion below is already complete.
 - `DOC-055` Message broker topology cookbook
 - `DOC-056` Custom resilience extensibility
 - `DOC-057` Elsa API permission reference
+- `DOC-058` Workflow dispatch outbox operations
 
 ### Available next slices
 
 No original backlog slices remain. Continue with the prioritized follow-on
 topics below.
 
-- `DOC-058` Workflow dispatch outbox operations: add a focused guide for
-  transactional-outbox delivery, retries, cleanup, and diagnosing delayed
-  cross-workflow dispatch.
+- `DOC-059` Runtime coordination storage: add a focused production guide for
+  the key-value and distributed-lock providers used by outbox, worker, and
+  multi-node runtime coordination.
 
 ### Recommended next slice
 
-- `DOC-058` Workflow dispatch outbox operations
+- `DOC-059` Runtime coordination storage
+
+### Current run selection (2026-07-22)
+
+- Selected and completed `DOC-058`, the workflow dispatch outbox operations
+  guide. The release source confirms a distinct runtime path for dispatches
+  made during workflow execution, with post-commit processing, retry limits,
+  orphan cleanup, and batch controls that are not covered by the existing
+  performance guidance.
+- Added `DOC-059` during source review: the default key-value store and local
+  file lock are unsafe durability/coordination defaults for production, and
+  the existing docs do not bring those runtime-provider choices together for
+  the outbox and other multi-node coordination paths.
 
 ### Current run selection (2026-07-21)
 
@@ -93,9 +106,9 @@ topics below.
 
 ### Newly discovered follow-on topics
 
-- `DOC-058` Workflow dispatch outbox operations: add a focused guide for
-  transactional-outbox delivery, retries, cleanup, and diagnosing delayed
-  cross-workflow dispatch.
+- `DOC-059` Runtime coordination storage: add a focused production guide for
+  the key-value and distributed-lock providers used by outbox, worker, and
+  multi-node runtime coordination.
 
 ### Most recent completed slice
 
@@ -103,6 +116,10 @@ topics below.
   completed on 2026-07-21 with a release-backed map of core and module
   permissions, Studio capability behavior, role templates, and authorization
   boundary caveats.
+
+- `DOC-058` Workflow dispatch outbox operations:
+  completed on 2026-07-22 with release-backed configuration, delivery,
+  retry, cleanup, locking, durability, and diagnosis guidance.
 
 - `DOC-056` Custom resilience extensibility:
   completed on 2026-07-20 with a release-backed guide for custom Polly

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -75,6 +75,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Programmatic** (`guides/http-workflows/programmatic.md`)
 - **Loading Workflows from JSON** (`guides/loading-workflows-from-json.md`)
 - **Standalone and Modular Hosting** (`guides/architecture/standalone-and-modular-hosting.md`)
+- **Workflow Dispatch Outbox** (`guides/architecture/workflow-dispatch-outbox.md`)
 - **Elsa API Permissions** (`guides/security/permission-reference.md`)
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)

--- a/guides/architecture/README.md
+++ b/guides/architecture/README.md
@@ -64,7 +64,9 @@ await workflowDispatcher.DispatchAsync(
 For the release-backed lifecycle that connects execution, dispatch, triggers,
 bookmarks, persistence, and resume behavior, see
 [Execution Model](execution-model.md). For a deeper dive into dispatching, see
-[Workflow Dispatcher Architecture](workflow-dispatcher.md).
+[Workflow Dispatcher Architecture](workflow-dispatcher.md). For transactional
+delivery of dispatches made during workflow execution, see [Workflow Dispatch
+Outbox](workflow-dispatch-outbox.md).
 
 #### IWorkflowRuntime
 
@@ -361,6 +363,7 @@ For detailed information on creating custom modules and plugins, see the [Module
 To dive deeper into specific aspects of Elsa's architecture:
 
 * [**Workflow Dispatcher Architecture**](workflow-dispatcher.md) - Deep dive into `IWorkflowDispatcher` and dispatching patterns
+* [**Workflow Dispatch Outbox**](workflow-dispatch-outbox.md) - Coordinate in-workflow dispatch with committed state and recover delayed delivery
 * [**Modules and Plugins**](../extensibility/modules-and-plugins.md) - Learn how to extend Elsa with custom modules and activities
 * [**Custom Activities**](../../extensibility/custom-activities.md) - Create domain-specific activities
 * [**Multitenancy Setup**](../../multitenancy/setup.md) - Configure multitenancy in your application

--- a/guides/architecture/workflow-dispatch-outbox.md
+++ b/guides/architecture/workflow-dispatch-outbox.md
@@ -1,0 +1,213 @@
+---
+description: >-
+  Release-backed guidance for configuring, operating, and diagnosing Elsa's
+  transactional outbox for workflow dispatch.
+---
+
+# Workflow dispatch outbox
+
+Use the workflow dispatch outbox when a workflow dispatch must not become
+visible until the current workflow state has been committed. It coordinates
+in-workflow dispatch with the owner's state commit and provides recovery when
+delivery is delayed or the host restarts.
+
+The outbox is for Elsa workflow dispatch commands. It is not a general-purpose
+outbox for arbitrary application messages or external side effects.
+
+{% hint style="warning" %}
+"Transactional" describes marker-gated coordination: the outbox item is
+written before the workflow state commit, and the processor delivers it only
+after the committed owner state contains its marker. This is not one atomic
+transaction spanning the outbox store and the workflow-state store.
+{% endhint %}
+
+## When to use it
+
+Enable it when a workflow starts, resumes, or triggers other workflows and the
+child or resumed work must not be dispatched from a parent state that may later
+be rolled back. This is especially useful for long-running, distributed, or
+failure-sensitive workflows.
+
+The outbox does not change dispatch calls made outside workflow execution. In
+that case, Elsa uses the normal background dispatcher. It also does not make
+the downstream workflow's activities transactional with the parent workflow.
+
+## Enable the outbox
+
+Configure `WorkflowDispatcherOptions` in the Elsa host:
+
+```csharp
+using Elsa.Workflows.Runtime.Options;
+
+builder.Services.Configure<WorkflowDispatcherOptions>(options =>
+{
+    options.UseTransactionalOutbox = true;
+    options.ProcessOutboxAfterCommit = true;
+    options.OutboxProcessorBatchSize = 100;
+});
+```
+
+The Elsa runtime registers the outbox, its processor, the post-commit handler,
+and a recurring processor when the workflow runtime feature is enabled. The
+default execution pipeline also includes the middleware that exposes the
+current workflow execution context to the outbox. If you replace that pipeline,
+retain `UseWorkflowDispatchOutbox()`.
+
+The release defaults are:
+
+| Option | Default | Effect |
+| --- | ---: | --- |
+| `UseTransactionalOutbox` | `false` | Enables transactional dispatch. |
+| `ProcessOutboxAfterCommit` | `true` | Attempts delivery after a commit. |
+| `OrphanedOutboxItemRetention` | 1 day | Keeps ownerless items. |
+| `MaxOutboxDeliveryAttempts` | 10 | Failed sends before abandonment. |
+| `OutboxProcessorBatchSize` | 100 | Items loaded per processor cycle. |
+
+`ProcessOutboxAfterCommit = false` does not disable the outbox. It skips the
+eager post-commit attempt and leaves delivery to the recurring sweep.
+
+## How delivery works
+
+For a dispatch made during workflow execution, Elsa follows this sequence:
+
+1. The transactional dispatcher creates an outbox item for a definition,
+   instance, trigger, or resume dispatch.
+2. Elsa stores the item and adds its ID to the current workflow state as an
+   ownership marker.
+3. The workflow state commit persists that marker with the owner workflow.
+4. After the commit, Elsa may try to process the item immediately. A recurring
+   task also scans for pending items every 10 seconds by default.
+5. The processor takes a distributed lock, verifies that the owner exists and
+   that its committed state contains the item ID, and sends the command through
+   the background command path.
+6. After a successful send, Elsa deletes the outbox item and removes its marker
+   from the owner workflow state.
+
+The processor uses a tenant-scoped lock when a tenant is active, and preserves
+the item's tenant ID as dispatch headers. Multiple nodes can therefore run the
+processor without intentionally sending the same pending item concurrently,
+provided they use a shared distributed lock provider. The release default is a
+file-system lock under `App_Data/locks`, which is suitable for one machine but
+must be replaced for nodes running on separate machines. The lock does not
+provide exactly-once delivery.
+
+## What is placed in the outbox
+
+The transactional dispatcher supports these four command kinds:
+
+| Command kind | Meaning |
+| --- | --- |
+| Workflow definition | Start a new workflow instance from a definition. |
+| Workflow instance | Dispatch an existing workflow instance. |
+| Trigger workflows | Dispatch workflows matched by a stimulus. |
+| Resume workflows | Resume workflows matched by a stimulus or bookmark. |
+
+The **Dispatch Workflow** and **Bulk Dispatch Workflows** activities use
+`IWorkflowDispatcher` while they execute, so their child dispatches can enter
+the outbox. If either activity is configured to wait for child completion, the
+parent still waits on its bookmark; the outbox only controls when the child
+dispatch becomes eligible for delivery.
+
+## Failure, retry, and cleanup behavior
+
+### Delivery failures
+
+If sending the command fails, Elsa increments `DeliveryAttempts` and keeps the
+item for a later processor cycle. There is no application-level exponential
+backoff in this processor; the retry cadence is determined by the eager attempt
+and recurring sweep. The processor continues with the next item in the batch
+when one item fails.
+
+When the attempt count reaches `MaxOutboxDeliveryAttempts`, Elsa abandons the
+item by deleting it and removing its committed marker. If deletion fails, Elsa
+preserves the attempt count and tries again during a later cycle.
+
+### Missing or uncommitted owners
+
+An item is not delivered until its owner workflow exists and its committed
+state contains the item ID. This prevents an item saved before a failed or
+rolled-back owner commit from being dispatched.
+
+If the owner is missing, or the owner never committed the marker, Elsa retains
+the item until `OrphanedOutboxItemRetention` expires. Set that option to zero or
+less only when immediate cleanup of such items is acceptable.
+
+### At-least-once delivery
+
+Delivery is at-least-once. If Elsa sends the command successfully but cannot
+delete the item, the item is not counted as a delivery failure and may be sent
+again. The outbox processor does not deduplicate child starts; the owner marker
+and outbox item ID only guard commit eligibility. Use application-level
+idempotency or deduplication where duplicate delivery would be harmful.
+
+If the item is deleted successfully but marker cleanup fails, Elsa does not
+recreate the item. The owner can temporarily retain a stale marker, which a
+later commit or state sweep may prune.
+
+Retry limits and orphan cleanup intentionally delete or abandon items. The
+release does not provide a separate dead-letter store or replay endpoint, so
+retain the relevant logs and failure context if operators need to investigate
+an abandoned dispatch.
+
+The default key-value outbox store also includes recovery and index records so
+an interrupted store write can be found and repaired on a later scan. For
+production, ensure that the configured key-value store and workflow-instance
+store are durable and shared by the nodes that process the same tenant/workload.
+Without a persistence provider, the release's default key-value store is
+in-memory and is not a restart-safe outbox.
+
+## Operating and diagnosing the outbox
+
+Use this checklist when a child workflow is delayed or appears more than once:
+
+- **Dispatch is delayed after a commit:** Check
+  `ProcessOutboxAfterCommit`, the 10-second sweep, batch size, processor lock,
+  and command-worker backlog.
+- **The item remains after a send failure:** Inspect the delivery-failure log
+  and `DeliveryAttempts`; confirm the configured maximum has not been reached.
+- **The item is never sent:** Confirm the owner workflow committed successfully
+  and that the workflow-state store and outbox store are available from the
+  same host.
+- **The same child appears more than once:** Treat this as possible redelivery
+  under at-least-once semantics; inspect outbox deletion failures and make the
+  downstream operation idempotent.
+- **Items disappear without delivery:** Check orphan retention and the
+  `Abandoning workflow dispatch outbox item` warning. Both missing owners and
+  max-attempt items are intentionally cleaned up.
+- **Only one node appears to process the queue:** This is expected while the
+  distributed processor lock is held. Check lock-provider configuration and
+  tenant identity when progress stops. A local file lock is not sufficient for
+  nodes on separate machines.
+
+For Studio users, the outbox is server-side runtime behavior. Configure it in
+the host, then use the activity's **Wait for Completion** option according to
+the workflow contract. The option controls whether the parent waits for the
+child; it does not turn delivery into a transaction across both workflows.
+Core exposes no outbox inspection endpoint, so operational diagnosis relies on
+host logs, persistence-store telemetry, and workflow-state investigation.
+
+## Related guides
+
+- [Workflow Dispatcher Architecture](workflow-dispatcher.md) explains the
+  dispatcher contracts and request types.
+- [Dispatch Workflow Activity](../running-workflows/dispatch-workflow-activity.md)
+  explains how to start one child workflow from a workflow.
+- [Bulk Dispatch Workflows Activity](../running-workflows/bulk-dispatch-workflows.md)
+  explains fan-out dispatch and completion behavior.
+- [Performance tuning](../performance/README.md) covers measurement-driven
+  batch and commit-path tuning.
+- [Distributed hosting](../../hosting/distributed-hosting.md) covers the
+  multi-node locking and shared-storage prerequisites.
+
+## Release source references
+
+This guide is grounded in Elsa Core `release/3.8.0` at
+[`e96c8f23`](https://github.com/elsa-workflows/elsa-core/tree/e96c8f23c998ee01d1b63151d26832b31be534b):
+
+- [`WorkflowDispatcherOptions`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.Workflows.Runtime/Options/WorkflowDispatcherOptions.cs)
+- [`TransactionalWorkflowDispatcher`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.Workflows.Runtime/Services/TransactionalWorkflowDispatcher.cs)
+- [`WorkflowDispatchOutboxProcessor`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.Workflows.Runtime/Services/WorkflowDispatchOutboxProcessor.cs)
+- [`ProcessWorkflowDispatchOutbox`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.Workflows.Runtime/Handlers/ProcessWorkflowDispatchOutbox.cs)
+- [`WorkflowRuntimeFeature`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs)
+- [`KeyValueFeature`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.KeyValues/ShellFeatures/KeyValueFeature.cs)
+- [`WorkflowDispatchCommandFactory`](https://github.com/elsa-workflows/elsa-core/blob/e96c8f23c998ee01d1b63151d26832b31be534b/src/modules/Elsa.Workflows.Runtime/Extensions/WorkflowDispatchCommandFactory.cs)

--- a/guides/performance/README.md
+++ b/guides/performance/README.md
@@ -136,7 +136,11 @@ For dispatch initiated during workflow execution, `WorkflowDispatcherOptions`
 can enable a transactional outbox. With `UseTransactionalOutbox` enabled, Elsa
 writes eligible dispatches with the workflow state commit and delivers them
 afterward. This makes recovery behavior more robust, but adds persistence and
-delivery work to the path.
+delivery work to the path. See the [Workflow dispatch outbox][outbox guide]
+for the delivery lifecycle, retry limits, orphan cleanup, and duplicate-
+delivery caveats.
+
+[outbox guide]: ../architecture/workflow-dispatch-outbox.md
 
 ```csharp
 using Elsa.Workflows.Runtime.Options;


### PR DESCRIPTION
## Summary

- add a release-backed guide for Elsa workflow dispatch transactional outbox configuration and operations
- document post-commit delivery, retries, orphan cleanup, at-least-once behavior, locking, durability, and diagnosis
- update architecture/performance navigation and advance the documentation slice plan

## Validation

- `git diff --cached --check`
- targeted Markdownlint for the new guide and `SUMMARY.md`
- relative-link and code-fence checks
- Core `release/3.8.0` source assertions
- 39 relevant Core runtime unit tests
- HTTP 200 checks for release source references
