### PR TITLE
docs: add custom activity icons guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -103,6 +103,7 @@
 * [Studio User Guide](guides/studio/README.md)
   * [Expressions](guides/studio/expressions.md)
   * [JavaScript IntelliSense Type Definitions](guides/studio/javascript-type-definition-providers.md)
+  * [Custom Activity Icons](guides/extensibility/custom-icons.md)
   * [Customization](guides/studio/customization.md)
   * [Custom UI Components](guides/studio/custom-ui-components.md)
   * [Integration](guides/studio/integration/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-08-01)
+## Slice Inventory (2026-08-03)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -71,10 +71,10 @@ acceptance criterion below is already complete.
 - `DOC-037` Alterations
 - `DOC-065` JavaScript type-definition providers
 - `DOC-066` External Authentication extension authoring
+- `DOC-031` Custom icons
 
 ### Available next slices
 
-- `DOC-031` Custom icons
 - `DOC-032` Workflow providers
 - `DOC-033` Custom types
 - `DOC-034` DropIns
@@ -84,7 +84,25 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-Document `DOC-031`, Custom icons, in the next documentation session.
+Document `DOC-032`, Workflow providers, in the next documentation session.
+
+### Current run selection (2026-08-03)
+
+- Selected `DOC-031` Custom icons after re-inventorying the published
+  `origin/main` contents. The remaining candidates are `DOC-032` through
+  `DOC-034` and `DOC-044` through `DOC-046`; custom activity metadata and
+  Studio customization are documented, but the release-backed icon asset and
+  registration path is not.
+- Initial inventory found no additional distinct slice. Source review confirmed
+  that this topic is a Studio display-settings provider rather than a runtime
+  metadata or package-asset feature.
+- Validation target: `release/3.8.0` in `elsa-core`, `elsa-studio`, and
+  `elsa-extensions`.
+- Presentation target: a concise developer guide with the end-to-end asset
+  path, a minimal registration example, and troubleshooting for missing icons.
+- Completed by adding `guides/extensibility/custom-icons.md`, linking it from
+  Studio customization, custom activities, and `SUMMARY.md`, and validating
+  the provider contract against the release source.
 
 ### Current run selection (2026-08-02)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -131,7 +131,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Introducing Elsa Workflows 3** (`README.md`)
 - **Table of contents** (`SUMMARY.md`)
 
-### STUDIO (8 pages)
+### STUDIO (9 pages)
 
 - **This section displays the available customization options for Elsa Studio.** (`studio/design/README.md`)
 - **Activity Pickers (3.7-preview)** (`studio/design/activity-pickers-3.7-preview.md`)
@@ -141,6 +141,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Content Visualisers (3.6-preview)** (`studio/workflow-editor/content-visualisers-3.6-preview.md`)
 - **Field Extensions** (`studio/workflow-editor/field-extensions.md`)
 - **UI Hints** (`studio/workflow-editor/ui-hints.md`)
+- **Custom Activity Icons** (`guides/extensibility/custom-icons.md`)
 
 ## Key Concepts Documented
 
@@ -169,6 +170,7 @@ Based on the current structure, the following core concepts are documented:
 - ✅ External Authentication administration and Server/WASM client setup
 - ✅ External Authentication server extension contracts and Studio custom editors
 - ✅ JavaScript IntelliSense type-definition providers
+- ✅ Custom activity icons through Studio display-settings providers
 - ✅ External Authentication adapters, policies, matchers, grant sources, and Studio editor extensibility
 
 ### Hosting & Operations

--- a/extensibility/custom-activities.md
+++ b/extensibility/custom-activities.md
@@ -128,6 +128,9 @@ especially useful for custom activities:
 For the built-in hints and how Studio resolves them, see
 [UI Hints](../studio/workflow-editor/ui-hints.md).
 
+To change how a custom activity appears in Studio's picker and designer, see
+[Custom Activity Icons](../guides/extensibility/custom-icons.md).
+
 ## Outputs
 
 You can expose additional outputs by declaring `Output<T>` properties and

