### PR TITLE
docs: add Elasticsearch persistence guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -80,6 +80,7 @@
   * [EF Core Setup](guides/persistence/examples/efcore-setup.md)
   * [MongoDB Setup](guides/persistence/examples/mongodb-setup.md)
   * [Dapper Setup](guides/persistence/examples/dapper-setup.md)
+  * [Elasticsearch Setup](guides/persistence/examples/elasticsearch-setup.md)
   * [Indexing Notes](guides/persistence/examples/indexing-notes.md)
 * [HTTP Workflows](guides/http-workflows/README.md)
   * [Tutorial](guides/http-workflows/tutorial.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-08-11)
+## Slice Inventory (2026-08-14)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -81,15 +81,77 @@ acceptance criterion below is already complete.
 - `DOC-046` FAQ
 - `DOC-067` Weaver and AI workflow assistance
 - `DOC-068` Workflow-definition labels
+- `DOC-069` Elasticsearch persistence provider
 
 ### Available next slices
 
-No named slices remain from the current inventory.
+- `DOC-070` Runtime Agents activities and Studio administration
 
 ### Recommended next slice
 
-Re-inventory the documentation and release source on the next run. No
-additional distinct topic was confirmed beyond the completed `DOC-068` slice.
+`DOC-070` Runtime Agents activities and Studio administration. The release
+extension contains runtime agent activities, provider and skill APIs, agent
+persistence options, and an optional Studio administration module; this is
+separate from the Core/Weaver guidance in `DOC-067`.
+
+### Newly discovered slices
+
+- `DOC-069` Elasticsearch persistence provider — `elsa-extensions`
+  `release/3.8.0` contains `Elsa.Persistence.Elasticsearch`, including
+  `UseElasticsearch`, configurable endpoint/authentication/index naming, a
+  workflow-instance store, and an execution-log store. The source also leaves
+  important boundaries that the guide must state: not every runtime/management
+  store is replaced, several workflow-instance filters are TODO, and the
+  release source has no caller for the optional index-configuration hook.
+- `DOC-070` Runtime Agents activities and Studio administration —
+  `elsa-extensions` release `3.8.0` contains `Elsa.Agents.*` runtime activities,
+  provider registration, agent/skill APIs, persistence options, and
+  `Elsa.Studio.Agents`. This is distinct from the Core/Weaver guide in
+  `DOC-067`; validate the compiled contracts rather than the extension README
+  examples, which contain claims not present in the release source.
+
+### Current run plan (2026-08-14)
+
+- Select and complete `DOC-069` Elasticsearch persistence provider from the
+  fresh `origin/main` worktree.
+- Add a concise setup and decision guide covering packages, endpoint and
+  authentication configuration, management/runtime registration, index naming,
+  supported stores, deployment/index lifecycle, limitations, and
+  troubleshooting.
+- Update persistence navigation, provider comparison, coverage metadata, and
+  this slice inventory. Validate all claims and examples against the exact
+  `release/3.8.0` source refs in Core, Studio, and Extensions.
+
+### Current run selection (2026-08-14)
+
+- The previous inventory completed `DOC-068` and left no named slices.
+- Release-source review found the distinct `DOC-069` gap: the Extensions
+  release ships Elasticsearch persistence for workflow instances and execution
+  logs, but no dedicated documentation explains how it composes with Elsa's
+  management/runtime features or which filters and index lifecycle behavior
+  are actually supported.
+- Presentation target: a task-oriented provider guide plus a short update to
+  the persistence comparison, with explicit production caveats rather than
+  implying Elasticsearch replaces every Elsa store.
+- Newly discovered follow-on: keep `DOC-070` available for the next inventory;
+  do not combine the runtime Agents activity contract with this persistence
+  slice.
+
+### Current run completion (2026-08-14)
+
+- Added `guides/persistence/examples/elasticsearch-setup.md`, linked it from
+  `SUMMARY.md`, updated the persistence provider comparison, and recorded the
+  guide in current coverage.
+- Documented the release-backed package and registration points, the two
+  supported stores, endpoint/authentication options, default and custom index
+  naming, index lifecycle responsibilities, Studio/server boundary, and
+  workflow-instance filter/timestamp limitations.
+- Self-review fixed two broken relative links, corrected the coverage count,
+  and added the companion-store durability warning. The final review found no
+  remaining factual, source-grounding, link, navigation, structure, regression,
+  or formatting high-priority issues.
+- `DOC-070` Runtime Agents activities and Studio administration is the next
+  available slice. No user input is required.
 
 ### Current run plan (2026-08-11)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -78,7 +78,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (29 pages)
