### PR TITLE
docs: add JavaScript IntelliSense provider guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -87,6 +87,7 @@
   * [Bulk Dispatch Workflows Activity](guides/running-workflows/bulk-dispatch-workflows.md)
 * [Studio User Guide](guides/studio/README.md)
   * [Expressions](guides/studio/expressions.md)
+  * [JavaScript IntelliSense Type Definitions](guides/studio/javascript-type-definition-providers.md)
   * [Customization](guides/studio/customization.md)
   * [Custom UI Components](guides/studio/custom-ui-components.md)
   * [Integration](guides/studio/integration/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-07-31)
+## Slice Inventory (2026-08-01)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -69,6 +69,7 @@ acceptance criterion below is already complete.
 - `DOC-036` Activity type providers
 - `DOC-035` Webhook extensibility
 - `DOC-037` Alterations
+- `DOC-065` JavaScript type-definition providers
 
 ### Available next slices
 
@@ -83,8 +84,25 @@ acceptance criterion below is already complete.
 ### Recommended next slice
 
 Re-inventory the release source and GitBook before selecting the next
-automation slice. The remaining candidates are `DOC-031` through `DOC-034`,
-`DOC-044` through `DOC-046`, and newly discovered `DOC-065`.
+automation slice. The remaining candidates are `DOC-031` through `DOC-034`
+and `DOC-044` through `DOC-046`.
+
+### Current run selection (2026-08-01)
+
+- Selected and completed `DOC-065` JavaScript type-definition providers after
+  re-inventorying the remaining candidates against the GitBook and
+  `release/3.8.0` source. The existing JavaScript and Studio expression pages
+  explained runtime syntax but did not explain how custom TypeScript
+  declarations reach Studio's Monaco editor.
+- Added a focused developer/Studio guide, linked it from the expression
+  documentation, and included release-source references for the Core provider
+  contract, endpoint, and Studio Monaco handler.
+- Core's remote `release/3.8.0` ref advanced from `7e82a55` to `edb5f7c` during
+  review; the cited JavaScript type-definition paths were unchanged. Studio
+  remains at `ef6a39d`, and Extensions has no advertised upstream
+  `release/3.8.0` branch.
+- No additional distinct follow-on topic was found during this source review;
+  re-inventory before selecting the next slice.
 
 ### Current run selection (2026-07-31)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -67,7 +67,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (17 pages)
+### GUIDES (18 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -86,6 +86,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Altering a Running Workflow Instance** (`guides/running-workflows/altering-workflow-instances.md`)
 - **Workflow Definition Version Lifecycle** (`guides/running-workflows/workflow-definition-lifecycle.md`)
 - **Using Elsa Studio** (`guides/running-workflows/using-elsa-studio.md`)
+- **JavaScript IntelliSense Type Definitions** (`guides/studio/javascript-type-definition-providers.md`)
 - **Package Manifests for Extensions** (`guides/plugins-modules/package-manifests.md`)
 
 ### HOSTING (1 pages)
@@ -156,6 +157,7 @@ Based on the current structure, the following core concepts are documented:
 - ✅ Activity pickers (preview)
 - ✅ Localization
 - ✅ Brokered external authentication administration and Server/WASM client setup
+- ✅ JavaScript IntelliSense type-definition providers
 
 ### Hosting & Operations
 - ✅ Distributed hosting
@@ -179,6 +181,7 @@ Based on the current structure, the following core concepts are documented:
   security boundary
 - ✅ Extension package manifests, runtime compatibility, infrastructure hints, and deploy-time settings
 - ✅ Custom resilience strategies and retry-attempt recording
+- ✅ JavaScript IntelliSense type-definition providers
 - ✅ Reusable triggers (preview)
 
 ### Advanced Features

--- a/expressions/javascript.md
+++ b/expressions/javascript.md
@@ -313,3 +313,10 @@ Converts a stream to a base64 string.
 ```javascript
 streamToBase64(value: Stream): string;
 ```
+
+## Extending Studio IntelliSense
+
+If your application adds custom JavaScript functions or types, see
+[JavaScript IntelliSense type definitions](../guides/studio/javascript-type-definition-providers.md)
+for the release-backed provider contracts and the distinction between editor
+declarations and runtime configuration.

--- a/guides/studio/expressions.md
+++ b/guides/studio/expressions.md
@@ -382,3 +382,4 @@ That is normal. `Default` uses the activity's UI hint. Switch the syntax picker 
 
 - [Workflow Instance Variables](../../operate/workflow-instance-variables.md)
 - [Using Elsa Studio](../running-workflows/using-elsa-studio.md)
