### PR TITLE
docs: add DropIns deployment guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -89,6 +89,7 @@
 * [Plugins & Modules](guides/plugins-modules/README.md)
   * [Package Manifests for Extensions](guides/plugins-modules/package-manifests.md)
 * [Extensibility](guides/extensibility/modules-and-plugins.md)
+  * [DropIns](guides/extensibility/dropins.md)
 * [Testing & Debugging Workflows](guides/testing-debugging.md)
 * [Running Workflows](guides/running-workflows/README.md)
   * [Using Elsa Studio](guides/running-workflows/using-elsa-studio.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-08-05)
+## Slice Inventory (2026-08-06)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -75,10 +75,10 @@ acceptance criterion below is already complete.
 - `DOC-032` Workflow providers
 - `DOC-033` Custom types
 - `DOC-043` Hangfire integration
+- `DOC-034` DropIns
 
 ### Available next slices
 
-- `DOC-034` DropIns
 - `DOC-044` Community resources
 - `DOC-045` Case studies
 - `DOC-046` FAQ
@@ -86,7 +86,25 @@ acceptance criterion below is already complete.
 
 ### Recommended next slice
 
-Document `DOC-034`, DropIns, after the current custom-types slice.
+Document `DOC-044`, Community resources, as the next remaining candidate.
+
+### Current run selection (2026-08-06)
+
+- Selected and completed `DOC-034` DropIns after re-inventorying the published
+  `origin/main` contents. The remaining candidates are `DOC-044` through
+  `DOC-046`; `DOC-067` is a newly discovered source-backed
+  AI/Weaver topic reserved for a later run.
+- The current GitBook has no focused guide for the DropIns module. This slice
+  will explain when to use DropIns instead of ordinary package references or
+  explicit module registration, how the release discovers assemblies, and
+  which host and deployment constraints matter.
+- Validation target: the exact remote `origin/release/3.8.0` commits in
+  `elsa-core`, `elsa-studio`, and `elsa-extensions`.
+- Presentation target: a concise developer guide with a minimal DropIn
+  package example, host configuration, discovery lifecycle, and
+  troubleshooting/operational boundaries.
+- Completed by adding `guides/extensibility/dropins.md`, linking it from the
+  extensibility and plugins/modules navigation, and updating coverage metadata.
 
 ### Current run selection (2026-08-05)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -42,12 +42,13 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Liquid** (`expressions/liquid.md`)
 - **Python** (`expressions/python.md`)
 
-### EXTENSIBILITY (5 pages)
+### EXTENSIBILITY (6 pages)
 
 - **This topic covers extending Elsa with your own custom activities.** (`extensibility/custom-activities.md`)
 - **Registering Custom Types** (`guides/extensibility/custom-types.md`)
 - **Add custom Polly-based resilience strategies and retry diagnostics to Elsa 3.8.0 workflows.** (`guides/extensibility/custom-resilience-strategies.md`)
 - **Workflow Providers** (`guides/extensibility/workflow-providers.md`)
+- **DropIns** (`guides/extensibility/dropins.md`)
 - **>-** (`extensibility/reusable-triggers-3.5-preview.md`)
 
 ### FEATURES (7 pages)
@@ -197,6 +198,7 @@ Based on the current structure, the following core concepts are documented:
 - ✅ Workflow providers for code-first, external, and file-backed definitions
 - ✅ Custom CLR type registration and Studio integration
 - ✅ Activity type providers and descriptor refresh
+- ✅ Server-side DropIns packaging, discovery, lifecycle, and deployment boundaries
 - ✅ Inbound webhook event activities, outbound webhook sinks, and the endpoint
   security boundary
 - ✅ Extension package manifests, runtime compatibility, infrastructure hints, and deploy-time settings

--- a/docs/meta/target-ia.yaml
+++ b/docs/meta/target-ia.yaml
@@ -412,7 +412,7 @@ sections:
       - id: dropins
         title: DropIns Module
         path: /docs/extensibility/dropins.md
-        status: missing
+        status: covered
         priority: low
         notes: "Issue #31"
       

