### PR TITLE
docs: add secrets management guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -46,6 +46,7 @@
   * [HTTP Endpoint Security](guides/security/http-endpoint-security.md)
   * [External Identity Providers](guides/security/external-identity-providers.md)
   * [Brokered External Authentication](guides/security/brokered-external-authentication.md)
+  * [Secrets Management](guides/security/secrets-management.md)
 * [Deployment](guides/deployment/README.md)
   * [Configuration Management](guides/deployment/configuration-management.md)
   * [Kubernetes Basics](guides/deployment/kubernetes.md)

--- a/activities/parallel-execution.md
+++ b/activities/parallel-execution.md
@@ -317,7 +317,7 @@ To handle errors gracefully, consider:
 
 1. **Wrap risky operations**: Use try-catch patterns in custom activities
 2. **Design for fault tolerance**: Check for errors after the `Parallel` activity completes
-3. **Use incident strategies**: Configure Elsa's [incident handling](../../operate/incidents/README.md) to automatically retry or continue on fault
+3. **Use incident strategies**: Configure Elsa's [incident handling](../operate/incidents/README.md) to automatically retry or continue on fault
 
 ### Performance Considerations
 

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-26)
+## Slice Inventory (2026-07-28)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -65,18 +65,26 @@ acceptance criterion below is already complete.
 - `DOC-061` Workflow definition version lifecycle
 - `DOC-062` Brokered external authentication and Studio administration
 - `DOC-063` Extension package manifests and infrastructure metadata
+- `DOC-064` Secrets management and Studio secret picker
 
 ### Available next slices
 
-- No distinct follow-on slice is currently selected. Re-inventory the source
-  and GitBook before the next run.
+- `DOC-031` Custom icons
+- `DOC-032` Workflow providers
+- `DOC-033` Custom types
+- `DOC-034` DropIns
+- `DOC-035` Webhook extensibility
+- `DOC-036` Activity type providers
+- `DOC-037` Alterations
+- `DOC-044` Community resources
+- `DOC-045` Case studies
+- `DOC-046` FAQ
 
 ### Recommended next slice
 
-`DOC-063` Extension package manifests and infrastructure metadata: explain the
-release extension annotations for runtime kind, infrastructure hints,
-secret/advanced settings, and restart requirements without implying that
-Studio provisions infrastructure automatically.
+`DOC-036` Activity type providers: explain how generated activity descriptors
+are registered, refreshed, surfaced in Studio, and kept executable and stable
+for persisted workflows. This is distinct from custom activity implementation.
 
 ### Current run selection (2026-07-27)
 
@@ -166,8 +174,29 @@ Studio provisions infrastructure automatically.
   the release extension annotations for runtime kind, infrastructure hints,
   secret/advanced settings, and restart requirements without implying that
   Studio provisions infrastructure automatically.
+- `DOC-064` Secrets management and Studio secret picker: document the Core
+  Secrets module, protected references and expressions, lifecycle operations,
+  permissions, and Studio's secret-management and activity-property picker
+  behavior. Clarify that the release's built-in repositories are not a claim
+  of integration with an external vault.
+
+### Current run selection (2026-07-28)
+
+- Selected and completed `DOC-064` Secrets management and Studio secret picker. Release
+  source review found a distinct cross-persona gap: Core exposes versioned
+  secrets, protected references, secret expressions, lifecycle endpoints, and
+  a file/in-memory repository, while Studio exposes a secret-management page
+  and secret picker for activity inputs. The GitBook had no focused guide for
+  using or securing this feature.
+- No further distinct follow-on topic was added during implementation; `DOC-036`
+  Activity type providers is now the recommended next slice.
 
 ### Most recent completed slice
+
+- `DOC-064` Secrets management and Studio secret picker:
+  completed on 2026-07-28 with a release-backed guide for encrypted and
+  configuration-backed stores, secret references and expressions, lifecycle
+  operations, permissions, Studio management, and the secret picker.
 
 - `DOC-063` Extension package manifests and infrastructure metadata:
   completed on 2026-07-27 with a release-backed guide for runtime kind,

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -67,7 +67,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (16 pages)
+### GUIDES (17 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -79,6 +79,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Runtime Coordination Storage** (`guides/architecture/runtime-coordination-storage.md`)
 - **Elsa API Permissions** (`guides/security/permission-reference.md`)
 - **Brokered External Authentication** (`guides/security/brokered-external-authentication.md`)
