### PR TITLE
docs: add runtime coordination storage guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,6 +35,7 @@
   * [Execution Model](guides/architecture/execution-model.md)
   * [Workflow Dispatcher Architecture](guides/architecture/workflow-dispatcher.md)
   * [Workflow Dispatch Outbox](guides/architecture/workflow-dispatch-outbox.md)
+  * [Runtime Coordination Storage](guides/architecture/runtime-coordination-storage.md)
   * [Standalone and Modular Hosting](guides/architecture/standalone-and-modular-hosting.md)
 * [Onboarding](guides/onboarding/README.md)
   * [Hosting Elsa in an Existing App](guides/onboarding/hosting-elsa-in-existing-app.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-22)
+## Slice Inventory (2026-07-23)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -60,19 +60,28 @@ acceptance criterion below is already complete.
 - `DOC-056` Custom resilience extensibility
 - `DOC-057` Elsa API permission reference
 - `DOC-058` Workflow dispatch outbox operations
+- `DOC-059` Runtime coordination storage
 
 ### Available next slices
 
 No original backlog slices remain. Continue with the prioritized follow-on
 topics below.
 
-- `DOC-059` Runtime coordination storage: add a focused production guide for
-  the key-value and distributed-lock providers used by outbox, worker, and
-  multi-node runtime coordination.
+- `DOC-060` Readiness and health checks: add a concise operator guide for
+  persistence, distributed-lock, and host-readiness probes.
 
 ### Recommended next slice
 
-- `DOC-059` Runtime coordination storage
+- `DOC-060` Readiness and health checks
+
+### Current run selection (2026-07-23)
+
+- Selected and completed `DOC-059` Runtime coordination storage with a
+  release-backed guide covering the key-value and distributed-lock providers
+  used by outbox, worker, and multi-node runtime coordination.
+- Added `DOC-060` during source review because the release exposes a useful
+  distributed-lock readiness probe, but the GitBook has no focused guide for
+  composing it with persistence and host-readiness checks.
 
 ### Current run selection (2026-07-22)
 
@@ -106,9 +115,9 @@ topics below.
 
 ### Newly discovered follow-on topics
 
-- `DOC-059` Runtime coordination storage: add a focused production guide for
-  the key-value and distributed-lock providers used by outbox, worker, and
-  multi-node runtime coordination.
+- `DOC-060` Readiness and health checks: add a concise operator guide for
+  `AddElsaReadinessChecks`, persistence probes, distributed-lock probes, and
+  deployment readiness behavior.
 
 ### Most recent completed slice
 
@@ -116,6 +125,11 @@ topics below.
   completed on 2026-07-21 with a release-backed map of core and module
   permissions, Studio capability behavior, role templates, and authorization
   boundary caveats.
+
+- `DOC-059` Runtime coordination storage:
+  completed on 2026-07-23 with a release-backed guide separating durable
+  key-value storage from cross-node distributed locking, mapping both to
+  outbox and runtime consumers, and documenting readiness validation.
 
 - `DOC-058` Workflow dispatch outbox operations:
   completed on 2026-07-22 with release-backed configuration, delivery,

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -76,6 +76,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Loading Workflows from JSON** (`guides/loading-workflows-from-json.md`)
 - **Standalone and Modular Hosting** (`guides/architecture/standalone-and-modular-hosting.md`)
 - **Workflow Dispatch Outbox** (`guides/architecture/workflow-dispatch-outbox.md`)
+- **Runtime Coordination Storage** (`guides/architecture/runtime-coordination-storage.md`)
 - **Elsa API Permissions** (`guides/security/permission-reference.md`)
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)