+- [JavaScript IntelliSense type definitions](javascript-type-definition-providers.md)

--- a/guides/studio/javascript-type-definition-providers.md
+++ b/guides/studio/javascript-type-definition-providers.md
@@ -1,0 +1,193 @@
+---
+description: >-
+  Extend Elsa Studio JavaScript IntelliSense with release-backed TypeScript
+  declarations from the Elsa Server.
+---
+
+# JavaScript IntelliSense type definitions
+
+Use a JavaScript type-definition provider when custom workflow values should
+be discoverable in Elsa Studio's JavaScript editor. The provider supplies
+TypeScript declarations for Monaco IntelliSense; it does not add a runtime
+object, function, variable, or CLR type to the JavaScript engine.
+
+This guide is based on the `release/3.8.0` source code in `elsa-core` and
+`elsa-studio`.
+
+## How the pieces fit together
+
+When a Studio user opens a JavaScript expression editor for an activity input:
+
+1. Studio sends the workflow definition ID, activity type name, and property
+   name to `POST /scripting/javascript/type-definitions/{workflowDefinitionId}`.
+2. Elsa Server resolves the latest workflow graph and asks every registered
+   JavaScript definition provider for declarations.
+3. Core renders the combined result as a TypeScript declaration document and
+   returns it as `application/x-typescript`.
+4. Studio adds the document to Monaco with
+   `javascriptDefaults.addExtraLib`, enabling completion and type information
+   for the open JavaScript editor.
+
+The declaration document is contextual: a provider receives the workflow graph,
+the activity type name, the property name, and a cancellation token. A provider
+can therefore emit declarations for a particular activity input or workflow
+shape, rather than publishing one unconditional global library.
+
+## Choose the right extension point
+
+The JavaScript feature has separate provider contracts:
+
+| Goal | Extension point |
+| --- | --- |
+| Declare a custom type for IntelliSense | `ITypeDefinitionProvider` |
+| Describe a global function | `IFunctionDefinitionProvider` |
+| Describe a global variable | `IVariableDefinitionProvider` |
+| Make a .NET type available at runtime | `JintOptions.RegisterType(...)` |
+
+The first three affect the generated declaration file. `RegisterType` affects
+Jint runtime configuration and is a separate security-sensitive decision. A
+type-definition provider does not make `new Order()` or `order.Total` execute
+successfully by itself; the expression still needs a real runtime value or
+function supplied by the workflow context or JavaScript configuration.
+
+## Add a provider
+
+Reference the JavaScript expressions package and derive from
+`TypeDefinitionProvider`:
+
+```csharp
+using Elsa.Expressions.JavaScript.TypeDefinitions.Abstractions;
+using Elsa.Expressions.JavaScript.TypeDefinitions.Models;
+
+public sealed class OrderIntellisenseProvider : TypeDefinitionProvider
+{
+    protected override IEnumerable<TypeDefinition> GetTypeDefinitions(
+        TypeDefinitionContext context)
+    {
+        if (context.ActivityTypeName != "Acme.SendOrder")
+            yield break;
+
+        yield return new TypeDefinition
+        {
+            DeclarationKeyword = "interface",
+            Name = "Order",
+            Properties =
+            {
+                new PropertyDefinition { Name = "Id", Type = "string" },
+                new PropertyDefinition { Name = "Total", Type = "number" },
+                new PropertyDefinition { Name = "IsPriority", Type = "boolean" }
+            }
+        };
+    }
+}
+```
+
+`DeclarationKeyword` is rendered directly into the TypeScript declaration,
+so use a keyword that produces valid output with the release renderer, such as
+`interface`, `class`, or `enum`. Property `Type` values are TypeScript type
+expressions such as `string`, `number`, `boolean`, or an already-declared
+type. The provider should emit valid, stable names because the generated text
+is inserted directly into Monaco.
+
+The provider can also override the asynchronous method when declarations need
+to be loaded from a service. Honor `context.CancellationToken` for remote or
+expensive work.
+
+## Register the provider
+
+Register the provider in the server's dependency-injection container alongside
+the JavaScript feature:
+
+```csharp
+using Elsa.Extensions;
+using Elsa.Expressions.JavaScript.Extensions;
+
+services.AddElsa(elsa =>
+{
+    elsa.UseJavaScript();
+});
+
+services.AddTypeDefinitionProvider<OrderIntellisenseProvider>();
+```
+
+Core registers the provider as a scoped service and includes all registered
+`ITypeDefinitionProvider` instances when it builds the declaration document.
+Constructor injection is therefore available for providers that need access to
+application services.
+
+## Keep runtime behavior separate
+
+This is the boundary to keep in mind:
+
+```csharp
+// Runtime configuration: changes what Jint can access.
+elsa.UseJavaScript(options => options.RegisterType<Order>());
+
+// Editor configuration: changes what Studio can suggest and type-check.
+services.AddTypeDefinitionProvider<OrderIntellisenseProvider>();
+```
+
+The two registrations can be used together, but neither one replaces the
+other. If a workflow variable is the runtime value, create or bind that
+variable through the normal workflow APIs. If its shape should appear in
+Studio, emit a matching declaration. If a custom global function is available
+at runtime, describe it with an `IFunctionDefinitionProvider` as well.
+
+Do not enable broad CLR access only to make IntelliSense understand a type.
+`AllowClrAccess` is intended for trusted scenarios; editor declarations are
+the safer way to describe a known shape to workflow authors.
+
+## Verify the Studio path
+
+After registering the provider:
+
+1. Enable JavaScript expressions on the Elsa Server.
+2. Ensure the connected Studio host can read the workflow definition.
+3. Open an activity input whose expression syntax is **JavaScript**.
+4. Type the declared type or property name and confirm that Monaco offers the
+   expected completion or type information.
+
+The endpoint requires either `read:*` or the specific
+`read:javascript-type-definitions` permission. A missing permission can look
+like a provider problem because Studio cannot load the declaration library.
+The endpoint resolves the latest workflow graph; a missing workflow
+definition returns an API error instead of a declaration document.
+
+## Troubleshooting
+
+### The type does not appear in completion
+
+Check the following in order:
+
+- The server has `UseJavaScript()` enabled.
+- The provider is registered in the server process connected to Studio.
+- The provider's context filters do not exclude the current activity type.
+- The declaration uses valid TypeScript syntax and identifiers.
+- The Studio client has `read:javascript-type-definitions` or a wildcard
+  permission.
+- The input is using the **JavaScript** expression type, not **Default**,
+  **Liquid**, or a custom UI editor.
+
+### The editor suggests the type but the workflow fails
+
+That is expected when only a declaration was registered. IntelliSense does not
+create runtime values. Bind the value through workflow inputs, variables, or
+activity outputs, or configure the corresponding JavaScript runtime behavior.
+
+### The declaration is stale
+
+Studio requests the declaration document when the JavaScript Monaco editor is
+initialized. Reopen or reinitialize the editor after changing provider output,
+and ensure the server is running the updated provider registration.
+
+## Release source references
+
+This page was checked against `release/3.8.0`:
+
+- Core [`ITypeDefinitionProvider`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Expressions.JavaScript/TypeDefinitions/Contracts/ITypeDefinitionProvider.cs)
+- Core [`TypeDefinitionContext`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Expressions.JavaScript/TypeDefinitions/Models/TypeDefinitionContext.cs)
+- Core [`TypeDefinitionService`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Expressions.JavaScript/TypeDefinitions/Services/TypeDefinitionService.cs)
+- Core [`AddTypeDefinitionProvider`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Expressions.JavaScript/Extensions/DependencyInjectionExtensions.cs)
+- Core [type-definition endpoint](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs)
+- Studio [`TypeDefinitionService`](https://github.com/elsa-workflows/elsa-studio/blob/release/3.8.0/src/framework/Elsa.Studio.Shared/Services/TypeDefinitionService.cs)
+- Studio [`JavaScriptMonacoHandler`](https://github.com/elsa-workflows/elsa-studio/blob/release/3.8.0/src/framework/Elsa.Studio.Shared/Monaco/Handlers/JavaScriptMonacoHandler.cs)


### PR DESCRIPTION
## What changed
- add a release-backed guide for `ITypeDefinitionProvider` and the Studio Monaco loading path
- show provider registration, contextual declarations, runtime/editor boundaries, permissions, and troubleshooting
- link the guide from Studio and JavaScript expression documentation
- reconcile the documentation slice inventory and coverage metadata

## Validation
- checked Core `origin/release/3.8.0` at `edb5f7c`; cited paths were unchanged from the prior local release ref
- checked Studio `release/3.8.0` at `ef6a39d`
- `npx --yes markdownlint-cli2 guides/studio/javascript-type-definition-providers.md`
- `git diff --check`
- verified changed-document local links and all seven release-source links
- asserted provider registration, endpoint permissions, latest workflow graph resolution, provider aggregation, and Monaco `addExtraLib` behavior against release source