+- **Secrets Management** (`guides/security/secrets-management.md`)
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)
 - **Using a Trigger** (`guides/running-workflows/using-a-trigger.md`)
@@ -234,7 +235,7 @@ Based on the current structure, the following core concepts are documented:
    - ❌ No workflow testing guide
    - ❌ No data persistence patterns guide
    - ✅ Security guidance now includes endpoint security, external identity
-     providers, and role-oriented permission recipes
+     providers, role-oriented permission recipes, and Elsa Secrets management
    - ❌ No workflow design patterns
 
 ## Documentation Quality Notes

--- a/getting-started/database-configuration.md
+++ b/getting-started/database-configuration.md
@@ -318,4 +318,4 @@ builder.Services.AddDbContext<ManagementDbContext>(options =>
 
 * [Docker Deployment](containers/docker-compose/persistent-database.md)
 * [Authentication Setup](../guides/authentication.md)
-* [Workflow Persistence](../guides/workflow-persistence.md)
+* [Workflow Persistence](../guides/persistence/README.md)

--- a/guides/deployment/configuration-management.md
+++ b/guides/deployment/configuration-management.md
@@ -42,6 +42,12 @@ they do not bind configuration or provision infrastructure. For the
 `elsa-package.json` contract and a modular-shell mapping example, see [Package
 manifests for extensions](../plugins-modules/package-manifests.md).
 
+For named values resolved by workflows, see [Secrets
+management](../security/secrets-management.md). Elsa's configuration-backed
+secret store reads from host configuration; it is distinct from the
+deployment-managed environment variables, user secrets, or external vaults
+that supply those values.
+
 ## The Three Main Host Shapes
 
 ### 1. Standalone Elsa Server (`AddElsa(...)`)

--- a/guides/plugins-modules/package-manifests.md
+++ b/guides/plugins-modules/package-manifests.md
@@ -182,7 +182,10 @@ The metadata fields used by the 3.8 generator include:
 `Secret` and `Sensitive` are manifest hints, not secret storage. Keep
 connection strings, tokens, and passwords in environment variables, a secret
 manager, or another deployment-specific provider. The feature code must still
-bind the value to the configuration section it actually uses.
+bind the value to the configuration section it actually uses. If the value is
+intended to be a named Elsa workflow secret, see the [Secrets management
+guide](../security/secrets-management.md) for the separate runtime feature and
+its Studio picker.
 
 For a modular host, the manifest setting name is not by itself the full
 configuration path. The host places feature settings under the shell's

--- a/guides/security/README.md
+++ b/guides/security/README.md
@@ -343,6 +343,12 @@ Ingress rate limiting is more scalable and protects against DDoS before traffic 
 
 ## Secrets Management
 
+For Elsa's named secret lifecycle, encrypted/configuration-backed stores,
+runtime `Secret` references, and the Studio secret picker, see [Secrets
+Management](secrets-management.md). The general deployment and host-secret
+guidance below remains applicable to identity keys, connection strings, and
+infrastructure-managed secrets.
+
 ### Storing Sensitive Configuration
 
 **Do:**

--- a/guides/security/permission-reference.md
+++ b/guides/security/permission-reference.md
@@ -150,6 +150,10 @@ role. These are the permission values declared by common release modules:
 | Resilience diagnostics | `read:resilience:strategies`, `read:resilience:retries` | `exec:resilience:simulate-response` |
 | Authenticated event trigger | — | `trigger:event` |
 
+For the secret lifecycle, built-in stores, Studio picker, and runtime
+reference contract behind these claims, see the [Secrets management
+guide](secrets-management.md).
+
 Some module endpoints also advertise namespace wildcards such as `read:*` or
 `exec:*`. Check the exact endpoint in the version you deploy before replacing
 named claims with a wildcard.

--- a/guides/security/secrets-management.md
+++ b/guides/security/secrets-management.md
@@ -1,0 +1,269 @@
+---
+description: >-
+  Use Elsa's release-backed Secrets module to store, resolve, rotate, and
+  reference sensitive values from workflows and Elsa Studio.
+---
+
+# Secrets management
+
+Elsa 3.8 includes an optional Secrets module for named values that workflows
+and feature modules can resolve at runtime. It gives you a stable technical
+name, a store and type, lifecycle metadata, and a reference that can be saved
+in a workflow definition without saving the cleartext value there.
+
+Use this guide when you need to decide:
+
+* whether to use an Elsa-managed encrypted value or a value already supplied by
+  application configuration;
+* how to configure the module and its encryption key;
+* how to create, rotate, revoke, and test a secret in Elsa Studio; or
+* how a workflow activity should reference a secret.
+
+This feature is separate from OIDC client secrets, identity signing keys, and
+Kubernetes `Secret` objects. Those are host or infrastructure configuration;
+the module documented here exposes named values to Elsa workflows and modules.
+
+## What the module provides
+
+The Core package exposes the `UseSecrets` module extension. The default service
+registration includes:
+
+* an encrypted store (`encrypted`) for values managed by Elsa;
+* a configuration-backed store (`configuration`) that reads a value from the
+  host configuration without storing that value in Elsa;
+* the `Secret` expression type and runtime resolver; and
+* HTTP endpoints for management and the Studio picker whose returned secret
+  models expose metadata rather than cleartext values.
+
+The paired Studio package adds a **Secrets** page under the settings menu and a
+reusable secret picker for activity inputs. Registering the Studio module does not
+enable the backend feature; the Server and Studio hosts must both have the
+corresponding feature available.
+
+## Configure the Core module
+
+For a standalone `AddElsa(...)` host, enable the module and configure the
+encryption key explicitly:
+
+```csharp
+using Elsa.Extensions;
+
+var encryptionKey = Convert.FromBase64String(
+    builder.Configuration["ELSA_SECRETS_ENCRYPTION_KEY_BASE64"]
+    ?? throw new InvalidOperationException("Missing Elsa secrets encryption key."));
+
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseSecrets(secrets =>
+    {
+        secrets.ConfigureOptions = options =>
+        {
+            options.EncryptionKey = encryptionKey;
+            options.RepositoryFilePath = Path.Combine(
+                builder.Environment.ContentRootPath,
+                "App_Data",
+                "elsa-secrets.json");
+        };
+    });
+});
+```
+
+The release's encrypted store uses AES-GCM and accepts an encryption key of
+exactly 16, 24, or 32 bytes. Keep the key outside source control and keep it
+stable for as long as encrypted values in the repository must remain
+readable. Changing or losing it prevents Elsa from resolving the encrypted
+payloads.
+
+The default repository is a JSON file at:
+
+```text
+<application base directory>/App_Data/elsa-secrets.json
+```
+
+`RepositoryFilePath` changes that location for the default file repository.
+If you configure a different `ISecretRepository`, use that provider's
+persistence and migration instructions instead; the file-path option does not
+configure every persistence provider.
+
+## Choose a store
+
+The release registers two built-in stores. The store is selected when the
+secret is created and cannot be changed by the update endpoint.
+
+* **`encrypted`** stores a protected payload in the Elsa repository and
+  requires the configured encryption key. The Secrets API supports create,
+  rotate, revoke, delete, and test for this store.
+* **`configuration`** stores only the configuration-key metadata. It reads
+  `Elsa:Secrets:<configuration-key>`, then the key itself, and supplies the
+  value from host configuration. The store is read-only from Elsa's
+  perspective.
+
+For example, a configuration-backed secret with configuration key
+`OrdersDatabase` resolves this host configuration:
+
+```json
+{
+  "Elsa": {
+    "Secrets": {
+      "OrdersDatabase": "Host=db;Database=orders;Username=elsa;Password=provided-outside-source-control"
+    }
+  }
+}
+```
+
+The configuration store does not copy that value into the Elsa secrets file or
+database. Use it when deployment infrastructure already owns the secret. Use
+the encrypted store when the value should be managed through Elsa's secret
+lifecycle and the host can protect the encryption key.
+
+The release also exposes `ISecretStore` and `ISecretRepository` extension
+points. The built-in module does not claim to be an integration with Azure Key
+Vault, AWS Secrets Manager, HashiCorp Vault, or another external vault. Add a
+custom store/repository or project the external value into application
+configuration when that is your source of truth.
+
+## Secret identity, types, and lifecycle
+
+### Technical names
+
+The technical name is the reference used by workflows. It is normalized to
+lowercase and must be 2–200 characters long, start with a letter, and contain
+only letters, numbers, dots, dashes, underscores, or colons. The release
+management API lets you edit the display name and description, but it does not
+provide a rename operation. Choose a stable technical name before publishing
+workflows.
+
+The default type providers are:
+
+* `text` for passwords, tokens, and connection strings;
+* `rsa-key` for RSA key material or a configuration reference; and
+* `x509-certificate` for certificate material, a thumbprint, or a
+  configuration reference.
+
+Types constrain which stores can be selected and validate the create/rotate
+payload. A type is metadata about how a value is interpreted; it does not
+make a configuration-backed value writable through Elsa.
+
+### Versions and status
+
+Creating a secret creates version 1. Rotating it creates the next version and
+retires the previously active version. Runtime resolution always selects the
+latest active, non-expired version. Revoking a secret marks the secret and its
+active versions as revoked, so resolution stops. Deleting a secret removes the
+protected payload from the encrypted store and marks the repository record as
+deleted; deleted records are hidden from normal reads.
+
+The API returns metadata such as the current version and expiration time, not
+the cleartext value. A successful **Test** operation means the configured store
+could resolve the latest active version; it does not display the value.
+
+## Reference a secret from a workflow
+
+Store a reference, not a value, in a workflow input or activity property. The
+reference has a required name and optional type and scope:
+
+```json
+{
+  "type": "Secret",
+  "value": {
+    "name": "orders:api-token",
+    "typeName": "text",
+    "scope": "production"
+  }
+}
+```
+
+At runtime, the `Secret` expression handler resolves the reference through
+`ISecretResolver`. It validates the optional type and scope, then resolves the
+latest active version from the selected store. The resolved value is available
+to the activity while it runs; the serialized workflow definition and workflow
+state retain the reference rather than the cleartext value.
+
+In code, create the expression explicitly when an activity input supports
+expressions:
+
+```csharp
+using Elsa.Secrets.Expressions;
+using Elsa.Secrets.Models;
+
+var authorization = SecretExpression.Create(
+    new SecretReference("orders:api-token", SecretTypeNames.Text, "production"));
+```
+
+In Studio, the Secrets module contributes the `Secret` expression descriptor
+with the `secret-picker` UI hint. When an activity input exposes that hint,
+Studio lists compatible active secrets and can create one inline when the
+backend reports a writable store. The picker can be constrained by type, store,
+scope, and whether inline creation is allowed through the input's UI metadata.
+
+## Use the Studio page
+
+After the backend and Studio modules are available, open the **Secrets** page
+at `/security/secrets`. The release UI supports this workflow:
+
+1. Select **Create Secret** and choose a technical name, type, and store.
+2. Enter either a value for the encrypted store or a configuration key for the
+   configuration store.
+3. Open the secret to edit its display name/description, rotate it, test
+   resolution, or revoke it.
+4. Use a compatible activity property in the workflow designer and select the
+   secret from the picker.
+
+The page displays name, type, store, status, current version, scope, and
+expiration metadata. It intentionally does not provide a cleartext reveal
+operation. The Studio module is registered in a custom host with:
+
+```csharp
+builder.Services.AddSecretsModule(backendApiConfig);
+```
+
+The built-in release hosts register this module for Server, WASM, and
+custom-elements Studio hosts. A custom host must also register the matching
+backend API client configuration.
+
+## API and permissions
+
+The route paths below are relative to the Elsa API base path. The endpoint
+classes in the release use these permissions:
+
+| Operation | Permission |
+| --- | --- |
+| List, read, descriptors, and picker | `read:secrets` |
+| Create, update details, rotate, and revoke | `write:secrets` |
+| Test resolution | `test:secrets` |
+| Delete | `delete:secrets` |
+
+The corresponding routes are:
+
+* Read: `GET /secrets`, `GET /secrets/{name}`, `GET /secrets/descriptors`, and
+  `POST /secrets/picker`.
+* Write: `POST /secrets`, `POST /secrets/{name}`,
+  `POST /secrets/{name}/rotate`, and `POST /secrets/{name}/revoke`.
+* Test: `POST /secrets/{name}/test`.
+* Delete: `DELETE /secrets/{name}`.
+
+Grant the smallest set that matches the user or service's job. A workflow
+designer who only needs to select existing secrets needs the read path and
+the appropriate workflow-definition permissions; creating or rotating secrets
+is a separate administrative capability. See [Elsa API Permissions](permission-reference.md)
+for the broader permission model.
+
+## Operational checklist
+
+* Keep the encrypted-store key in a deployment secret manager, not in the
+  repository or a workflow definition.
+* Back up the encrypted repository and its encryption key together. A backup
+  without the key is not a usable backup.
+* Prefer the configuration store when an external deployment system already
+  owns the value and its rotation process.
+* Use scopes such as `production` or `staging` when the same technical name
+  must resolve differently by environment or integration boundary.
+* Rotate before expiry, then verify the new version with **Test** and a safe
+  workflow execution path.
+* Do not log resolved values, include them in activity output, or copy them into
+  ordinary workflow variables unnecessarily.
+
+For OIDC client secrets and other host authentication settings, use the
+[authentication](../authentication.md) and [external identity provider](external-identity-providers.md)
+guides. For deployment-managed Kubernetes or cloud secrets, use the deployment
+guides rather than the Elsa Secrets API.

--- a/guides/studio/expressions.md
+++ b/guides/studio/expressions.md
@@ -308,7 +308,10 @@ Python expressions are executed through Python.NET in Elsa 3.8. Keep them for in
 
 Studio can also surface feature-specific expression types beyond the core set above.
 
-For example, Elsa's secrets feature contributes a `Secret` expression descriptor with its own custom UI instead of a code editor. The general rule is:
+For example, Elsa's secrets feature contributes a `Secret` expression descriptor
+with its own custom UI instead of a code editor. See [Secrets management](../security/secrets-management.md)
+for the store choices, lifecycle, permissions, and runtime reference contract.
+The general rule is:
 
 - if a backend feature registers an expression descriptor and marks it browsable, Studio can show it.
 - if the descriptor provides a custom `UIHint`, Studio renders that custom picker/editor instead of Monaco.

--- a/guides/troubleshooting/examples/logging-config.md
+++ b/guides/troubleshooting/examples/logging-config.md
@@ -242,5 +242,5 @@ This structure is ideal for querying in log aggregation systems:
 
 ## Related Documentation
 
-- [Logging Framework](../../features/logging-framework.md) - Elsa's activity logging
-- [Troubleshooting Guide](README.md) - Main troubleshooting reference
+- [Logging Framework](../../../features/logging-framework.md) - Elsa's activity logging
+- [Troubleshooting Guide](../README.md) - Main troubleshooting reference


### PR DESCRIPTION
## Summary

- add a release-backed Elsa Secrets guide for encrypted and configuration-backed stores
- document secret references, lifecycle operations, permissions, Studio management, and the activity-property picker
- update security, deployment, package-manifest, expression, and coverage navigation
- fix four pre-existing broken local documentation links found during the holistic link review

## Validation

- validated claims against Core and Studio `release/3.8.0`
- `git diff --check`
- targeted markdownlint for the new guide
- repository-wide local-link and fenced-code validation

The extensions checkout was validated at its local `release/3.8.0` commit because the upstream release branch is no longer available.