### PR TITLE
docs: add alteration operations guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -77,6 +77,7 @@
 * [Testing & Debugging Workflows](guides/testing-debugging.md)
 * [Running Workflows](guides/running-workflows/README.md)
   * [Using Elsa Studio](guides/running-workflows/using-elsa-studio.md)
+  * [Altering a Running Workflow Instance](guides/running-workflows/altering-workflow-instances.md)
   * [Using a Trigger](guides/running-workflows/using-a-trigger.md)
   * [Timer and Scheduled Workflows](guides/running-workflows/timer-and-scheduled-workflows.md)
   * [Workflow Definition Version Lifecycle](guides/running-workflows/workflow-definition-lifecycle.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-29)
+## Slice Inventory (2026-07-30)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -67,6 +67,7 @@ acceptance criterion below is already complete.
 - `DOC-063` Extension package manifests and infrastructure metadata
 - `DOC-064` Secrets management and Studio secret picker
 - `DOC-036` Activity type providers
+- `DOC-037` Alterations
 
 ### Available next slices
 
@@ -75,14 +76,30 @@ acceptance criterion below is already complete.
 - `DOC-033` Custom types
 - `DOC-034` DropIns
 - `DOC-035` Webhook extensibility
-- `DOC-037` Alterations
 - `DOC-044` Community resources
 - `DOC-045` Case studies
 - `DOC-046` FAQ
 
 ### Recommended next slice
 
-Re-inventory the release source and GitBook before selecting the next slice.
+Re-inventory the release source and GitBook before selecting the next
+automation slice. The remaining candidates are `DOC-031` through `DOC-035`,
+`DOC-044`, `DOC-045`, and `DOC-046`.
+
+### Current run selection (2026-07-30)
+
+- Selected and completed `DOC-037` Alterations. Added a task-oriented,
+  release-backed guide that connects immediate execution, filtered plans,
+  Studio staging, retry behavior, durability, and custom handlers. Corrected
+  the existing retry reference for the `GET`/`POST` contract and the
+  multi-instance batching caveat in `release/3.8.0`.
+- Core's remote `release/3.8.0` ref advanced from `7e82a55` to `edb5f7c`
+  during review; the alteration implementation paths used here were
+  unchanged. Studio remains at `ef6a39d`, and Extensions has no advertised
+  upstream `release/3.8.0` branch, so its local release snapshot remains
+  pinned to `d407e96`.
+- No additional distinct follow-on topic was identified during the source
+  review; re-inventory before selecting the next slice.
 
 ### Current run selection (2026-07-29)
 
@@ -199,6 +216,11 @@ Re-inventory the release source and GitBook before selecting the next slice.
   Activity type providers is now the recommended next slice.
 
 ### Most recent completed slice
+
+- `DOC-037` Alterations: completed on 2026-07-30 with a release-backed
+  operational guide for execution-mode choice, immediate and planned
+  alterations, Studio staging, retry behavior, durability, and extension
+  boundaries.
 
 - `DOC-036` Activity type providers: completed on 2026-07-29 with a
   release-backed guide covering the provider contract, descriptor registry

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -83,6 +83,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)
 - **Using a Trigger** (`guides/running-workflows/using-a-trigger.md`)
+- **Altering a Running Workflow Instance** (`guides/running-workflows/altering-workflow-instances.md`)
 - **Workflow Definition Version Lifecycle** (`guides/running-workflows/workflow-definition-lifecycle.md`)
 - **Using Elsa Studio** (`guides/running-workflows/using-elsa-studio.md`)
 - **Package Manifests for Extensions** (`guides/plugins-modules/package-manifests.md`)
@@ -184,6 +185,8 @@ Based on the current structure, the following core concepts are documented:
 - ✅ Brokered external authentication and Studio SSO administration
 - ✅ Elsa API permission reference with Studio capability and role templates
 - ✅ Alterations and alteration plans
+- ✅ Release-backed operational guide for immediate alterations, filtered
+  plans, Studio staging, retry behavior, and durability
 - ✅ Log persistence and retention
 - ✅ Logging framework
 

