### PR TITLE
docs: add adoption evidence and case studies guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -113,6 +113,7 @@
 * [Workflow Patterns](guides/patterns/README.md)
 * [Troubleshooting](guides/troubleshooting/README.md)
 * [Community & Resources](guides/community-resources.md)
+* [Adoption Evidence and Case Studies](guides/case-studies.md)
 
 ## Activities
 

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-08-07)
+## Slice Inventory (2026-08-08)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -77,16 +77,41 @@ acceptance criterion below is already complete.
 - `DOC-043` Hangfire integration
 - `DOC-034` DropIns
 - `DOC-044` Community resources
+- `DOC-045` Adoption evidence and case studies
 
 ### Available next slices
 
-- `DOC-045` Case studies
 - `DOC-046` FAQ
 - `DOC-067` Weaver and AI workflow assistance
 
 ### Recommended next slice
 
-Document `DOC-045`, Case studies, as the next remaining candidate.
+Document `DOC-046`, FAQ, as the next remaining candidate. `DOC-067` remains
+available as a source-backed follow-on for a later run.
+
+### Current run plan (2026-08-08)
+
+- Selected `DOC-045` Case studies after re-inventorying the published
+  `origin/main` contents. The remaining candidates are `DOC-046` FAQ and the
+  source-backed `DOC-067` Weaver and AI workflow assistance topic.
+- Add a concise case-studies and adoption-evidence guide that distinguishes
+  named public references, official sample applications, and generic Elsa
+  architecture patterns. Link each claim to its public source and give
+  architects a decision-oriented way to evaluate fit without treating samples
+  as production customer references.
+- Validation target: `origin/release/3.8.0` in `elsa-core`, `elsa-studio`, and
+  `elsa-extensions` for any runtime, Studio, package, and deployment claims;
+  the originating GitHub issue and linked public evidence for adoption claims.
+- Presentation target: a compact evidence table followed by scenario cards and
+  an evaluation checklist for CTOs, architects, integrators, designers, and
+  domain specialists.
+- No additional distinct topic was discovered during the inventory; `DOC-067`
+  remains tracked for a later source-backed run.
+- Completed by adding `guides/case-studies.md`, linking it from `SUMMARY.md`,
+  and updating the coverage inventory. Because no named production customer
+  evidence is published in the current official documentation, the guide
+  labels the anonymous ERP discussion and release reference hosts accurately
+  instead of presenting them as customer case studies.
 
 ### Current run plan (2026-08-07)
 
@@ -370,6 +395,12 @@ Document `DOC-045`, Case studies, as the next remaining candidate.
   Activity type providers is now the recommended next slice.
 
 ### Most recent completed slice
+
+- `DOC-045` Adoption evidence and case studies: completed on 2026-08-08 with
+  an evidence-first guide that distinguishes named public references,
+  anonymous architecture descriptions, official reference hosts, and
+  generic adoption patterns. It also adds a permission-aware contribution
+  template for future named case studies.
 
 - `DOC-035` Webhook extensibility: completed on 2026-07-31 with a
   release-backed guide for inbound event sources, generated trigger

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -78,7 +78,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (25 pages)
+### GUIDES (26 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -104,6 +104,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **JavaScript IntelliSense Type Definitions** (`guides/studio/javascript-type-definition-providers.md`)
 - **Package Manifests for Extensions** (`guides/plugins-modules/package-manifests.md`)
 - **Community & Resources** (`guides/community-resources.md`)
+- **Adoption Evidence and Case Studies** (`guides/case-studies.md`)
 
 ### HOSTING (1 pages)
 
@@ -211,6 +212,8 @@ Based on the current structure, the following core concepts are documented:
 
 - ✅ Official documentation, repositories, samples, support-channel routing,
   release checking, and contribution guidance
+- ✅ Public adoption evidence boundaries, reference architectures, and a
+  permission-aware case-study contribution template
 
 ### Advanced Features
 

