### PR TITLE
docs: add readiness and health checks guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -124,6 +124,7 @@
 ## Operate
 
 * [Monitoring & Observability](operate/monitoring-observability.md)
+* [Readiness and Health Checks](operate/readiness-and-health-checks.md)
 * [Distributed Tracing](operate/distributed-tracing.md)
 * [Investigate a Workflow Instance](operate/workflow-state-and-journal.md)
 * [Variables](operate/workflow-instance-variables.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-23)
+## Slice Inventory (2026-07-24)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -61,18 +61,27 @@ acceptance criterion below is already complete.
 - `DOC-057` Elsa API permission reference
 - `DOC-058` Workflow dispatch outbox operations
 - `DOC-059` Runtime coordination storage
+- `DOC-060` Readiness and health checks
 
 ### Available next slices
 
-No original backlog slices remain. Continue with the prioritized follow-on
-topics below.
-
-- `DOC-060` Readiness and health checks: add a concise operator guide for
-  persistence, distributed-lock, and host-readiness probes.
+No original or currently validated follow-on slices remain. Continue the
+inventory from `origin/main` on the next run and add a new topic only when
+release-source review identifies a distinct, high-value gap.
 
 ### Recommended next slice
 
-- `DOC-060` Readiness and health checks
+No next slice is preselected; re-inventory the released source and current
+documentation before selecting one.
+
+### Current run selection (2026-07-24)
+
+- Selected and completed `DOC-060` Readiness and health checks with a
+  release-backed operator guide for runtime, persistence, distributed-lock,
+  liveness, and readiness behavior.
+- No new distinct follow-on topic was discovered during this run's source
+  review; the existing monitoring, deployment, and runtime-coordination guides
+  now link to the focused health-check contract.
 
 ### Current run selection (2026-07-23)
 
@@ -80,7 +89,7 @@ topics below.
   release-backed guide covering the key-value and distributed-lock providers
   used by outbox, worker, and multi-node runtime coordination.
 - Added `DOC-060` during source review because the release exposes a useful
-  distributed-lock readiness probe, but the GitBook has no focused guide for
+  distributed-lock readiness probe, but the GitBook had no focused guide for
   composing it with persistence and host-readiness checks.
 
 ### Current run selection (2026-07-22)
@@ -115,11 +124,13 @@ topics below.
 
 ### Newly discovered follow-on topics
 
-- `DOC-060` Readiness and health checks: add a concise operator guide for
-  `AddElsaReadinessChecks`, persistence probes, distributed-lock probes, and
-  deployment readiness behavior.
+No new follow-on topic was added during this source review.
 
 ### Most recent completed slice
+
+- `DOC-060` Readiness and health checks:
+  completed on 2026-07-24 with a release-backed operator guide for runtime,
+  persistence, distributed-lock, liveness, and readiness behavior.
 
 - `DOC-057` Elsa API permission reference:
   completed on 2026-07-21 with a release-backed map of core and module

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -92,9 +92,10 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Introduction** (`multitenancy/introduction.md`)
 - **Setup** (`multitenancy/setup.md`)
 
-### OPERATE (8 pages)
+### OPERATE (9 pages)
 
 - **Monitoring & Observability** (`operate/monitoring-observability.md`)
+- **Readiness and Health Checks** (`operate/readiness-and-health-checks.md`)
 - **Distributed Tracing** (`operate/distributed-tracing.md`)
 - **Investigate a Workflow Instance** (`operate/workflow-state-and-journal.md`)
 - **Incidents** (`operate/incidents/README.md`)
@@ -157,6 +158,7 @@ Based on the current structure, the following core concepts are documented:
 - ✅ Activation strategies
 - ✅ Incidents and strategies
 - ✅ Monitoring and distributed tracing guidance
+- ✅ Runtime, persistence, and distributed-lock readiness guidance
 - ✅ Workflow-instance state, journal, activity-execution, and variable investigation guidance
 
 ### HTTP Workflows