--- a/guides/extensibility/dropins.md
+++ b/guides/extensibility/dropins.md
@@ -1,0 +1,216 @@
+---
+description: >-
+  Package and discover server-side Elsa extensions from a DropIns directory in
+  Elsa 3.8.0.
+---
+
+# DropIns
+
+The DropIns module lets an Elsa Server load extension assemblies or NuGet
+packages from a directory at runtime. Use it when the host should discover
+trusted extension artifacts without adding each extension as a compile-time
+project reference.
+
+DropIns is a server-side deployment mechanism. It does not install NuGet
+dependencies, expose a package feed, or add a client-side Elsa Studio plugin.
+If an extension also needs an activity catalog, variable type, API endpoint, or
+Studio editor, configure those surfaces separately on the server and in Studio.
+
+## When to use DropIns
+
+Choose the extension path that matches the deployment model:
+
+| Need | Prefer |
+| --- | --- |
+| Fixed build-time extension | Normal package reference and `Use...`/`Add...` registration |
+| Independent trusted artifact | DropIns |
+| Studio-only visual customization | [Studio customization](../studio/customization.md) |
+| Activity catalog contribution | [Activity type providers](activity-type-providers.md) |
+
+DropIns are most useful for controlled server deployments. Every assembly or
+package under the configured directory is inspected and may execute code, so
+do not point the directory at an upload location or an untrusted shared path.
+
+## Enable DropIns in the host
+
+Reference `Elsa.DropIns` from the server host and call `InstallDropIns` while
+configuring Elsa. The release workbench uses an `App_Data/DropIns` directory;
+an application can choose another location.
+
+```csharp
+using Elsa.DropIns.Extensions;
+using Elsa.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddElsa(elsa => elsa
+    .InstallDropIns(options =>
+    {
+        options.DropInRootDirectory = Path.Combine(
+            builder.Environment.ContentRootPath,
+            "App_Data",
+            "DropIns");
+    }));
+```
+
+`DropInRootDirectory` is a required operational setting. The monitor creates
+the directory if it does not exist, but the host must still provide a usable
+path. In a container, mount or copy the directory into every server replica
+that is expected to load the same extensions.
+
+## Author a DropIn
+
+Reference `Elsa.DropIns.Core` from the extension project. Implement
+`IDropIn` with a public parameterless constructor:
+
+```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.DropIns.Core;
+using Elsa.Features.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+public sealed class AcmeDropIn : IDropIn
+{
+    public void Install(IModule module)
+    {
+        // This runs while Elsa is building its module configuration.
+        module.Services.AddSingleton<AcmeGreetingService>();
+    }
+
+    public ValueTask ConfigureAsync(
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken)
+    {
+        // This runs after the host service provider is available.
+        return ValueTask.CompletedTask;
+    }
+
+    public void Unconfigure(IServiceProvider serviceProvider)
+    {
+        // Release resources owned by this DropIn when its artifact is deleted.
+    }
+}
+
+public sealed class AcmeGreetingService
+{
+}
+```
+
+The three methods have different responsibilities:
+
+- `Install(IModule)` registers services or configures Elsa features. It runs
+  during `InstallDropIns`, before the application service provider is built.
+- `ConfigureAsync(...)` performs initialization that needs the application
+  service provider. It is called for each discovered DropIn during the
+  monitor's initial scan and when a watched path changes.
+- `Unconfigure(...)` releases resources when the monitor processes a deleted
+  artifact. It is not a general rollback mechanism for registrations made by
+  `Install`.
+
+The loader finds exported, non-abstract, non-interface implementations of
+`IDropIn` and creates them with `Activator.CreateInstance`. Keep the DropIn
+constructor parameterless and put dependency resolution in the lifecycle
+methods instead.
+
+## Deploy an artifact
+
+The directory catalog recursively scans the configured root for both `.dll`
+and `.nupkg` files.
+
+### Deploy assemblies
+
+Copy the DropIn assembly and its dependencies into an isolated subdirectory:
+
+```text
+App_Data/
+  DropIns/
+    Acme/
+      Acme.Elsa.DropIn.dll
+      Acme.Dependency.dll
+```
+
+The directory loader uses an assembly dependency resolver for the assembly
+path. Keep the DropIn's dependency set together and avoid copying the whole
+host's publish directory into the DropIns directory: every DLL below the root
+is inspected for `IDropIn` implementations.
+
+### Deploy NuGet packages
+
+Copy a `.nupkg` into the root or a subdirectory:
+
+```text
+App_Data/
+  DropIns/
+    Acme/
+      Acme.Elsa.DropIn.<version>.nupkg
+```
+
+The release loader reads every DLL in the package archive and searches the
+loaded assemblies for `IDropIn` implementations. This is not package restore:
+the package must already contain the assemblies the DropIn needs, and the
+artifact must be trusted before it is copied into the directory.
+
+Use an `Elsa.DropIns.Core` package version compatible with the server's Elsa
+release. The DropIn is loaded into a separate assembly load context, but its
+contract types still need to resolve to the host-compatible Elsa assemblies.
+
+## Understand the lifecycle
+
+`InstallDropIns` performs two related actions:
+
+1. It scans the root immediately and calls `Install` on each discovered
+   DropIn, allowing the DropIn to contribute to the `IModule`.
+2. It registers `DropInDirectoryMonitorHostedService`, which creates the root
+   directory if necessary, performs an initial scan, and calls
+   `ConfigureAsync` with the real application service provider.
+
+The monitor uses a `FileSystemWatcher` recursively. In the 3.8.0 source it
+handles `Changed` and `Deleted` events, debounced by two seconds. When the
+monitor has recorded instances for a deleted event path, those instances
+receive `Unconfigure`. The initial scan is keyed differently in the release
+implementation, so deletion is not a reliable rollback for every initially
+loaded artifact. A changed artifact is scanned and configured again; the
+module does not provide a transactional replacement operation.
+
+Treat replacement as a deployment operation with a health check and, when
+necessary, a restart. Do not assume that changing a file atomically adds a new
+DropIn, rolls back service registrations, or unloads all assembly memory. The
+release source calls `Unconfigure` for deletion but does not expose a public
+assembly-unload or rollback contract.
+
+## Troubleshoot loading
+
+Check these boundaries in order:
+
+1. Confirm the server calls `InstallDropIns` and that
+   `DropInRootDirectory` resolves to the directory you populated.
+2. Confirm the artifact extension is `.dll` or `.nupkg` and that it is below
+   the root, including any required dependencies.
+3. Confirm the DropIn type is public, concrete, implements `IDropIn`, and has
+   a public parameterless constructor.
+4. Check startup and hosted-service logs. `Install` runs during module setup;
+   `ConfigureAsync` and monitor errors occur at a different lifecycle stage.
+5. If a changed artifact behaves unpredictably, remove it only after the
+   extension has released external resources, then restart the host to obtain
+   a clean module and assembly state.
+
+DropIns do not automatically update Studio. After a server extension is
+loaded, Studio can use only the capabilities the server exposes through its
+normal APIs and the Studio packages/configuration you have installed. For
+reusable server modules, start with [Modules and Plugins](modules-and-plugins.md),
+then use the focused guides for [custom activities](../../extensibility/custom-activities.md),
+[activity type providers](activity-type-providers.md), and
+[custom types](custom-types.md).
+
+## Release source
+
+The behavior described here is implemented in the
+[release/3.8.0 DropIns source directory][dropins-source].
+Key files include `Elsa.DropIns.Core/IDropIn.cs`,
+`Elsa.DropIns/Extensions/ModuleExtensions.cs`,
+`Elsa.DropIns/Catalogs/DirectoryDropInCatalog.cs`, and
+`Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs`.
+
+[dropins-source]: https://github.com/elsa-workflows/elsa-extensions/tree/release/3.8.0/src/modules/dropins