--- a/guides/case-studies.md
+++ b/guides/case-studies.md
@@ -1,0 +1,173 @@
+---
+description: Adoption evidence, reference architectures, and case-study guidance for Elsa Workflows.
+---
+
+# Adoption evidence and case studies
+
+This page helps teams evaluate Elsa using evidence that can be checked. It
+also explains the difference between a public customer reference, an official
+sample, and an architecture pattern that you can adapt.
+
+## What is publicly verifiable?
+
+The original request for this page asks for named organizations using Elsa in
+production ([issue #82](https://github.com/elsa-workflows/elsa-gitbook/issues/82)).
+The documentation does not currently maintain a verified, named customer
+list. Do not treat an anonymous community description or an Elsa sample as a
+customer reference.
+
+| Evidence | What it demonstrates | How to use it |
+| --- | --- | --- |
+| [Anonymous ERP and portal architecture](https://github.com/elsa-workflows/elsa-core/discussions/1002) | A publicly described design with an ASP.NET Core workflow server, portal-facing API controllers, approval signals, and correlation IDs. | Use it as a historical architecture pattern, not as a named customer reference or a claim about a current Elsa release. |
+| [Core reference server](https://github.com/elsa-workflows/elsa-core/tree/release/3.8.0/src/apps/Elsa.Server.Web) | A server host that manages and executes workflows through Elsa services, persistence, runtime, and API modules. | Use it to understand a self-hosted workflow-server baseline. It is reference code, not proof of production readiness by itself. |
+| [Core Docker reference app](https://github.com/elsa-workflows/elsa-core/blob/5429008d98a56afd29b4fd11107f7760710b1a64/README.md#try-with-docker) | A combined Elsa Server + Studio development path. | Use it for evaluation and local exploration. The release README explicitly says the reference image is not intended for production use. |
+| [Elsa Studio hosts](https://github.com/elsa-workflows/elsa-studio/tree/release/3.8.0/src/hosts) | Server-side and WebAssembly Studio hosts that connect to a remote Elsa backend and register workflow/dashboard modules. | Use the host model that fits your deployment and security boundary; validate authentication and backend configuration separately. |
+
+If your organization is using Elsa in production, a public case study should
+be added only with the organization's permission. A name without a published
+source is not enough evidence for this page.
+
+## Scenario 1: Existing business application with a workflow service
+
+This pattern fits an ERP, portal, or line-of-business application that owns
+business data while Elsa owns workflow execution.
+
+```mermaid
+flowchart LR
+    UI["Business application"] --> API["Workflow service API"]
+    API["Workflow service API"] --> Elsa["Elsa runtime"]
+    Elsa["Elsa runtime"] --> Store[("Workflow persistence")]
+    Elsa["Elsa runtime"] --> External["Email, HTTP, messaging, or domain services"]
+    External --> API
+```
+
+The public ERP discussion describes this shape: application controllers start
+and resume workflows, and an external business identifier is used to correlate
+signals with the waiting workflow. The release source provides the corresponding
+building blocks: the [reference server host](https://github.com/elsa-workflows/elsa-core/blob/5429008d98a56afd29b4fd11107f7760710b1a64/src/apps/Elsa.Server.Web/Program.cs)
+enables workflow management, workflow runtime, and the workflows API.
+
+Choose this pattern when:
+
+- the existing application must remain the system of record for domain data;
+- domain specialists need to change approval or routing logic without
+  redeploying the whole business application; and
+- the workflow service needs an explicit API boundary for starting, resuming,
+  and inspecting workflow instances.
+
+Before adopting it, decide which system owns authorization, tenant resolution,
+correlation identifiers, retries, and audit records. Elsa workflow state does
+not replace the business application's transactional data.
+
+Useful next reads:
+
+- [Hosting Elsa in an existing app](onboarding/hosting-elsa-in-existing-app.md)
+- [External application interaction](external-application-interaction.md)
+- [Using a trigger](running-workflows/using-a-trigger.md)
+- [Workflow state and journal investigation](../operate/workflow-state-and-journal.md)
+
+## Scenario 2: Standalone workflow server with Studio
+
+This pattern separates workflow authoring and operations from the application
+that invokes workflows. It is a good fit when a platform team owns workflow
+infrastructure and several applications consume the same workflow API.
+
+In the Elsa 3.8.0 [reference server](https://github.com/elsa-workflows/elsa-core/blob/5429008d98a56afd29b4fd11107f7760710b1a64/src/apps/Elsa.Server.Web/Program.cs),
+`AddElsa(...)` composes the workflow services, `UseWorkflowManagement(...)`
+and `UseWorkflowRuntime(...)` configure the management and execution layers,
+and `UseWorkflowsApi(...)` exposes the workflow API. Elsa Studio's [server
+host](https://github.com/elsa-workflows/elsa-studio/blob/5941a7f6e6cd3df9deda8f45313d4332bdc55429/src/hosts/Elsa.Studio.Host.Server/Program.cs)
+and [WebAssembly host](https://github.com/elsa-workflows/elsa-studio/blob/5941a7f6e6cd3df9deda8f45313d4332bdc55429/src/hosts/Elsa.Studio.Host.Wasm/Program.cs)
+use `AddRemoteBackend(...)` and register the workflow and dashboard modules,
+so Studio communicates with a backend rather than embedding workflow state in
+the browser.
+
+This separation gives different personas a clear boundary:
+
+- **Process designers** work in Studio with published workflow definitions.
+- **Domain specialists** review the workflow behavior and business rules
+  without owning the host deployment.
+- **Technical users** integrate applications with the API and configure
+  persistence, authentication, scheduling, and observability.
+- **CTOs and architects** can scale or secure the workflow service separately
+  from the applications that call it.
+
+Do not infer production readiness from the Docker quickstart. Use it to learn
+the product, then apply the [deployment](deployment/README.md),
+[persistence](persistence/README.md), [security](security/README.md), and
+[clustering](clustering/README.md) guidance for a real environment.
+
+Useful next reads:
+
+- [Elsa Server](../application-types/elsa-server.md)
+- [Elsa Studio](../application-types/elsa-studio.md)
+- [Using Elsa Studio](running-workflows/using-elsa-studio.md)
+- [Monitoring and observability](../operate/monitoring-observability.md)
+
+## Scenario 3: Elsa as a capability inside a modular platform
+
+Elsa can also be one capability in a larger ASP.NET Core platform. The
+release repositories show this through modular hosts and Studio modules: the
+host composes only the features it needs, while Studio modules add focused
+management, workflow, dashboard, authentication, and integration behavior.
+
+This pattern fits a platform team that wants to offer workflow as one part of
+a broader product. Keep the boundaries explicit:
+
+- package and register server capabilities in the host that executes them;
+- expose only the APIs and activities that the platform intends to support;
+- keep Studio's backend connection and authentication configuration aligned
+  with the host; and
+- treat extension packages as versioned dependencies, not as a substitute for
+  an application architecture.
+
+Start with [plugins and modules](plugins-modules/README.md), then review the
+[Studio integration guides](studio/README.md) and the [extension package
+manifest guide](plugins-modules/package-manifests.md).
+
+## How to evaluate fit
+
+Use these questions in an architecture review:
+
+1. **Ownership:** Which application owns domain data, and which service owns
+   workflow state and execution?
+2. **Authoring:** Who publishes definitions, and which activities and
+   expressions are trusted in a production workflow?
+3. **Interaction:** Do external systems start or resume workflows through HTTP,
+   messages, timers, or another trigger?
+4. **Durability:** Which persistence provider, retry strategy, incident
+   strategy, and recovery procedure apply to waiting or faulted instances?
+5. **Operations:** Who can inspect instances, journal entries, variables, and
+   logs, and how are sensitive values protected?
+6. **Deployment:** Is Studio server-side, WebAssembly, embedded, or a separate
+   application? Which authentication boundary protects its backend calls?
+7. **Evidence:** Is the proposed reference a named customer story, a public
+   but anonymous description, an official sample, or only a design hypothesis?
+
+## Contributing a case study
+
+To propose a named case study, open a documentation pull request with:
+
+- the organization's name and permission to publish it;
+- the business problem and workflow scope;
+- the Elsa version and relevant packages;
+- the deployment topology, persistence, and external integrations;
+- the roles of Studio users and operators;
+- measurable outcomes, if the organization approves sharing them; and
+- a public source or an approver who can verify the claim.
+
+Until that evidence is available, keep the description anonymous and label it
+as an architecture pattern.
+
+## Release boundary
+
+The runtime and host statements on this page were checked against the
+`release/3.8.0` repositories on 2026-08-08:
+
+- [Elsa Core](https://github.com/elsa-workflows/elsa-core/tree/5429008d98a56afd29b4fd11107f7760710b1a64)
+- [Elsa Studio](https://github.com/elsa-workflows/elsa-studio/tree/5941a7f6e6cd3df9deda8f45313d4332bdc55429)
+- [Elsa Extensions](https://github.com/elsa-workflows/elsa-extensions/tree/335a26495318f6ee1528bf2723b7333c753ce9a2)
+
+The named-adoption question is separate from runtime behavior: the release
+source can validate what Elsa supports, but it cannot prove that an unnamed
+organization deploys it in production.


### PR DESCRIPTION
## Summary
- add an evidence-first adoption and case-studies guide
- distinguish named customer references, anonymous public architecture, and official reference hosts
- update navigation, coverage, and the documentation slice plan

## Validation
- grounded runtime and host claims in release/3.8.0 Core and Studio source
- targeted markdownlint passes for the new guide and navigation
- git diff --check and local/external link checks pass
- pre-existing metadata lint findings remain outside the new guide

Latest release refs checked: Core 5429008d, Studio 5941a7f6, Extensions 335a2649.