--- a/guides/architecture/runtime-coordination-storage.md
+++ b/guides/architecture/runtime-coordination-storage.md
@@ -1,0 +1,212 @@
+---
+description: >-
+  Configure the key-value and distributed-lock providers that Elsa uses for
+  durable outbox records and multi-node workflow coordination.
+---
+
+# Runtime coordination storage
+
+Elsa has two infrastructure contracts that are easy to confuse:
+
+| Contract | What it stores or coordinates | Elsa 3.8.0 default |
+| --- | --- | --- |
+| `IKeyValueStore` | Small serialized records such as outbox items, instance heartbeats, and persisted administrative pauses | In-memory |
+| `IDistributedLockProvider` | Leases that ensure only one node performs a coordinated operation at a time | Local files under `App_Data/locks` |
+
+These defaults are useful for development and single-host tests. They are not
+durable or cross-node production infrastructure. A production cluster needs a
+key-value provider visible to every node and a lock provider that coordinates
+across every node.
+
+{% hint style="warning" %}
+`UseDistributedRuntime()` does not select a shared lock provider or make the
+default key-value store durable. Configure both storage boundaries explicitly
+when more than one host can process the same Elsa deployment.
+{% endhint %}
+
+## What uses each contract?
+
+The stores are infrastructure, not user-facing workflow data stores. Their
+consumers have different failure and durability requirements:
+
+| Runtime path | Contract | Operational consequence |
+| --- | --- | --- |
+| Workflow dispatch outbox | `IKeyValueStore` and `IDistributedLockProvider` | Pending dispatch records must survive restarts, and only one processor should claim a tenant-scoped batch at a time. See [Workflow dispatch outbox](workflow-dispatch-outbox.md). |
+| Distributed bookmark queue worker | `IDistributedLockProvider` | Only one node processes the distributed queue at a time; a node that cannot acquire the lock retries locally. |
+| Workflow resumption and trigger indexing | `IDistributedLockProvider` | Concurrent resume and trigger-indexing operations are serialized across nodes. |
+| Instance heartbeats | `IKeyValueStore` and `IDistributedLockProvider` | Every node writes a heartbeat; the monitor takes a lock before finding timed-out nodes. |
+| Administrative pause persistence | `IKeyValueStore` | `PausePersistencePolicy.AcrossReactivations` can restore a pause after the host is reactivated. |
+
+The key-value store is not a replacement for the workflow definition,
+instance, bookmark, or execution-log stores. Configure the runtime persistence
+provider for those stores as well, and point every node at the same logical
+runtime database or document store.
+
+## Choose a key-value provider
+
+The default `MemoryKeyValueStore` loses its records when the process exits and
+is local to one process. Select a runtime persistence provider that also
+registers an `IKeyValueStore` implementation:
+
+| Runtime persistence | Key-value implementation in the release line | Typical fit |
+| --- | --- | --- |
+| EF Core | `EFCoreKeyValueStore` | Relational database deployments that already use EF Core runtime persistence |
+| MongoDB | `MongoKeyValueStore` | Deployments using the MongoDB runtime provider |
+| Dapper | `DapperKeyValueStore` | Deployments using the Dapper runtime provider |
+
+For EF Core, the runtime persistence feature wires the key-value store for
+you:
+
+```csharp
+using Elsa.Extensions;
+using Elsa.Persistence.EFCore.Modules.Management;
+using Elsa.Persistence.EFCore.Modules.Runtime;
+
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseWorkflowManagement(management =>
+    {
+        management.UseEntityFrameworkCore(ef =>
+        {
+            ef.UsePostgreSql(builder.Configuration.GetConnectionString("Elsa"));
+        });
+    });
+
+    elsa.UseWorkflowRuntime(runtime =>
+    {
+        runtime.UseEntityFrameworkCore(ef =>
+        {
+            ef.UsePostgreSql(builder.Configuration.GetConnectionString("Elsa"));
+        });
+    });
+});
+```
+
+Use the matching runtime persistence extension when you use MongoDB or Dapper.
+Do not register a durable workflow instance store while leaving
+`IKeyValueStore` on the in-memory default: outbox records and coordination
+records would still disappear on restart.
+
+{% hint style="info" %}
+The outbox is marker-gated rather than one atomic transaction across every
+store. A durable key-value provider improves recovery, but it does not turn a
+workflow-state commit and an outbox write into a single cross-store
+transaction. See [Workflow dispatch outbox](workflow-dispatch-outbox.md) for
+the delivery and recovery semantics.
+{% endhint %}
+
+## Choose a distributed lock provider
+
+The runtime feature exposes a provider factory on `UseWorkflowRuntime`. The
+release default is a `FileDistributedSynchronizationProvider` rooted at
+`App_Data/locks`. That coordinates processes that can safely share the same
+local file system; it does not coordinate independent containers or hosts.
+
+Configure a provider supplied by your infrastructure package. Redis,
+PostgreSQL, and SQL Server are examples of cross-node providers supported by
+the release's startup diagnostic. The provider must use the same shared
+resource namespace and compatible lease/timeout settings on every node.
+
+The following shows the Elsa integration point; the provider construction is
+intentionally omitted because its type and connection lifecycle depend on the
+package you choose:
+
+```csharp
+using Elsa.Extensions;
+using Elsa.Workflows.Runtime.Distributed.Extensions;
+using Medallion.Threading;
+
+// Construct this with the provider package and shared connection used by every node.
+// The constructor is provider-specific; see the Redis example below.
+IDistributedLockProvider crossNodeLockProvider = CreateCrossNodeLockProvider();
+
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseWorkflowRuntime(runtime =>
+    {
+        runtime.UseDistributedRuntime();
+        runtime.DistributedLockProvider = _ => crossNodeLockProvider;
+        runtime.DistributedLockingOptions = options =>
+        {
+            options.LockAcquisitionTimeout = TimeSpan.FromMinutes(2);
+        };
+    });
+});
+```
+
+Use the constructor and connection lifecycle recommended by the Redis,
+PostgreSQL, SQL Server, or cloud-lock package you selected. The important Elsa
+integration point is `runtime.DistributedLockProvider`; registering an
+unrelated provider under a different service key does not replace this feature
+setting.
+
+For a complete Redis example, see [Redis distributed locking](../clustering/examples/redis-lock-setup.md).
+For the broader distributed-hosting checklist, see [Distributed hosting](../../hosting/distributed-hosting.md).
+
+## Development and single-host exceptions
+
+The distributed runtime validates its provider during startup. If it detects
+the built-in file or no-op provider, it logs a warning because the provider
+cannot coordinate across application nodes. The warning is useful: do not
+silence it as a substitute for configuring a shared provider.
+
+For a deliberately single-host development or test deployment, acknowledge the
+local provider explicitly:
+
+```csharp
+elsa.UseWorkflowRuntime(runtime =>
+{
+    runtime.UseDistributedRuntime();
+    runtime.DistributedLockingOptions = options =>
+    {
+        options.AllowLocalLockProviderInDistributedRuntime = true;
+    };
+});
+```
+
+The Elsa Server sample enables this option by default only in development. In
+production, set it to `false` and treat any local-provider warning as a
+configuration defect. A shared network folder is not a substitute for a
+lock service: file semantics and failure detection may not be consistent
+across hosts.
+
+## Validate a deployment
+
+Before adding a second node, verify all of the following:
+
+1. Every node uses the same durable runtime persistence provider and logical
+   database or document store.
+2. Every node resolves the same cross-node `IDistributedLockProvider`.
+3. The lock provider can acquire and release a probe lock from each node.
+4. Outbox, heartbeat, and runtime coordination records remain visible after a
+   restart.
+5. A two-node test exercises concurrent resume, trigger indexing, and outbox
+   processing; inspect logs for local-provider warnings and lock timeouts.
+6. Tenant-aware workloads use the same tenant resolution and shared storage
+   configuration on every node.
+
+Elsa exposes a distributed-lock readiness check when you register readiness
+checks with `includeDistributedLocks: true`. Add it to the host's readiness
+pipeline so a node with an unreachable lock provider is not presented as
+ready:
+
+```csharp
+using Elsa.Extensions;
+
+builder.Services
+    .AddHealthChecks()
+    .AddElsaReadinessChecks(includeDistributedLocks: true);
+```
+
+The readiness probe confirms that the configured provider can reach and acquire
+a probe lock; it does not prove that the provider is configured with the right
+business-level topology. Keep the two-node concurrency test in your deployment
+validation as well.
+
+## Related guides
+
+- [Workflow dispatch outbox](workflow-dispatch-outbox.md)
+- [Distributed hosting](../../hosting/distributed-hosting.md)
+- [Redis distributed locking](../clustering/examples/redis-lock-setup.md)
+- [Persistence](../persistence/README.md)
+- [Performance tuning](../performance/README.md)


### PR DESCRIPTION
## Summary
- add a release-backed guide for Elsa 3.8.0 runtime coordination storage
- separate durable `IKeyValueStore` configuration from cross-node `IDistributedLockProvider` configuration
- map provider usage across outbox, workers, heartbeat monitoring, resumption, and trigger indexing
- update navigation, coverage, and the iterative slice plan with DOC-060 readiness checks

## Validation
- release-source assertions against Core `e96c8f23c998ee01d1b63151d26832b31be534b6`
- Extensions provider assertions against the available local 3.8.0 snapshot `d407e9621770a55427ac6c2315bd779da08d5fea`
- staged `git diff --check`
- targeted relative-link validation
- balanced Markdown code fences

No local Markdownlint or GitBook build command is configured in this repository.