+### GUIDES (30 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -95,6 +95,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **HTTP Endpoint Security** (`guides/security/http-endpoint-security.md`)
 - **Bookmark Resume Tokens** (`guides/security/bookmark-resume-tokens.md`)
 - **Secrets Management** (`guides/security/secrets-management.md`)
+- **Elasticsearch Setup** (`guides/persistence/examples/elasticsearch-setup.md`)
 - **Running Workflows** (`guides/running-workflows/README.md`)
 - **Dispatch Workflow Activity** (`guides/running-workflows/dispatch-workflow-activity.md`)
 - **Using a Trigger** (`guides/running-workflows/using-a-trigger.md`)
@@ -194,6 +195,8 @@ Based on the current structure, the following core concepts are documented:
 - ✅ Incidents and strategies
 - ✅ Monitoring and distributed tracing guidance
 - ✅ Runtime, persistence, and distributed-lock readiness guidance
+- ✅ Elasticsearch workflow-instance and execution-log persistence setup,
+  provider boundaries, index lifecycle, and release-backed limitations
 - ✅ Workflow-instance state, journal, activity-execution, and variable investigation guidance
 
 ### HTTP Workflows

--- a/guides/persistence/README.md
+++ b/guides/persistence/README.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Comprehensive guide to choosing, configuring, and tuning persistence providers
-  for Elsa Workflows v3, covering EF Core, MongoDB, and Dapper, along with
+  for Elsa Workflows v3, covering EF Core, MongoDB, Dapper, and Elasticsearch, along with
   retention, migrations, and operational best prac
 ---
 
@@ -11,7 +11,7 @@ description: >-
 
 Elsa Workflows uses persistence providers to store workflow definitions, workflow instances, bookmarks, and execution logs. Choosing the right persistence strategy is critical for performance, scalability, and operational requirements. This guide covers:
 
-* **Provider selection** — When to choose EF Core, MongoDB, or Dapper
+* **Provider selection** — When to choose EF Core, MongoDB, Dapper, or Elasticsearch
 * **Configuration patterns** — Connection strings, migrations, and store registration
 * **Indexing recommendations** — Essential indexes for common queries
 * **Retention & cleanup** — Managing completed workflows and bookmark cleanup
@@ -37,7 +37,8 @@ Elsa organizes persistence into logical stores, each responsible for a specific 
 
 ## Persistence Providers
 
-Elsa supports three primary persistence providers:
+Elsa supports several persistence providers. The provider is selected per
+store, so a deployment can combine providers when a specific workload needs it.
 
 ### Entity Framework Core (EF Core)
 
@@ -122,6 +123,20 @@ See [MongoDB Setup Example](examples/mongodb-setup.md) for configuration details
 * Scenarios requiring custom query optimization
 
 See [Dapper Setup Example](examples/dapper-setup.md) for configuration details.
+
+### Elasticsearch
+
+**Best for:** Deployments that already operate Elasticsearch and want
+workflow-instance and execution-log stores backed by Elasticsearch.
+
+**Important boundary:** The 3.8.0 extension does not replace every Elsa store.
+It wires `IWorkflowInstanceStore` and `IWorkflowExecutionLogStore`; configure
+workflow definitions, bookmarks, inbox messages, and other stores separately.
+The release store also has filter and timestamp-update limitations, so validate
+your operational queries before choosing it as the primary persistence path.
+
+See [Elasticsearch Setup Example](examples/elasticsearch-setup.md) for the
+registration, index, authentication, and deployment guidance.
 
 ## Configuration Patterns
 