--- a/features/alterations/README.md
+++ b/features/alterations/README.md
@@ -4,6 +4,10 @@ An [alteration](../../getting-started/concepts/#alteration) represents a change 
 
 Using alterations, you can change the state of a running workflow instance without republishing the workflow definition. In `release/3.8.0`, Elsa exposes alterations through server APIs and Elsa Studio.
 
+For the task-oriented path through immediate execution, filtered plans, Studio,
+durability, and retry operations, start with [Alter a Running Workflow
+Instance](../../guides/running-workflows/altering-workflow-instances.md).
+
 ## What Elsa ships in `release/3.8.0`
 
 Enabling `UseAlterations()` adds:
@@ -22,7 +26,7 @@ Use alterations when you need to correct or steer existing workflow instances. T
 * updating a variable on a live instance
 * scheduling an activity so a stalled workflow can continue
 * canceling a workflow or a specific running activity
-* migrating a running instance to a newer published workflow version
+* migrating a running instance to a specific version of the same definition
 
 ## Alteration Types <a href="#alteration-types" id="alteration-types"></a>
 
@@ -32,7 +36,8 @@ Elsa Workflows supports the following alteration types:
 * **CancelActivity**: Cancels a specific running activity instance, or all running instances of an activity ID.
 * **ScheduleActivity**: Schedules an activity for execution by activity ID or activity instance ID.
 * **ModifyVariable**: Modifies a workflow variable by variable ID.
-* **Migrate**: Migrates a workflow instance to a newer published version of the same workflow definition.
+* **Migrate**: Migrates a workflow instance to a specific version of the same
+  workflow definition.
 
 ## Two execution modes
 
@@ -52,7 +57,7 @@ Use these pages for each mode:
 | --- | --- |
 | You already know the exact workflow instance IDs and need the response now | `POST /alterations/run` or `IAlterationRunner` |
 | You need Elsa to find matching workflow instances from filters and process them in the background | alteration plans |
-| You need to retry faulted activities for known workflow instances | `POST /alterations/workflows/retry` |
+| You need to retry faulted activities for known workflow instances | `GET` or `POST /alterations/workflows/retry` |
 | You want designers or operators to stage alterations for one running instance visually and inspect resulting plans later | Elsa Studio alterations module |
 
 ## Elsa Studio

--- a/features/alterations/applying-alterations/rest-api.md
+++ b/features/alterations/applying-alterations/rest-api.md
@@ -73,7 +73,12 @@ After the runner finishes, the endpoint automatically dispatches any successful 
 
 ## Retry faulted activities
 
-`release/3.8.0` also exposes `POST /alterations/workflows/retry` for retrying faulted activities on specified workflow instances.
+`release/3.8.0` exposes `GET` and `POST /alterations/workflows/retry` for
+retrying faulted activities on specified workflow instances. Prefer `POST` for
+operational scripts and send one workflow instance ID per request. The 3.8.0
+handler loops over loaded instances while passing the full request ID
+collection to the runner, which can repeat work and result entries when
+several IDs are batched.
 
 If you omit `activityIds`, Elsa retries all incident activity IDs recorded on each specified workflow instance.
 
@@ -105,4 +110,7 @@ Host: localhost:5001
 }
 ```
 
-The response shape matches `/alterations/run` by returning one result per targeted workflow instance.
+The response shape matches `/alterations/run` for a single targeted workflow
+instance. See [Alter a Running Workflow Instance](../../../guides/running-workflows/altering-workflow-instances.md)
+for the release-specific batching caveat and the choice between immediate
+execution, plans, and Studio.

--- a/guides/running-workflows/README.md
+++ b/guides/running-workflows/README.md
@@ -20,6 +20,8 @@ If you need the release-backed runtime mental model behind these options, see
 If you need to understand how Studio drafts become published versions and
 which definition version an API call selects, see
 [Workflow Definition Version Lifecycle](workflow-definition-lifecycle.md).
+If you need to correct or steer an existing instance, see
+[Alter a Running Workflow Instance](altering-workflow-instances.md).
 
 ## Before you start﻿ <a href="#before-you-start" id="before-you-start"></a>
 

--- a/guides/running-workflows/altering-workflow-instances.md
+++ b/guides/running-workflows/altering-workflow-instances.md
@@ -1,0 +1,280 @@
+---
+description: >-
+  Choose the right Elsa 3.8.0 alteration path, apply changes safely, and
+  monitor the resulting workflow and alteration jobs.
+---
+
+# Alter a running workflow instance
+
+Alterations change the state of an existing workflow instance without changing
+the workflow definition for every instance. They are useful for operational
+corrections, controlled recovery, and migrating a running instance to another
+version of the same definition.
+
+This guide describes the behavior of Elsa `release/3.8.0`. For the individual
+request and extension contracts, see the [Alterations feature reference](../../features/alterations/README.md).
+
+## Choose an execution path
+
+Start with the target-selection and auditability requirements:
+
+- **Known instance IDs:** use `POST /alterations/run` or
+  `IAlterationRunner`. You get one result per requested instance; the HTTP
+  endpoint also resumes successful instances that have scheduled work.
+- **Filtered or auditable changes:** use `POST /alterations/dry-run`, then
+  `POST /alterations/submit`. Elsa creates an asynchronous plan and one job
+  for each matched instance.
+- **One visible instance in Studio:** use **Alterations → Instances**. Studio
+  stages a plan for the selected instance and provides plan/job inspection.
+- **Retrying faulted work:** use `GET` or
+  `POST /alterations/workflows/retry`. Elsa creates `ScheduleActivity`
+  alterations and dispatches the instance.
+
+Use a plan when the target set is defined by runtime state, such as a
+workflow definition, incident state, activity, or time range. Use immediate
+execution when the target set is already known and the caller needs the
+alteration log synchronously.
+
+## Enable the feature
+
+Register the Core Alterations module on the Elsa Server:
+
+```csharp
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseAlterations();
+});
+```
+
+The module registers the five built-in alteration types:
+
+- `ModifyVariable` changes an existing variable by variable ID.
+- `ScheduleActivity` schedules an activity by activity ID or activity-instance ID.
+- `CancelActivity` cancels one or more running activity instances.
+- `Cancel` cancels the workflow instance.
+- `Migrate` loads a specific version of the same workflow definition.
+
+The server endpoints require `run:alterations` for writes and dry runs, and
+`read:alterations` to retrieve a stored plan and its jobs. The Studio module
+also needs to be enabled and connected to the server's Alterations feature.
+
+## Apply a known change immediately
+
+Use `POST /alterations/run` when you already have the workflow instance IDs.
+The request applies the alterations to each requested instance and returns a
+`RunAlterationsResult` containing the instance ID, log, success flag, and
+whether the updated workflow has scheduled work.
+
+For example, the following changes a variable and schedules an activity:
+
+```http
+POST /alterations/run HTTP/1.1
+Host: localhost:5001
+Content-Type: application/json
+
+{
+  "workflowInstanceIds": ["<workflow-instance-id>"],
+  "alterations": [
+    {
+      "type": "ModifyVariable",
+      "variableId": "<variable-id>",
+      "value": "approved"
+    },
+    {
+      "type": "ScheduleActivity",
+      "activityId": "ReviewOrder"
+    }
+  ]
+}
+```
+
+The HTTP endpoint dispatches successful results that contain scheduled work.
+If you call `IAlterationRunner` directly, it only applies and commits the
+state. Call `IAlteredWorkflowDispatcher` yourself when the result has
+scheduled work:
+
+```csharp
+var results = await runner.RunAsync(
+    workflowInstanceIds,
+    alterations,
+    cancellationToken);
+
+await alteredWorkflowDispatcher.DispatchAsync(results, cancellationToken);
+```
+
+An alteration can fail for an individual instance—for example, when a
+variable, activity, or target workflow version does not exist. Inspect the
+result log before treating the operation as complete.
+
+## Use a plan for filtered or auditable changes
+
+Plans are asynchronous. Submission dispatches Elsa's system workflow
+`Elsa.Alterations.ExecuteAlterationPlan`, which stores the plan, finds matching
+instances, creates one alteration job per match, and dispatches those jobs.
+The plan and jobs have separate statuses and logs, so you can distinguish
+"the plan found no targets" from "one targeted instance failed".
+
+For a broad filter, first run a dry run:
+
+```http
+POST /alterations/dry-run HTTP/1.1
+Host: localhost:5001
+Content-Type: application/json
+
+{
+  "definitionIds": ["order-processing"],
+  "statuses": ["Running"],
+  "hasIncidents": true,
+  "isSystem": false
+}
+```
+
+The response contains the workflow instance IDs that the filter would select.
+If the result is correct, submit the same filter with the alterations:
+
+```http
+POST /alterations/submit HTTP/1.1
+Host: localhost:5001
+Content-Type: application/json
+
+{
+  "alterations": [
+    {
+      "type": "ScheduleActivity",
+      "activityId": "ReviewOrder"
+    }
+  ],
+  "filter": {
+    "workflowInstanceIds": ["<confirmed-instance-id>"]
+  }
+}
+```
+
+The submission response contains the plan ID. Retrieve its current plan and
+jobs with:
+
+```http
+GET /alterations/<plan-id> HTTP/1.1
+Host: localhost:5001
+```
+
+An empty match is still a valid plan: Elsa stores the plan, creates no jobs,
+and completes the plan through the no-job path. Use `read:alterations` to
+inspect the plan, job status, timestamps, and per-job log entries.
+
+## Use the Studio workflow
+
+With the server and Studio Alterations modules enabled:
+
+1. Open **Alterations → Instances**. Studio lists running, non-system workflow
+   instances and provides an **Alter** action for each one.
+2. Stage one or more of the five built-in alterations for that instance.
+3. Submit the staged plan.
+4. Open **Alterations → Plans** and select the plan to inspect its status,
+   generated jobs, target instance links, and log entries.
+
+Studio's staging flow is intentionally instance-oriented. It does not replace
+the filter authoring and dry-run workflow for bulk operations; use the server
+API for those operations and Studio's Plans view for follow-up inspection.
+
+## Configure durability and background execution
+
+`UseAlterations()` uses in-memory plan and job stores and an in-memory job
+dispatcher unless you replace them. These defaults are suitable for local
+development, but plan and job records and queued jobs are not durable across a
+process restart.
+
+For durable plan and job records, configure an available persistence provider
+inside `UseAlterations`:
+
+```csharp
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseAlterations(alterations =>
+    {
+        alterations.UseEntityFrameworkCore(ef =>
+            ef.UseSqlServer(connectionString));
+    });
+});
+```
+
+The `elsa-extensions` repository also provides MongoDB persistence and a
+MassTransit alteration-job dispatcher:
+
+```csharp
+elsa.UseAlterations(alterations =>
+{
+    alterations.UseMongoDb();
+    alterations.UseMassTransitDispatcher();
+});
+```
+
+The MassTransit dispatcher changes how generated alteration jobs are sent to a
+consumer. It does not change the synchronous `/alterations/run` path. In a
+multi-node deployment, install the same alteration handlers and workflow
+definition versions on every node that can load or resume the affected
+instances, and use durable stores and broker topology appropriate for the
+failure model.
+
+## Retry faulted activities
+
+Use the retry endpoint when the intent is specifically to retry faulted work.
+If `activityIds` is omitted, Elsa reads the incident activity IDs from each
+target workflow instance. If it is supplied, Elsa schedules only those
+activity IDs.
+
+```http
+POST /alterations/workflows/retry HTTP/1.1
+Host: localhost:5001
+Content-Type: application/json
+
+{
+  "workflowInstanceIds": ["<workflow-instance-id>"],
+  "activityIds": ["CapturePayment"]
+}
+```
+
+In `release/3.8.0`, the endpoint accepts both `GET` and `POST`. Send one
+workflow instance ID per request: the released handler loops over the loaded
+instances but passes the full request ID collection to the alteration runner,
+which can repeat work and result entries when several IDs are batched.
+
+## Add a custom alteration
+
+When the change cannot be expressed with the built-in types, implement
+`IAlteration` and an `IAlterationHandler` (or derive from
+`AlterationHandlerBase<T>`), then register the pair with
+`AddAlteration<T, THandler>()`. The handler runs against the existing workflow
+execution context and must explicitly succeed or fail the operation. See
+[Alteration extensibility](../../features/alterations/applying-alterations/extensibility.md)
+for the implementation contract.
+
+## Operational checklist
+
+- Confirm the target IDs or dry-run filter results before changing state.
+- Use `run:alterations` and `read:alterations` as separate least-privilege
+  capabilities.
+- Test a representative instance before submitting a broad plan.
+- Keep variable IDs, activity IDs, and workflow definition versions stable
+  enough for the persisted instances being operated on.
+- Use durable plan/job storage and a durable job dispatcher when a restart or
+  node failure must not lose alteration work.
+- Review plan status, job status, and log entries; a submitted plan is not the
+  same thing as a successful alteration on every target.
+
+## Release source
+
+This page was checked against the following `release/3.8.0` implementations:
+
+- [Core Alterations feature](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations/Features/AlterationsFeature.cs)
+- [Core immediate execution endpoint](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations/Endpoints/Alterations/Run/Endpoint.cs)
+- [Core alteration runner](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations/Services/DefaultAlterationRunner.cs)
+- [Core alteration-plan scheduler](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations/Services/DefaultAlterationPlanScheduler.cs)
+- [Core alteration-plan workflow](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations/Workflows/ExecuteAlterationPlanWorkflow.cs)
+- [Core retry endpoint](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations/Endpoints/Workflows/Retry/Endpoint.cs)
+- [Core alteration filter](https://github.com/elsa-workflows/elsa-core/blob/edb5f7cd51e1c24a6ccbbe215684661e3d6c1e33/src/modules/Elsa.Alterations.Core/Models/AlterationWorkflowInstanceFilter.cs)
+- [Studio Alterations menu](https://github.com/elsa-workflows/elsa-studio/blob/ef6a39d103d1a76e9f33fd4a37f499c5f02a4bfa/src/modules/Elsa.Studio.Alterations/Menu/AlterationsMenu.cs)
+- [Studio instance list](https://github.com/elsa-workflows/elsa-studio/blob/ef6a39d103d1a76e9f33fd4a37f499c5f02a4bfa/src/modules/Elsa.Studio.Alterations/Pages/Instances/Index.razor)
+- [Studio plan details](https://github.com/elsa-workflows/elsa-studio/blob/ef6a39d103d1a76e9f33fd4a37f499c5f02a4bfa/src/modules/Elsa.Studio.Alterations/Pages/Plans/Details.razor)
+- [Extensions MongoDB alteration persistence](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/persistence/Elsa.Persistence.MongoDb/Modules/Alterations/Extensions.cs)
+- [Extensions MassTransit alteration dispatcher](https://github.com/elsa-workflows/elsa-extensions/blob/d407e9621770a55427ac6c2315bd779da08d5fea/src/modules/alterations/Elsa.Alterations.MassTransit/Extensions/ModuleExtensions.cs)


### PR DESCRIPTION
## Summary

- add a release-backed guide for choosing immediate alterations, filtered plans, Studio staging, retry operations, and durable background execution
- correct the 3.8.0 retry method and batching behavior in the existing reference
- update navigation, coverage, and the daily slice inventory

## Validation

- Core `release/3.8.0` advanced to `edb5f7c`; alteration paths were unchanged
- Studio `release/3.8.0` validated at `ef6a39d`
- Extensions local `release/3.8.0` snapshot validated at `d407e96` because no upstream branch is advertised
- source assertions, local-link checks, balanced-fence checks, targeted Markdownlint, source-link HTTP checks, and `git diff --check` passed
- broad Markdownlint still reports pre-existing style issues in legacy metadata/pages

Automation: daily-documentation-improvement-slice