--- a/guides/extensibility/modules-and-plugins.md
+++ b/guides/extensibility/modules-and-plugins.md
@@ -598,6 +598,8 @@ builder.Services.AddElsa(elsa => elsa
 
 ## Further Reading
 
+- [DropIns](dropins.md) for independently deployed server-side extension
+  assemblies and packages.
 - **[Custom Activities](../../extensibility/custom-activities.md)** - Detailed guide on creating activities
 - **[Plugins & Modules](../plugins-modules/README.md)** - Extended guide with more examples
 - **[Architecture Overview](../architecture/README.md)** - Understanding Elsa's architecture

--- a/guides/plugins-modules/README.md
+++ b/guides/plugins-modules/README.md
@@ -21,6 +21,11 @@ This architecture enables you to:
 - Maintain clean separation of concerns in large applications
 - Configure complex functionality through simple, fluent APIs
 
+For independently deployed, server-side extension artifacts, see the
+[DropIns guide](../extensibility/dropins.md). DropIns are discovered from a
+trusted directory and have a distinct install/configure lifecycle; they are not
+the same as normal compile-time module registration.
+
 ## Table of Contents
 
 - [Key Concepts](#key-concepts)
@@ -38,6 +43,7 @@ This architecture enables you to:
   - [Registering Activities](#registering-activities)
 - [Packaging & Distribution](#packaging--distribution)
   - [Package manifests for extensions](package-manifests.md)
+- [Runtime DropIns](../extensibility/dropins.md)
 - [Advanced Topics](#advanced-topics)
 - [Complete Examples](#complete-examples)
 


### PR DESCRIPTION
## Summary
- add a release-backed DropIns guide for server-side assembly and NuGet package discovery
- document the IDropIn lifecycle, directory layout, compatibility, watcher limits, and Studio boundary
- update navigation, coverage, slice inventory, and target IA metadata

## Validation
- release/3.8.0 source assertions for Core/Extensions/Studio boundaries
- local Markdown link, SUMMARY target, fence-balance, and diff checks
- release source links return HTTP 200
