### PR TITLE
docs: document extension package manifests

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -71,6 +71,7 @@
 * [External Application Interaction](guides/external-application-interaction.md)
 * [Loading Workflows from JSON](guides/loading-workflows-from-json.md)
 * [Plugins & Modules](guides/plugins-modules/README.md)
+  * [Package Manifests for Extensions](guides/plugins-modules/package-manifests.md)
 * [Extensibility](guides/extensibility/modules-and-plugins.md)
 * [Testing & Debugging Workflows](guides/testing-debugging.md)
 * [Running Workflows](guides/running-workflows/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -64,10 +64,12 @@ acceptance criterion below is already complete.
 - `DOC-060` Readiness and health checks
 - `DOC-061` Workflow definition version lifecycle
 - `DOC-062` Brokered external authentication and Studio administration
+- `DOC-063` Extension package manifests and infrastructure metadata
 
 ### Available next slices
 
-- `DOC-063` Extension package manifests and infrastructure metadata
+- No distinct follow-on slice is currently selected. Re-inventory the source
+  and GitBook before the next run.
 
 ### Recommended next slice
 
@@ -75,6 +77,17 @@ acceptance criterion below is already complete.
 release extension annotations for runtime kind, infrastructure hints,
 secret/advanced settings, and restart requirements without implying that
 Studio provisions infrastructure automatically.
+
+### Current run selection (2026-07-27)
+
+- Selected and completed `DOC-063` Extension package manifests and
+  infrastructure metadata. Added a release-backed guide covering generated
+  `elsa-package.json` output, Server/Studio runtime compatibility hints,
+  infrastructure requirements, deploy-time settings, packaging checks, and
+  the boundary between package metadata and Studio provisioning.
+- No additional distinct follow-on topic was discovered during the source
+  review; re-inventory the GitBook and release source before selecting the next
+  slice.
 
 ### Current run selection (2026-07-26)
 
@@ -155,6 +168,10 @@ Studio provisions infrastructure automatically.
   Studio provisions infrastructure automatically.
 
 ### Most recent completed slice
+
+- `DOC-063` Extension package manifests and infrastructure metadata:
+  completed on 2026-07-27 with a release-backed guide for runtime kind,
+  infrastructure, setting, build/pack, and Studio-boundary metadata.
 
 - `DOC-062` Brokered external authentication and Studio administration:
   completed on 2026-07-26 with a release-backed guide for the optional broker,

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -67,7 +67,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (15 pages)
+### GUIDES (16 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -84,6 +84,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Using a Trigger** (`guides/running-workflows/using-a-trigger.md`)
 - **Workflow Definition Version Lifecycle** (`guides/running-workflows/workflow-definition-lifecycle.md`)
 - **Using Elsa Studio** (`guides/running-workflows/using-elsa-studio.md`)
+- **Package Manifests for Extensions** (`guides/plugins-modules/package-manifests.md`)
 
 ### HOSTING (1 pages)
 
@@ -171,6 +172,7 @@ Based on the current structure, the following core concepts are documented:
 
 ### Extensibility
 - ✅ Custom activities
+- ✅ Extension package manifests, runtime compatibility, infrastructure hints, and deploy-time settings
 - ✅ Custom resilience strategies and retry-attempt recording
 - ✅ Reusable triggers (preview)
 

--- a/guides/architecture/standalone-and-modular-hosting.md
+++ b/guides/architecture/standalone-and-modular-hosting.md
@@ -146,6 +146,13 @@ available. A `UseX(...)` call must be translated to the corresponding shell
 feature, and any callback logic must be replaced by settings that the shell
 feature actually exposes.
 
+When a NuGet extension includes an `elsa-package.json` manifest, use it as a
+metadata and packaging aid. It describes runtime compatibility,
+infrastructure requirements, and deploy-time settings; the shell still has to
+register the feature and bind its settings. See [Package manifests for
+extensions](../plugins-modules/package-manifests.md) for the annotation and
+build contract.
+
 ## Configuration-shape warning
 
 The 3.8.0 source tree contains both `src/apps/Elsa.ModularServer.Web/appsettings.json`

--- a/guides/deployment/configuration-management.md
+++ b/guides/deployment/configuration-management.md
@@ -37,6 +37,11 @@ That means two things:
    `appsettings.json`, environment-specific JSON files, user secrets, command
    line arguments, and environment variables for server-side hosts.
 
+Extension package manifests describe settings for tooling and operators, but
+they do not bind configuration or provision infrastructure. For the
+`elsa-package.json` contract and a modular-shell mapping example, see [Package
+manifests for extensions](../plugins-modules/package-manifests.md).
+
 ## The Three Main Host Shapes
 
 ### 1. Standalone Elsa Server (`AddElsa(...)`)

--- a/guides/plugins-modules/README.md
+++ b/guides/plugins-modules/README.md
@@ -37,6 +37,7 @@ This architecture enables you to:
   - [Activity Attributes](#activity-attributes)
   - [Registering Activities](#registering-activities)
 - [Packaging & Distribution](#packaging--distribution)
+  - [Package manifests for extensions](package-manifests.md)
 - [Advanced Topics](#advanced-topics)
 - [Complete Examples](#complete-examples)
 
@@ -367,6 +368,11 @@ This scans for all types marked with `[Activity]` and registers them with the ac
 
 ## Packaging & Distribution
 
+For the release-backed package metadata contract, see [Package manifests for
+extensions](package-manifests.md). It covers runtime compatibility,
+infrastructure requirements, deploy-time settings, and the build/pack checks
+needed before publishing a NuGet extension.
+
 To share your custom modules, package them as NuGet packages:
 
 ### 1. Create a Class Library Project
@@ -554,7 +560,7 @@ For complete, working examples, see:
 
 - [Custom Activities Guide](../../extensibility/custom-activities.md) - Detailed activity creation guide
 - [Elsa Core Repository](https://github.com/elsa-workflows/elsa-core) - Official source code and examples
-- [Feature Documentation](../../features/README.md) - Built-in features reference
+- [Alterations Feature Guide](../../features/alterations/README.md) - Built-in alterations reference
 
 ## Support
 

--- a/guides/plugins-modules/package-manifests.md
+++ b/guides/plugins-modules/package-manifests.md
@@ -1,0 +1,273 @@
+---
+description: >-
+  Explain the Elsa 3.8 package manifest generated for CShells extension
+  packages, including runtime compatibility, infrastructure requirements, and
+  deploy-time settings.
+---
+
+# Package manifests for extensions
+
+Use this guide when you publish a NuGet package that contains Elsa server
+extensions implemented as CShells features. Elsa 3.8 can generate an
+`elsa-package.json` manifest while the package is built and include it at the
+root of the NuGet package. The manifest describes what the package contains
+and what an operator needs to configure; it does not replace your feature's
+service registration or provision infrastructure.
+
+## What the manifest is for
+
+The package manifest is build-time metadata for extension packages. It helps
+package and runtime tooling answer questions such as:
+
+- Is this package intended for Elsa Server or Elsa Studio?
+- Does a feature need a database, cache, message broker, or another resource?
+- Which deploy-time settings should an operator provide?
+- Is a setting secret, advanced, experimental, or restart-sensitive?
+
+The manifest is not an application configuration file. `ManifestInfrastructure`
+and `ManifestSetting` do not create a database, bind options, add a health
+check, restart a shell, or make a setting available in Studio automatically.
+Your feature still has to register services and read its configuration.
+
+## How release packages generate it
+
+The release source uses `Elsa.Platform.PackageManifest.Generator` as a
+private build dependency. Core imports the shared package-manifest MSBuild
+props for projects that contain a `ShellFeatures` directory; extension
+modules apply the same generator package and compile the runtime-kind hint
+file from their modules build props. The generator creates the manifest during
+build/pack, and the default package path is `elsa-package.json`.
+
+The release source uses different generator patch versions in the two
+repositories (`0.0.1-preview.53` in Core and `0.0.1-preview.50` in
+Extensions). Keep the generator version aligned with the Elsa release and
+inspect the generated manifest before publishing.
+
+If your extension project is not already covered by a shared build props
+file, add the generator as a private build dependency. This is the pattern
+used by the released Extensions modules:
+
+```xml
+<PackageReference
+    Include="Elsa.Platform.PackageManifest.Generator"
+    Version="0.0.1-preview.50"
+    PrivateAssets="all" />
+```
+
+Use the generator version selected by the release you target; Core 3.8.0 uses
+`0.0.1-preview.53`.
+
+Relevant release files:
+
+- [Core package-manifest MSBuild props](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/PackageManifest.props)
+- [Core package-manifest runtime hint](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/PackageManifestHints.cs)
+- [Extensions module build props](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/Directory.Build.props)
+- [Extensions package-manifest runtime hint](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/PackageManifestHints.cs)
+- [Extensions MassTransit Azure Service Bus feature](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/servicebus/Elsa.ServiceBus.MassTransit.AzureServiceBus/ShellFeatures/MassTransitAzureServiceBusFeature.cs)
+
+## Declare runtime compatibility
+
+Mark the package at assembly level when all of its features target one runtime
+kind:
+
+```csharp
+using Elsa.Platform.PackageManifest.Generator.Hints;
+
+[assembly: ManifestRuntimeKind(ElsaRuntimeKinds.Server)]
+```
+
+The released Core and Extensions sources both use `ElsaRuntimeKinds.Server`,
+which resolves to `elsa.server`. The generator also supports feature-level
+runtime hints when only part of a package is runtime-specific. Use
+`ElsaRuntimeKinds.Studio` for Studio features, and do not label a package as
+Studio-compatible merely because it contributes workflow activities that
+appear in a Studio-hosted designer.
+
+## Describe infrastructure requirements
+
+Attach one or more infrastructure requirements to the feature that uses the
+resource. For example, the released Azure Service Bus feature declares the
+provider, a stable identifier, the infrastructure kind, and related
+configuration keys:
+
+```csharp
+[ManifestInfrastructure(
+    "azure-service-bus",
+    "service-bus",
+    Reason = "Publishes and consumes workflow messages through Azure Service Bus.",
+    Providers = new[] { "Azure Service Bus" },
+    ConfigurationKeys = new[] { "ConnectionStringOrName" })]
+public class AzureServiceBusShellFeature : IShellFeature
+{
+    // The feature still binds and uses this setting in ConfigureServices.
+}
+```
+
+The first argument is the requirement identifier and the second is its kind.
+The attribute also supports `Optional`, `Reason`, `Capabilities`, `Providers`,
+`ConfigurationKeys`, and `Extensions`. Use the metadata to explain the
+dependency to tooling and operators; it is not a provisioning declaration.
+
+Examples from the release use `database` for Quartz and persistence stores,
+`message-broker` for RabbitMQ and Kafka, and `service-bus` for Azure Service
+Bus. The same logical infrastructure can be declared by multiple features;
+give each requirement an identifier that is stable and meaningful within the
+package.
+
+A generated manifest contains package and feature records. The following
+fragment shows the fields relevant to infrastructure and settings; inspect the
+file produced for your package for the complete schema and inferred metadata:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "package": {
+    "id": "MyCompany.Elsa.Messaging",
+    "version": "1.0.0"
+  },
+  "features": [
+    {
+      "id": "MyCompany.Elsa.Messaging.AzureServiceBus",
+      "settings": [
+        {
+          "name": "ConnectionStringOrName",
+          "required": true,
+          "secret": true,
+          "restartRequired": true
+        }
+      ],
+      "infrastructure": [
+        {
+          "id": "azure-service-bus",
+          "kind": "service-bus",
+          "providers": ["Azure Service Bus"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Describe deploy-time settings
+
+Use `ManifestSetting` on a public, settable feature property when the property
+is a deploy-time setting. The released Azure Service Bus feature marks its
+connection value as required, secret, and restart-sensitive:
+
+```csharp
+[ManifestSetting(
+    DisplayName = "Connection string or name",
+    Description = "Azure Service Bus connection string or configured name.",
+    Category = "Connection",
+    Secret = true,
+    Required = true,
+    HasRequired = true,
+    RestartRequired = true)]
+public string ConnectionStringOrName { get; set; } = string.Empty;
+```
+
+The metadata fields used by the 3.8 generator include:
+
+| Field | Use it for |
+| --- | --- |
+| `DisplayName`, `Description` | Operator-facing labels and help text. |
+| `Category`, `Group` | Organizing related settings. |
+| `Required`, `HasRequired` | Required-setting metadata. |
+| `DefaultValue` | A deployment default. |
+| `Secret`, `Sensitive` | Sensitivity metadata. |
+| `RestartRequired` | The setting takes effect after a restart. |
+| `Advanced`, `Experimental` | Progressive disclosure and release status. |
+| `UIHint` | A consumer-facing hint for choosing an editor or presentation. |
+
+`Secret` and `Sensitive` are manifest hints, not secret storage. Keep
+connection strings, tokens, and passwords in environment variables, a secret
+manager, or another deployment-specific provider. The feature code must still
+bind the value to the configuration section it actually uses.
+
+For a modular host, the manifest setting name is not by itself the full
+configuration path. The host places feature settings under the shell's
+`Settings` object, and the feature selects the section it binds. For example,
+the released MassTransit Azure Service Bus feature binds
+`MassTransitAzureServiceBus:ConnectionStringOrName`, which can be represented
+in the modular host configuration as:
+
+```json
+{
+  "CShells": {
+    "Shells": [
+      {
+        "Name": "Default",
+        "Settings": {
+          "MassTransitAzureServiceBus": {
+            "ConnectionStringOrName": "${ConnectionStrings:Messaging}"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+The package manifest documents the setting; the shell configuration and
+feature binding determine whether the value is actually used. See
+[Standalone and Modular Hosting](../architecture/standalone-and-modular-hosting.md)
+and [Configuration Management](../deployment/configuration-management.md) for
+host-specific configuration shapes.
+
+For example, the released Quartz feature marks scheduler properties as
+restart-required because they affect service registration and lifecycle
+behavior. The manifest does not perform that restart; it communicates the
+operational consequence.
+
+## Build, inspect, and pack
+
+Build the package before packing it, then inspect the generated manifest:
+
+```bash
+dotnet build -c Release
+find obj -name elsa-package.json -print
+dotnet pack -c Release
+unzip -p bin/Release/*.nupkg elsa-package.json
+```
+
+The generator's defaults generate the manifest and include it in the package.
+If a pipeline uses `dotnet pack --no-build`, the manifest must already exist
+under the matching `obj/<configuration>/<target-framework>/` directory. A
+missing manifest causes packing to fail when inclusion is enabled. Use the
+generator's MSBuild properties to change this behavior, including
+`GenerateElsaPackageManifest`, `ElsaPackageManifestOutputPath`, and
+`ElsaPackageManifestIncludeInPackage`.
+
+When metadata cannot be inferred from code, add an `elsa-package.overrides.json`
+file beside the project file and pass it with
+`ElsaPackageManifestOverrideFile`. Treat override data as packaging metadata:
+it does not change the feature's runtime configuration.
+
+## What this means for Studio users
+
+An extension package can be compatible with Elsa Server, contribute activities
+that a Studio user can place on a canvas, or provide a Studio-specific
+feature. These are different concerns. The `elsa.server` hint in the released
+Core and Extensions packages describes the package's runtime compatibility; it
+does not mean that Studio will provision its database or message broker.
+
+For a Studio-facing extension, document the separate Studio host registration,
+activity or UI registration, backend URL, and any required permissions. Verify
+the behavior in the target Studio host rather than assuming that a package
+manifest turns `ManifestSetting` metadata into a designer editor.
+
+## Extension author checklist
+
+- Add the generator as a private build dependency for the package projects that
+  contain CShells features.
+- Declare package- or feature-level runtime compatibility.
+- Add infrastructure metadata where a feature depends on an external resource.
+- Mark only deploy-time properties as manifest settings.
+- Make `ConfigurationKeys` match the names your feature actually reads.
+- Keep sensitive values out of source-controlled JSON and example defaults.
+- Build, inspect `elsa-package.json`, and verify the `.nupkg` contains the file.
+- Document the actual Server and Studio registration paths separately.
+
+For the complete feature implementation behind the examples, see the
+[released Azure Service Bus shell feature](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/servicebus/Elsa.ServiceBus.AzureServiceBus/ShellFeatures/AzureServiceBusShellFeature.cs)
+and [released Quartz shell feature](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/scheduling/Elsa.Scheduling.Quartz/ShellFeatures/QuartzFeature.cs).


### PR DESCRIPTION
## Summary
- add a release-backed guide to Elsa package manifests for CShells extensions
- document runtime compatibility, infrastructure requirements, deploy-time settings, and build/pack inspection
- clarify that manifest metadata does not provision infrastructure or automatically configure Studio
- update navigation, coverage, and the documentation slice plan

## Validation
- targeted Markdownlint for the new guide
- staged diff and local Markdown/link checks
- release/3.8.0 source assertions across Core and Extensions
- HTTP 200 checks for all release source links
- verified Studio release source has no package-manifest consumption references