--- a/guides/extensibility/custom-icons.md
+++ b/guides/extensibility/custom-icons.md
@@ -1,0 +1,174 @@
+---
+description: >-
+  Add custom activity icons to Elsa Studio with a release-backed display
+  settings provider.
+---
+
+# Custom Activity Icons
+
+Use a custom activity icon when your Elsa Studio users need to recognize a
+domain activity quickly in the activity picker, workflow designer, or runtime
+inspection views. In Elsa `release/3.8.0`, icons are a Studio display concern:
+the Core `ActivityDescriptor` contains activity metadata, but no icon field.
+
+That means the icon provider belongs in the Elsa Studio host (Server, WASM, or
+Custom Elements), not in the Elsa Server runtime. It changes how Studio
+renders an activity; it does not add the activity to the server, change its
+execution behavior, or install an icon asset for other clients.
+
+## How the icon path works
+
+The release implementation has three parts:
+
+1. `IActivityDisplaySettingsProvider.GetSettings()` returns a dictionary keyed
+   by the exact activity `TypeName`.
+2. `ActivityDisplaySettings` supplies an `Icon` string and a `Color` string.
+3. `DefaultActivityDisplaySettingsRegistry` combines all providers and returns
+   the matching settings. Unknown activity types receive Studio's default
+   icon and color.
+
+The registry is used by the activity pickers and by designer and workflow
+instance components. A custom provider therefore updates several Studio
+surfaces at once without changing workflow JSON.
+
+## Add a provider
+
+Create a Studio-side provider in the project or module that owns your Studio
+customization:
+
+```csharp
+using System.Collections.Generic;
+using Elsa.Studio.Workflows.UI.Contracts;
+using Elsa.Studio.Workflows.UI.Models;
+
+public sealed class AcmeActivityDisplaySettingsProvider
+    : IActivityDisplaySettingsProvider
+{
+    private const string InvoiceIcon = """
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path fill="currentColor" d="M4 3h16v18H4z" />
+            <path fill="currentColor" d="M7 7h10v2H7zm0 4h10v2H7zm0 4h6v2H7z" />
+        </svg>
+        """;
+
+    public IDictionary<string, ActivityDisplaySettings> GetSettings() =>
+        new Dictionary<string, ActivityDisplaySettings>
+        {
+            ["Acme.SendInvoice"] = new("#2563eb", InvoiceIcon)
+        };
+}
+```
+
+The key, `Acme.SendInvoice`, must match the activity descriptor's `TypeName`
+exactly. It is not the display name shown to designers. For a CLR activity,
+confirm the value in the descriptors response or in the activity descriptor
+that Studio receives from the server.
+
+The `Icon` value is passed to the Studio components as an icon string. Elsa's
+stock provider uses both `ElsaStudioIcons` and MudBlazor icon constants. An
+inline SVG is useful when you own the artwork, but keep it small and suitable
+for the icon slot. If the SVG should follow the configured activity color,
+use `currentColor` for its `fill` or `stroke`; the tree picker applies the
+activity color to those exact SVG attributes.
+
+## Register it in the Studio host
+
+Register the provider after the workflows module in the Studio host's
+dependency-injection setup. The same pattern applies to Server, WASM, and
+Custom Elements hosts; use the container exposed by that host.
+
+```csharp
+builder.Services.AddWorkflowsModule();
+builder.Services.AddActivityDisplaySettingsProvider<
+    AcmeActivityDisplaySettingsProvider>();
+```
+
+For a WASM host, the equivalent is `services.AddWorkflowsModule()` followed by
+`services.AddActivityDisplaySettingsProvider<...>()`. The generic registration
+adds the provider as a scoped `IActivityDisplaySettingsProvider`.
+
+Do not register this provider only in `elsa-core` or only on the Elsa Server.
+Those processes do not own the Studio display registry. If you deploy more
+than one Studio host, include the provider in each host that should show the
+custom icon.
+
+## Dynamic activity sets
+
+The provider may build its dictionary from the Studio activity registry when a
+family of activities is discovered dynamically. The released Agents extension
+uses this pattern: it selects descriptors whose `RootType` custom property is
+`AgentActivity`, then maps each descriptor's `TypeName` to one shared robot
+icon and color.
+
+Use a dynamic provider only when the set of activity type names really is
+dynamic. For a fixed set of custom activities, a static dictionary is easier
+to review and less sensitive to registry timing.
+
+## Provider precedence and fallback
+
+The release registry evaluates providers in sequence and assigns each returned
+dictionary entry into one combined dictionary. If two providers return the
+same type name, the later assignment wins. Use unique keys or make an override
+intentional; do not depend on incidental registration order.
+
+If no provider returns a matching type name, Studio uses its built-in default
+icon and color. This fallback is useful while a provider is being rolled out,
+but it can also hide a type-name mismatch. When an icon does not appear, check
+the descriptor `TypeName` first.
+
+The registry builds its combined dictionary lazily and caches it for the
+current scope. `IActivityDisplaySettingsRegistry` exposes `MarkStale()` to
+clear that cache, but the release source does not automatically invalidate it
+when an arbitrary provider's backing data changes. Prefer stable startup
+mappings; if your provider is genuinely dynamic, make cache invalidation part
+of the same explicit refresh operation.
+
+## Troubleshooting
+
+### The activity still has the default icon
+
+Check these in order:
+
+1. The provider is registered in the Studio host that the browser is actually
+   using.
+2. The dictionary key exactly matches the activity descriptor `TypeName`,
+   including punctuation and casing.
+3. The provider is included in the deployed Studio module or application.
+4. The icon string is non-empty and is accepted by the Studio icon component.
+5. The browser has loaded the updated Studio deployment rather than a cached
+   application bundle.
+
+### The icon appears in one surface but not another
+
+The activity picker and designer use the same display-settings registry, but
+they render the icon through different components. Verify the SVG markup is
+valid and keep `fill="currentColor"` or `stroke="currentColor"` where the
+activity color should be applied. A library icon constant can avoid SVG
+markup differences between components.
+
+### The activity is missing entirely
+
+An icon provider does not register activities. Confirm the Elsa Server returns
+the activity descriptor and that the activity is browsable. Use the
+[activity type provider guide](activity-type-providers.md) when the activity
+itself is generated dynamically or is not present in the activity picker.
+
+## Related guides
+
+- [Customizing Elsa Studio](../studio/customization.md)
+- [Custom Activities](../../extensibility/custom-activities.md)
+- [Activity Type Providers](activity-type-providers.md)
+
+## Release source
+
+This page was checked against the following `release/3.8.0` implementations:
+
+- [Studio display settings contract](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsProvider.cs)
+- [Studio display settings model](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/UI/Models/ActivityDisplaySettings.cs)
+- [Studio display settings registry contract](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsRegistry.cs)
+- [Studio display settings registry](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultActivityDisplaySettingsRegistry.cs)
+- [Studio provider registration](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs)
+- [Studio tree activity picker](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs)
+- [Studio icon color handling](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs)
+- [Core activity descriptor](https://github.com/elsa-workflows/elsa-core/blob/e59a0f172166efc24244f8fc49d8e8c33f05166b/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs)
+- [Extensions Agents provider example](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Studio.Agents/UI/Providers/DefaultActivityDisplaySettingsProvider.cs)

--- a/guides/studio/README.md
+++ b/guides/studio/README.md
@@ -127,6 +127,7 @@ Explore these guides to learn more about using Elsa Studio effectively:
 
 - **[Expressions](expressions.md)**: Learn how to use JavaScript and C# expressions to reference variables and create dynamic workflows
 - **[Customization](customization.md)**: Understand the main Studio customization seams in release 3.8.0, including host composition, menus, widgets, branding, and editor extensibility
+- **[Custom Activity Icons](../extensibility/custom-icons.md)**: Add Studio-side icons for custom activities
 - **[Custom UI Components](custom-ui-components.md)**: Create custom property editors for activity inputs
 - **[Integration](integration/README.md)**: Integrate Elsa Studio into React, Angular, Blazor, or MVC applications
 - **[Studio Tour & Troubleshooting](../../studio/studio-tour-troubleshooting.md)**: Detailed walkthrough of the Studio interface with troubleshooting tips

--- a/guides/studio/customization.md
+++ b/guides/studio/customization.md
@@ -31,6 +31,7 @@ injection and feature modules.
 | Add app-bar UI | `IAppBarService` from an `IFeature` | `DefaultAppBarService` |
 | Add panels, tabs, or editor widgets | `IWidget` or `IWidgetRegistry` | `DefaultWidgetRegistry` |
 | Change the workflow activity picker | Replace `IActivityPickerComponentProvider` | workflows module plus host override |
+| Add icons for custom activities | `IActivityDisplaySettingsProvider` | `AddActivityDisplaySettingsProvider<T>` |
 | Render a new input editor | Studio `IUIHintHandler` plus backend `UIHint` metadata | `AddDefaultUIHintHandlers`, `ActivityDescriber` |
 | Decorate an existing input editor | `IUIFieldExtensionHandler` | `FieldExtension.razor` |
 
@@ -256,6 +257,9 @@ the stock shell without forking its pages.
 
 Use UI hint handlers and field extensions when the change belongs inside
 the workflow inspector rather than the shell.
+
+For custom activity icons, see
+[Custom Activity Icons](../extensibility/custom-icons.md).
 
 ## Related Guides
 


### PR DESCRIPTION
## Summary
- add a release-backed guide for Studio-side custom activity icons
- document `IActivityDisplaySettingsProvider`, SVG/icon formats, DI registration, fallback and cache behavior
- link the guide from Studio customization, custom activities, and navigation
- update slice inventory and coverage metadata for DOC-031

## Validation
- validated against Core `e59a0f1`, Studio `a067420`, and Extensions `335a264` release/3.8.0 snapshots
- release-source contract assertions passed
- repository local-link and fenced-code checks passed
- all release-source links returned HTTP 200
- `git diff --check` passed

Local Markdownlint, Vale, and Lychee binaries are not installed in this repository; the available GitHub checks remain authoritative.