--- a/guides/persistence/examples/elasticsearch-setup.md
+++ b/guides/persistence/examples/elasticsearch-setup.md
@@ -1,0 +1,237 @@
+---
+description: >-
+  Configure the Elsa 3.8.0 Elasticsearch extension for workflow-instance and
+  execution-log persistence, with its provider boundaries and production
+  caveats.
+---
+
+# Elasticsearch Setup Example
+
+Elsa 3.8.0 includes an `Elsa.Persistence.Elasticsearch` extension for teams
+that already operate Elasticsearch and want Elasticsearch-backed workflow
+instance and workflow execution-log stores. It is not a complete replacement
+for every Elsa persistence store: workflow definitions, bookmarks, inbox
+messages, activity execution records, and other stores remain backed by the
+provider you configure for them.
+
+## When to use it
+
+Choose Elasticsearch when:
+
+- your operations team already runs Elasticsearch and can manage its index,
+  mapping, security, and retention lifecycle;
+- workflow-instance and execution-log search are important workloads; and
+- you are comfortable validating the release implementation's filter and
+  update limitations before using it for production operations.
+
+Use [EF Core](efcore-setup.md), [MongoDB](mongodb-setup.md), or
+[Dapper](dapper-setup.md) when you need a provider guide for the broader Elsa
+management and runtime store set. A mixed setup is possible, but document the
+store ownership explicitly so operators know where each type of data lives.
+
+## Packages and endpoint
+
+Install the extension package that matches the rest of your Elsa 3.8.0 package
+set:
+
+```bash
+dotnet add package Elsa.Persistence.Elasticsearch --version 3.8.0
+```
+
+`ElasticsearchOptions.Endpoint` can be either an Elasticsearch URI or the name
+of a .NET connection string. The extension first looks up a connection string
+with that name and otherwise treats the value as the URI.
+
+For example:
+
+```json
+{
+  "ConnectionStrings": {
+    "Elasticsearch": "https://elasticsearch.example.com:9200"
+  },
+  "Elasticsearch": {
+    "ApiKey": "store-this-in-your-secret-provider"
+  }
+}
+```
+
+Prefer a secret manager, mounted configuration, or environment variables for
+credentials. The extension supports either an API key or a username/password
+pair. When both are supplied, the API key is selected.
+
+## Configure the stores
+
+The extension has three separate registration points:
+
+- `elsa.UseElasticsearch(...)` registers the shared Elasticsearch client and
+  connection options.
+- `management.UseElasticsearch()` replaces the workflow-instance store.
+- `runtime.UseElasticsearch()` replaces the workflow-execution-log store.
+
+Enable only the stores you intend to move. The following example enables both
+Elasticsearch stores while leaving the other Elsa stores with their existing
+configuration:
+
+```csharp
+using Elsa.Extensions;
+using Elsa.Persistence.Elasticsearch.Extensions;
+using Elsa.Persistence.Elasticsearch.Modules.Management;
+using Elsa.Persistence.Elasticsearch.Modules.Runtime;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseElasticsearch(options =>
+    {
+        // Resolves ConnectionStrings:Elasticsearch from configuration.
+        options.Endpoint = "Elasticsearch";
+        options.ApiKey = builder.Configuration["Elasticsearch:ApiKey"];
+    });
+
+    elsa.UseWorkflowManagement(management =>
+    {
+        // Workflow definitions are not replaced by this call.
+        management.UseElasticsearch();
+    });
+
+    elsa.UseWorkflowRuntime(runtime =>
+    {
+        runtime.UseElasticsearch();
+    });
+
+    elsa.UseWorkflowsApi();
+});
+
+var app = builder.Build();
+app.UseWorkflows();
+app.Run();
+```
+
+If you only want execution logs in Elasticsearch, omit the management call.
+If you only want workflow instances there, omit the runtime call. Configure a
+definition store and the remaining runtime stores separately, using the
+[persistence overview](../README.md) to choose an approach.
+
+This snippet is intentionally focused on the Elasticsearch registrations; it
+does not by itself make every Elsa store durable. Treat the companion-store
+configuration as part of your production persistence design.
+
+## Indexes and naming
+
+The default index name is the dasherized simple document type name:
+
+| Elsa document | Default index |
+| --- | --- |
+| `WorkflowInstance` | `workflow-instance` |
+| `WorkflowExecutionLogRecord` | `workflow-execution-log-record` |
+
+Override names in the shared options when your deployment uses a naming
+standard or separate indices:
+
+```csharp
+using Elsa.Persistence.Elasticsearch.Options;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Runtime.Entities;
+
+elsa.UseElasticsearch(options =>
+{
+    options.Endpoint = "Elasticsearch";
+    options.IndexNameMappings[typeof(WorkflowInstance)] = "elsa-workflow-instances";
+    options.IndexNameMappings[typeof(WorkflowExecutionLogRecord)] = "elsa-execution-logs";
+});
+```
+
+The release configures a flattened mapping for
+`WorkflowInstance.WorkflowState.Properties`. Treat index mappings as a
+deployment concern: create and review them before sending production data,
+and keep index naming/mapping changes compatible with your rollover and
+retention policy.
+
+## Index lifecycle and deployment checks
+
+The release source contains a `ConfigureClientAsync` hook that can create the
+workflow-instance index, but the 3.8.0 source tree contains no caller for that
+hook. Do not assume that registering the package provisions indices or applies
+your production mappings. Before starting Elsa, verify the following in the
+target cluster:
+
+1. The endpoint resolves from the deployed configuration.
+2. The Elsa identity has permission to read, write, search, and delete the
+   selected indices as required by your operations.
+3. The expected indices exist with reviewed mappings, or your cluster's
+   auto-create policy is an intentional part of the deployment.
+4. Index templates, rollover, snapshots, and retention are owned by the same
+   operational process that owns the Elasticsearch cluster.
+5. A test workflow can be created, queried, updated, and deleted before the
+   provider is used for production workloads.
+
+The extension does not configure Elasticsearch retention, rollover, snapshots,
+or cluster availability. Use the Elasticsearch operational controls approved
+by your organization.
+
+## Release-backed limits to test
+
+The Elasticsearch workflow-instance store in 3.8.0 does not implement every
+`WorkflowInstanceFilter` option. Its source handles the singular identity,
+version, correlation, status, sub-status, and search-term fields, while
+collection-based ID filters and parent-instance filters remain TODO. The
+store's `UpdateUpdatedTimestampAsync` method also throws
+`NotImplementedException`. Avoid assuming that every Elsa feature that uses a
+workflow-instance filter or timestamp-only update has the same behavior as an
+EF Core or MongoDB store.
+
+The execution-log store supports filtering by workflow instance ID, activity
+ID, and event name. Other log-query requirements should be verified against
+the API and the release source before you promise them to operators.
+
+## Troubleshooting
+
+### Elsa cannot connect
+
+- Confirm that `Endpoint` is either a valid absolute URI or the exact
+  `ConnectionStrings` key.
+- Confirm TLS, DNS, firewall, and cluster health from the Elsa host.
+- Confirm that the deployed API key or username/password has not been placed
+  in source control and is accepted by the cluster.
+
+### Documents are rejected or searches return unexpected results
+
+- Inspect the actual index name after applying `IndexNameMappings`.
+- Compare the index mapping with the workflow-instance state and execution
+  log documents emitted by your application.
+- Check that the request uses a filter supported by the release store; a
+  different persistence provider may support a broader filter set.
+
+### Studio shows incomplete data
+
+The release Studio source has no Elasticsearch provider reference. Studio
+consumes the Elsa API, so confirm that the server has the intended provider
+registration, all required companion stores, and the permissions needed by the
+Studio user. Elasticsearch configuration belongs to the server deployment,
+not to the Studio browser package.
+
+## Release source
+
+The behavior described here is based on the `release/3.8.0` sources:
+
+- [`ModuleExtensions.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/release/3.8.0/src/modules/persistence/Elsa.Persistence.Elasticsearch/Extensions/ModuleExtensions.cs)
+  and [`ElasticsearchFeature.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/release/3.8.0/src/modules/persistence/Elsa.Persistence.Elasticsearch/Features/ElasticsearchFeature.cs)
+  define endpoint, authentication, and client setup.
+- [`ElasticWorkflowInstanceFeature.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/release/3.8.0/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/ElasticWorkflowInstanceFeature.cs)
+  and [`WorkflowInstanceStore.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/release/3.8.0/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs)
+  define the workflow-instance store and its filter behavior.
+- [`ElasticExecutionLogRecordFeature.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/release/3.8.0/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Runtime/ElasticExecutionLogRecordFeature.cs)
+  and [`WorkflowExecutionLogStore.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/release/3.8.0/src/modules/persistence/Elsa.Persistence.Elasticsearch/Modules/Runtime/WorkflowExecutionLogStore.cs)
+  define the execution-log store.
+- Core's [`WorkflowManagementFeature`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs)
+  and [`WorkflowRuntimeFeature`](https://github.com/elsa-workflows/elsa-core/blob/release/3.8.0/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs)
+  provide the management/runtime composition points.
+
+## Related guidance
+
+- [Persistence overview](../README.md)
+- [MongoDB setup](mongodb-setup.md)
+- [Dapper setup](dapper-setup.md)
+- [Investigate a workflow instance](../../../operate/workflow-state-and-journal.md)
+- [Monitoring and observability](../../../operate/monitoring-observability.md)


### PR DESCRIPTION
## Summary
- add a release-backed Elasticsearch persistence setup guide
- document store scope, configuration, index lifecycle, limitations, and Studio/server boundaries
- update persistence navigation, provider comparison, coverage, and the next-slice inventory

## Validation
- release-source assertions against Core `c58fe8770ff7ba39be74b58cd4b1e6017ee5e140`, Studio `d25f0aae`, and Extensions `335a2649`
- repository-wide local-link check: 0 missing
- balanced Markdown fences and staged `git diff --check`
- cited release-source URLs: HTTP 200

Closes the DOC-069 documentation slice.