--- a/guides/architecture/runtime-coordination-storage.md
+++ b/guides/architecture/runtime-coordination-storage.md
@@ -198,6 +198,10 @@ builder.Services
     .AddElsaReadinessChecks(includeDistributedLocks: true);
 ```
 
+For the complete runtime, persistence, and endpoint contract—including the
+sample's `/health/live` and `/health/ready` mappings—see [Readiness and Health
+Checks](../../operate/readiness-and-health-checks.md).
+
 The readiness probe confirms that the configured provider can reach and acquire
 a probe lock; it does not prove that the provider is configured with the right
 business-level topology. Keep the two-node concurrency test in your deployment

--- a/operate/monitoring-observability.md
+++ b/operate/monitoring-observability.md
@@ -21,6 +21,9 @@ Use this mapping:
 - For readiness and liveness, use health checks such as `/health/live` and
   `/health/ready` in `Elsa.Server.Web`.
 
+For the registration, endpoint mapping, probe semantics, and deployment
+guidance behind those endpoints, see [Readiness and Health Checks](readiness-and-health-checks.md).
+
 If you need a dedicated tracing setup guide, see
 [Distributed Tracing](distributed-tracing.md).
 

--- a/operate/readiness-and-health-checks.md
+++ b/operate/readiness-and-health-checks.md
@@ -1,0 +1,206 @@
+---
+description: >-
+  Release-backed guidance for configuring Elsa runtime, persistence, and
+  distributed-lock readiness checks.
+---
+
+# Readiness and health checks
+
+Use health endpoints to answer an operational question: **can this host
+receive workflow work right now?** A workflow instance being `Running` or
+`Suspended` is not the same thing as the host being ready. Health checks belong
+to the host and orchestrator; Elsa Studio does not replace them with workflow
+status indicators.
+
+The Elsa 3.8.0 runtime provides three Elsa-specific readiness probes:
+
+| Probe | What it checks | Healthy when |
+| --- | --- | --- |
+| Runtime | The runtime can create a workflow client and is accepting new work | The runtime is not paused or draining |
+| Persistence | The registered workflow stores can be reached | Each registered store probe succeeds |
+| Distributed locks | The configured lock provider can create and acquire a short-lived probe lock | A unique probe lock is acquired within the configured timeout |
+
+Registration and endpoint mapping are separate steps. `AddElsaReadinessChecks`
+registers probes; it does not create `/health/ready` or `/health/live`.
+
+## Register the Elsa probes
+
+Call the extension on the ASP.NET Core health-check builder after configuring
+the Elsa runtime and its providers:
+
+```csharp
+using Elsa.Extensions;
+
+builder.Services
+    .AddHealthChecks()
+    .AddElsaReadinessChecks(
+        includePersistence: true,
+        includeDistributedLocks: true,
+        configureOptions: options =>
+        {
+            options.DistributedLockAcquisitionTimeout = TimeSpan.FromSeconds(2);
+            options.ContinuePersistenceProbesAfterFailure = true;
+        });
+```
+
+The defaults are `includePersistence: true`,
+`includeDistributedLocks: false`, a one-second distributed-lock acquisition
+timeout, and `ContinuePersistenceProbesAfterFailure: false`. Enable the lock
+probe for a deployment that uses distributed runtime coordination. Keep
+persistence enabled unless this host intentionally does not register Elsa
+workflow stores.
+
+The lock timeout must be greater than zero. Elsa validates it when options are
+validated on start, so an invalid value can prevent the host from starting.
+
+## Map liveness and readiness endpoints
+
+The released `Elsa.Server.Web` sample maps liveness and readiness separately:
+
+```csharp
+using Elsa.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+app.MapHealthChecks("/health/live", new()
+{
+    // Liveness answers only whether the process and HTTP pipeline respond.
+    Predicate = _ => false
+});
+
+app.MapHealthChecks("/health/ready", new()
+{
+    Predicate = check =>
+        check.Tags.Contains(HealthCheckExtensions.ElsaTag) &&
+        check.Tags.Contains(HealthCheckExtensions.ReadinessTag),
+    ResultStatusCodes =
+    {
+        [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    }
+});
+```
+
+The sample's `/health/live` endpoint selects no checks, so it is deliberately
+cheap and does not test a database or the workflow runtime. Use it to decide
+whether an orchestrator should restart a process. Use `/health/ready` to decide
+whether a load balancer or orchestrator should send traffic to the process.
+
+The readiness predicate selects the tags `elsa` and `elsa-readiness`, which
+`AddElsaReadinessChecks` applies to all three Elsa probes. The sample maps both
+`Degraded` and `Unhealthy` to HTTP 503; a healthy report returns 200. If you
+add application checks and expect them to affect this endpoint, give them the
+same tags or map a separate endpoint for your broader application contract.
+
+## Understand the probe results
+
+### Runtime
+
+The runtime probe first asks `IWorkflowRuntime` to create a workflow client,
+then reads the quiescence signal:
+
+- **Healthy** means the runtime is accepting new work.
+- **Degraded** means it is paused or draining. This is useful during an
+  administrative pause or graceful shutdown and should normally remove the
+  host from traffic without restarting it.
+- **Unhealthy** means the runtime could not create a workflow client.
+
+The health result includes the acceptance flag, quiescence reason, and active
+execution-cycle count. It does not prove that a particular workflow definition
+or external dependency is usable.
+
+### Persistence
+
+The persistence probe checks store reachability with harmless lookups. It
+probes these stores in order:
+
+1. Workflow definitions.
+2. Workflow instances.
+3. Triggers.
+4. Bookmark queue.
+
+The returned entity or count is intentionally ignored. This is a connectivity
+probe, not a migration verifier or a data-integrity scan. When a registered
+store throws, the health-check result data identifies the failed store. Whether
+that data appears in the HTTP response depends on the response writer your
+host configures. By default Elsa stops after the first failed probe; set
+`ContinuePersistenceProbesAfterFailure` to `true` when an operator needs the
+full failure inventory in one request.
+
+If an individual store is not registered, Elsa skips that probe. If no
+persistence stores are registered, the persistence check is **Degraded**.
+Treat that as a configuration problem for a host expected to run persisted
+workflows, even though it is not reported as `Unhealthy` by the check itself.
+
+### Distributed locks
+
+The lock probe resolves `IDistributedLockProvider`, creates a unique lock named
+`elsa-health-check-{guid}`, and tries to acquire it using
+`DistributedLockAcquisitionTimeout`:
+
+- **Healthy** means the provider was reachable and the probe lock was acquired.
+- **Degraded** means no provider is registered or the provider was reachable
+  but could not acquire the probe lock before the timeout.
+- **Unhealthy** means the provider threw while creating or acquiring the lock.
+
+Acquiring a probe lock proves provider reachability and the basic acquire path;
+it does not prove that all nodes use the same namespace, lease settings, or
+business-level topology. Keep the two-node concurrency test described in
+[Runtime coordination storage](../guides/architecture/runtime-coordination-storage.md).
+
+## Apply the checks to deployments
+
+Use the endpoint contract that matches the deployment:
+
+| Deployment | Liveness | Readiness |
+| --- | --- | --- |
+| Local development | `/health/live` | `/health/ready` when troubleshooting provider setup |
+| Single-node production | `/health/live` | Runtime and persistence; include locks if the runtime uses coordinated work |
+| Multi-node production | `/health/live` | Runtime, persistence, and distributed locks backed by shared infrastructure |
+
+For a multi-node deployment, validate all of the following before routing
+traffic to a new node:
+
+- The node uses the same durable workflow management/runtime stores as its
+  peers.
+- The node resolves the same cross-node distributed-lock provider.
+- `/health/ready` succeeds from the node itself, not only through the load
+  balancer.
+- Outbox, heartbeat, resume, and trigger-indexing behavior works in a
+  two-node test. A green probe cannot validate every cross-node failure mode.
+
+For the storage choices behind these checks, see [Runtime coordination
+storage](../guides/architecture/runtime-coordination-storage.md). For
+dispatch durability and retry behavior, see [Workflow dispatch
+outbox](../guides/architecture/workflow-dispatch-outbox.md).
+
+## Diagnose a failed readiness check
+
+1. Call `/health/ready` directly on the affected node and record the HTTP
+   status and any details your host's response writer exposes.
+2. If the health-check result or logs name a persistence store, check its
+   connection, schema, credentials, and provider registration. A skipped or
+   missing store can indicate an incomplete host composition rather than a
+   transient outage.
+3. If the distributed-lock check is degraded, inspect lock contention and the
+   acquisition timeout. If it is unhealthy, inspect provider connectivity and
+   the shared resource configuration.
+4. If the runtime check is degraded, look at the quiescence reason before
+   restarting the process; the host may be intentionally paused or draining.
+5. Compare the node's runtime providers and tenant/storage configuration with
+   a healthy peer before changing workflow definitions or retrying work.
+
+Do not use a failed readiness probe as evidence that individual workflow
+instances are corrupt. Use Studio's instance status, incidents, journal, and
+activity execution records for workflow-level diagnosis; use these endpoints
+for host admission and orchestration decisions.
+
+## Release source
+
+This page is grounded in Elsa Core `release/3.8.0`:
+
+- [`HealthCheckExtensions`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Runtime/Extensions/HealthCheckExtensions.cs)
+- [`ElsaReadinessHealthCheckOptions`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Runtime/Options/ElsaReadinessHealthCheckOptions.cs)
+- [`ElsaRuntimeHealthCheck`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Runtime/HealthChecks/ElsaRuntimeHealthCheck.cs)
+- [`ElsaWorkflowPersistenceHealthCheck`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Runtime/HealthChecks/ElsaWorkflowPersistenceHealthCheck.cs)
+- [`ElsaDistributedLockHealthCheck`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Runtime/HealthChecks/ElsaDistributedLockHealthCheck.cs)
+- [`Elsa.Server.Web` health endpoint mapping](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/apps/Elsa.Server.Web/Program.cs)


### PR DESCRIPTION
## Summary
- add a release-backed operator guide for Elsa runtime, persistence, and distributed-lock readiness checks
- document the sample `/health/live` and `/health/ready` endpoint contract and deployment diagnosis flow
- update operations navigation, cross-links, coverage, and the daily slice inventory

## Validation
- `dotnet test test/unit/Elsa.Workflows.Runtime.UnitTests/Elsa.Workflows.Runtime.UnitTests.csproj --no-restore --filter 'FullyQualifiedName~HealthChecks'` (18 passed)
- targeted `markdownlint-cli2` (0 issues with repository-wide MD013 disabled for existing wide tables)
- staged diff, Markdown fence, relative-link, release-source assertion, and cited-source HTTP checks
