### PR TITLE
docs: add Agents runtime and Studio guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -94,6 +94,7 @@
   * [DropIns](guides/extensibility/dropins.md)
 * [Testing & Debugging Workflows](guides/testing-debugging.md)
 * [Weaver and AI Workflow Assistance](guides/ai-workflow-assistance.md)
+* [Agents Activities and Studio Administration](guides/ai-agents.md)
 * [Running Workflows](guides/running-workflows/README.md)
   * [Using Elsa Studio](guides/running-workflows/using-elsa-studio.md)
   * [Altering a Running Workflow Instance](guides/running-workflows/altering-workflow-instances.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -82,17 +82,16 @@ acceptance criterion below is already complete.
 - `DOC-067` Weaver and AI workflow assistance
 - `DOC-068` Workflow-definition labels
 - `DOC-069` Elasticsearch persistence provider
+- `DOC-070` Runtime Agents activities and Studio administration
 
 ### Available next slices
 
-- `DOC-070` Runtime Agents activities and Studio administration
+No named slice remains; the next run should re-inventory the documentation and
+the latest release source for a new gap.
 
 ### Recommended next slice
 
-`DOC-070` Runtime Agents activities and Studio administration. The release
-extension contains runtime agent activities, provider and skill APIs, agent
-persistence options, and an optional Studio administration module; this is
-separate from the Core/Weaver guidance in `DOC-067`.
+No recommended slice remains until the next source-backed inventory.
 
 ### Newly discovered slices
 
@@ -112,46 +111,40 @@ separate from the Core/Weaver guidance in `DOC-067`.
 
 ### Current run plan (2026-08-14)
 
-- Select and complete `DOC-069` Elasticsearch persistence provider from the
-  fresh `origin/main` worktree.
-- Add a concise setup and decision guide covering packages, endpoint and
-  authentication configuration, management/runtime registration, index naming,
-  supported stores, deployment/index lifecycle, limitations, and
-  troubleshooting.
-- Update persistence navigation, provider comparison, coverage metadata, and
-  this slice inventory. Validate all claims and examples against the exact
-  `release/3.8.0` source refs in Core, Studio, and Extensions.
+- Select and complete `DOC-070` Runtime Agents activities and Studio
+  administration from the fresh `origin/main` worktree.
+- Add a concise cross-persona guide covering runtime activities, registration
+  and invocation, persistence, API permissions, Studio setup, and
+  operational/security limits.
+- Update navigation, coverage metadata, and this slice inventory. Validate all
+  claims and examples against the exact `release/3.8.0` source refs in Core,
+  Studio, and Extensions.
 
 ### Current run selection (2026-08-14)
 
-- The previous inventory completed `DOC-068` and left no named slices.
-- Release-source review found the distinct `DOC-069` gap: the Extensions
-  release ships Elasticsearch persistence for workflow instances and execution
-  logs, but no dedicated documentation explains how it composes with Elsa's
-  management/runtime features or which filters and index lifecycle behavior
-  are actually supported.
-- Presentation target: a task-oriented provider guide plus a short update to
-  the persistence comparison, with explicit production caveats rather than
-  implying Elasticsearch replaces every Elsa store.
-- Newly discovered follow-on: keep `DOC-070` available for the next inventory;
-  do not combine the runtime Agents activity contract with this persistence
-  slice.
+- The previous inventory completed `DOC-069`; `DOC-070` is the remaining
+  named slice.
+- Release-source review confirms the distinct `DOC-070` gap: the Extensions
+  release ships runtime agent activities, provider and skill APIs, persistence
+  options, and an optional Studio administration module, but the GitBook has
+  no dedicated guide.
+- Presentation target: a task-oriented guide that starts with the runtime
+  contract, then explains host setup, Studio usage, API entry points, and
+  explicit security and operational limits.
+- No additional distinct source-backed topic was discovered before this run.
 
 ### Current run completion (2026-08-14)
 
-- Added `guides/persistence/examples/elasticsearch-setup.md`, linked it from
-  `SUMMARY.md`, updated the persistence provider comparison, and recorded the
-  guide in current coverage.
-- Documented the release-backed package and registration points, the two
-  supported stores, endpoint/authentication options, default and custom index
-  naming, index lifecycle responsibilities, Studio/server boundary, and
-  workflow-instance filter/timestamp limitations.
-- Self-review fixed two broken relative links, corrected the coverage count,
-  and added the companion-store durability warning. The final review found no
-  remaining factual, source-grounding, link, navigation, structure, regression,
-  or formatting high-priority issues.
-- `DOC-070` Runtime Agents activities and Studio administration is the next
-  available slice. No user input is required.
+- Added `guides/ai-agents.md`, linked it from `SUMMARY.md`, and updated the
+  coverage inventory.
+- Documented the compiled 3.8.0 Agents runtime, dynamic workflow activities,
+  provider registration, API routes and permissions, in-memory and EF Core
+  persistence, Studio administration, and security/operational boundaries.
+- Explicitly separated Agents from Weaver and avoided unreleased multi-agent
+  and automatic configuration APIs described by the extension README.
+- Self-review and release-source assertions found no remaining high-priority
+  factual, source-grounding, navigation, link, structure, regression, or
+  formatting issues. No additional distinct follow-on topic was discovered.
 
 ### Current run plan (2026-08-11)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -78,7 +78,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (30 pages)
+### GUIDES (31 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -103,6 +103,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Workflow Definition Version Lifecycle** (`guides/running-workflows/workflow-definition-lifecycle.md`)
 - **Using Elsa Studio** (`guides/running-workflows/using-elsa-studio.md`)
 - **Weaver and AI Workflow Assistance** (`guides/ai-workflow-assistance.md`)
+- **Agents Activities and Studio Administration** (`guides/ai-agents.md`)
 - **JavaScript IntelliSense Type Definitions** (`guides/studio/javascript-type-definition-providers.md`)
 - **Package Manifests for Extensions** (`guides/plugins-modules/package-manifests.md`)
 - **Community & Resources** (`guides/community-resources.md`)
@@ -238,6 +239,8 @@ Based on the current structure, the following core concepts are documented:
   persistence, permissions, and audit boundaries
 - ✅ Workflow-definition labels, Studio management, API assignment, filtering,
   persistence, and permission boundaries
+- ✅ Agents runtime activities, provider/API composition, persistence choices,
+  Studio administration, and security boundaries
 
 ### Expressions
 - ✅ C#, JavaScript, Python, Liquid

--- a/getting-started/architecture-overview.md
+++ b/getting-started/architecture-overview.md
@@ -1196,8 +1196,8 @@ This architecture guide is based on the following official Elsa sources:
 - Studio modules and extensibility
 
 **Official Documentation:**
-- [Getting Started Guides](../getting-started/)
-- [Application Types](../application-types/)
+- [Getting Started Guides](hello-world.md)
+- [Application Types](../application-types/elsa-server.md)
 - [Distributed Hosting](../hosting/distributed-hosting.md)
 - [Custom Activities](../extensibility/custom-activities.md)
 

--- a/guides/ai-agents.md
+++ b/guides/ai-agents.md
@@ -1,0 +1,296 @@
+---
+description: >-
+  Configure Elsa Agents, expose agent activities and APIs, and manage agents
+  from Elsa Studio.
+---
+
+# Agents activities and Studio administration
+
+Elsa Agents is an optional extension that turns configured AI agents into
+workflow activities and exposes an API and Studio module for managing them.
+It is separate from [Weaver and AI workflow assistance](ai-workflow-assistance.md):
+Weaver helps people inspect and shape workflows, while Agents execute an
+agent as part of an Elsa workflow or an HTTP request.
+
+This guide describes the contracts shipped in `release/3.8.0`. It focuses on
+the compiled extension behavior; some examples in the extension README and
+migration guide refer to types that are not present in this release.
+
+## When to use Agents
+
+Use Agents when a workflow needs a model-backed step with a stable input and
+output contract, for example classifying a request, extracting structured
+data, or drafting text for a later approval step. Use a normal activity or
+Weaver when the work must be deterministic, directly inspectable, or limited
+to workflow-authoring assistance.
+
+The released module provides:
+
+- one dynamically generated workflow activity for each configured agent;
+- Handlebars prompt rendering with named input variables;
+- optional JSON output conversion into the declared output type;
+- provider registration for OpenAI or Azure OpenAI chat completion; and
+- agent definition, skill discovery, and invocation APIs.
+
+The release does not provide a persisted chat conversation through the invoke
+endpoint. Each API invocation starts a new chat history. The workflow activity
+stores the model response in its `Output` value, while the API endpoint
+requires that the response content be valid JSON.
+
+## How the pieces fit
+
+The runtime has four distinct concerns:
+
+1. **Agent configuration** — `AgentsOptions` supplies agents in a host-managed
+   configuration, or `StoreKernelConfigProvider` reads definitions from the
+   agent store when persistence is enabled.
+2. **Model provider** — an `AgentsFeature` service descriptor configures a
+   Semantic Kernel chat-completion service for each agent invocation.
+3. **Workflow activity** — `AgentActivityProvider` creates a browsable,
+   synthetic-input activity descriptor for every agent. The activity invokes
+   `IAgentInvoker` and writes one `Output` value.
+4. **Management surface** — `UseAgentsApi` adds CRUD, skills, and invoke
+   endpoints. `AddAgentsModule` adds the corresponding remote clients and an
+   **Agents** menu entry to Studio.
+
+The main runtime entry point is [`UseAgents`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Agents/ModuleExtensions.cs),
+which installs the Core and activity features through
+[`AgentsFeature`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Agents/AgentsFeature.cs).
+
+## Install and configure a server
+
+Install the packages for the capabilities you use:
+
+- `Elsa.Agents` for the runtime and workflow activities;
+- `Elsa.Agents.OpenAI` or `Elsa.Agents.AzureOpenAI` for a chat-completion
+  provider;
+- `Elsa.Agents.Api` for agent management and invocation endpoints; and
+- `Elsa.Agents.Persistence.EFCore` plus one provider-specific package when
+  agent definitions must survive a restart.
+
+The provider packages expose `AddOpenAIChatCompletion` and
+`AddAzureOpenAIChatCompletion`. The release source does not expose the
+`UseOpenAI` method shown in the extension README.
+
+A minimal server composition using the persisted management path looks like
+this:
+
+```csharp
+services.AddElsa(elsa =>
+{
+    elsa.UseAgents(agents =>
+    {
+        agents.AddOpenAIChatCompletion(
+            modelId: "<model>",
+            apiKey: "<secret>");
+    });
+
+    elsa.UseAgentPersistence(persistence =>
+        persistence.UseEntityFrameworkCore(ef =>
+            ef.UseSqlServer(connectionString)));
+
+    elsa.UseAgentsApi();
+});
+```
+
+Use the corresponding `UsePostgreSql`, `UseMySql`, or `UseSqlite` extension
+from the provider package when needed. Apply the agent persistence migrations
+using the same EF Core deployment process as the rest of the host.
+
+`UseAgentsApi` depends on agent persistence. Persistence uses an in-memory
+store unless an EF Core (or another `IAgentStore`) implementation replaces
+it. The in-memory store is process-local and is suitable for development or
+tests, not a production deployment.
+
+### Configuration-only activities
+
+If the host only needs workflow activities and does not use the API or
+persistence, register `AgentsOptions` yourself. The release does not bind an
+`appsettings.json` `Agents` section automatically:
+
+```csharp
+services.Configure<AgentsOptions>(options =>
+{
+    options.Agents.Add(new AgentConfig
+    {
+        Name = "ClassifyRequest",
+        Description = "Classifies an incoming request",
+        PromptTemplate = "Classify this request: {{request}}",
+        InputVariables =
+        [
+            new InputVariableConfig
+            {
+                Name = "request",
+                Type = "string",
+                Description = "The request text"
+            }
+        ],
+        OutputVariable = new OutputVariableConfig
+        {
+            Type = "string",
+            Description = "The classification"
+        }
+    });
+});
+```
+
+When `UseAgentPersistence` is enabled, the persistence feature replaces the
+options-backed provider with `StoreKernelConfigProvider`. Create and update
+definitions through the API, Studio, or your own `IAgentStore`; adding an
+agent to `AgentsOptions` is not enough for persisted invocation.
+
+## Define an agent for a workflow
+
+An `AgentConfig` contains the agent name, prompt template, input variables,
+output variable, execution settings, and selected skills. The activity
+provider turns each input variable into a synthetic activity input and exposes
+the output as `Output`.
+
+In Studio, select the generated activity from the **Agents** category. Its
+activity type is generated from the agent name and optional function name, so
+renaming an agent can produce a different activity type. Prefer stable agent
+names once workflow definitions are published.
+
+The prompt is rendered as Handlebars. Inputs are inserted into the prompt,
+then the agent is invoked with automatic function-choice behavior. Treat
+workflow inputs as untrusted model input: validate data before invocation and
+do not put secrets into prompts.
+
+Set `ExecutionSettings.ResponseFormat` to `json_object` when the next
+activity needs structured output or when the agent will be invoked through the
+API. The runtime adds a JSON-only system message, removes code fences for the
+workflow activity, and converts its response to the declared output type. If
+the declared output type is `object`, a JSON response is deserialized as an
+`ExpandoObject`; invalid or unexpected model output still fails at runtime, so
+validate it before making business decisions. The API endpoint deserializes
+the response directly as JSON and does not remove code fences.
+
+The activity is marked asynchronous and returns one output. It does not
+persist the `ChatHistory` used internally by the invoker. If a process needs
+human review, durable state, or repeatable compensation, put those concerns in
+ordinary workflow activities around the agent step.
+
+## Manage agents through the API
+
+Enable `UseAgentsApi()` on the server and use the authenticated backend from
+Studio or another client. The release routes and permission claims are:
+
+- `GET /ai/agents` and `GET /ai/agents/{id}` — `ai/agents:read`;
+- `POST /ai/agents` and `POST /ai/agents/{id}` — `ai/agents:write`;
+- `DELETE /ai/agents/{id}` and `POST /ai/bulk-actions/agents/delete` —
+  `ai/agents:delete`;
+- `POST /ai/actions/agents/generate-unique-name` — `ai/agents:write`;
+- `POST /ai/queries/agents/is-unique-name` — `ai/agents:read`;
+- `POST /ai/agents/{agent}/invoke` — `ai/agents:invoke`; and
+- `GET /ai/skills` — `ai/skills:read`.
+
+The invoke request contains an agent name and an `inputs` object. Configure the
+target agent with `ResponseFormat` set to `json_object`; otherwise the endpoint
+may reject a plain-text model response when it deserializes the result:
+
+```http
+POST /ai/agents/ClassifyRequest/invoke
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"inputs":{"request":"The customer cannot sign in."}}
+```
+
+The API returns the serialized JSON agent response and fails when the model
+returns content that is not valid JSON. It does not accept a chat history in
+this release. Protect `ai/agents:invoke` separately from configuration write
+permissions when callers should run agents but not edit their prompts or
+skills.
+
+Agent definitions inherit Elsa's entity and tenant model, but the agent
+filter itself only selects by ID or name. Do not use a globally unique name as
+your tenant boundary; configure authentication and tenancy for the host and
+test that every management and invocation route is isolated as intended.
+
+## Add Agents to Elsa Studio
+
+Register the optional Studio module in the same client that registers the
+authenticated remote backend. In the release WASM host, the Agents line comes
+after the standard shell, login, dashboard, and Workflows modules:
+
+```csharp
+builder.Services.AddCore();
+builder.Services.AddShell();
+builder.Services.AddRemoteBackend(backendApiConfig);
+builder.Services.AddLoginModule();
+builder.Services.UseElsaIdentity();
+builder.Services.AddDashboardModule();
+builder.Services.AddWorkflowsModule();
+builder.Services.AddAgentsModule(backendApiConfig);
+```
+
+`AddAgentsModule` registers the agent and skills API clients, the Agents
+activity display-settings provider, and a remote **Agents** menu item. The
+Studio feature is marked as remote `Elsa.AgentsApi`, so the server must expose
+the corresponding feature for the module to be useful. Studio does not hold
+provider credentials or invoke the model directly.
+
+The Agents page can list, create, edit, and delete definitions. The editor
+loads available skills from `GET /ai/skills`, lets a user define input and
+output variables, selects JSON response mode, and saves the definition through
+the API. After a persisted definition changes, the server refreshes its
+activity registry. Studio explicitly marks its local activity and
+display-settings registries stale after delete and bulk-delete; after create
+or update, reopen or refresh an already-open designer if it does not show the
+new activity.
+
+## Security and production checklist
+
+- Keep provider API keys in a secret provider. The release provider helpers
+  accept raw key strings; they do not create a secret-management boundary.
+- Grant `ai/agents:invoke` only to callers that may send data to the model.
+  Grant write/delete claims only to administrators or a controlled authoring
+  role.
+- Review every selected skill. The built-in skill registry includes image
+  generation and document-query skills, and custom skill providers can add
+  more model-callable functions.
+- Treat prompts and workflow inputs as data that can contain instructions.
+  The runtime enables Handlebars dangerous-content rendering and automatic
+  function choice, so add application-level validation and tool governance.
+- Use EF Core or another durable `IAgentStore` for production definitions and
+  apply its migrations. The default store loses definitions on process
+  restart.
+- Test tenant isolation, model failure, malformed JSON, timeouts, rate limits,
+  and provider outages before allowing an agent to make irreversible changes.
+
+## Troubleshooting
+
+**The Agents activity category is empty.** Confirm that `UseAgents()` is
+enabled, that at least one agent is available from the active configuration or
+store, and that the configured model provider is registered. With persistence,
+check the agent store rather than only `AgentsOptions`.
+
+**Studio has no Agents menu.** Confirm that the WASM host calls
+`AddAgentsModule(backendApiConfig)`, the backend URL and authentication are
+correct, and the server exposes `UseAgentsApi()`.
+
+**An invoke call is unauthorized.** Check the caller's `ai/agents:invoke`
+permission. Listing and editing agents use different claims.
+
+**The API invoke response cannot be deserialized.** Set the stored agent's
+`ResponseFormat` to `json_object`, and instruct the model to return one JSON
+object without code fences. The API path does not accept plain text; diagnose
+workflow activity failures through the workflow journal or host logs.
+
+**A changed definition is not visible in an open designer.** Reload the
+activity registry or reopen the designer after the definition notification has
+been processed.
+
+## Release-source references
+
+This page was checked against the requested `release/3.8.0` refs:
+
+- Core: [`c58fe877`](https://github.com/elsa-workflows/elsa-core/tree/c58fe8770ff7ba39be74b58cd4b1e6017ee5e140)
+- Studio: [`d25f0aae`](https://github.com/elsa-workflows/elsa-studio/tree/d25f0aaeb5f14af6c5938d173aae828d87ebad5c)
+- Extensions: [`335a2649`](https://github.com/elsa-workflows/elsa-extensions/tree/335a26495318f6ee1528bf2723b7333c753ce9a2)
+
+The most relevant implementations are [`AgentActivityProvider`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Agents.Activities/ActivityProviders/AgentActivityProvider.cs),
+[`AgentInvoker`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Agents.Core/Services/AgentInvoker.cs),
+[`AgentPersistenceFeature`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Agents.Persistence/Features/AgentPersistenceFeature.cs),
+[`Agents API endpoints`](https://github.com/elsa-workflows/elsa-extensions/tree/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Agents.Api/Endpoints),
+and [`AddAgentsModule`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Studio.Agents/Extensions/ServiceCollectionExtensions.cs).

--- a/guides/extensibility/custom-icons.md
+++ b/guides/extensibility/custom-icons.md
@@ -163,12 +163,12 @@ itself is generated dynamically or is not present in the activity picker.
 
 This page was checked against the following `release/3.8.0` implementations:
 
-- [Studio display settings contract](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsProvider.cs)
-- [Studio display settings model](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/UI/Models/ActivityDisplaySettings.cs)
-- [Studio display settings registry contract](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsRegistry.cs)
-- [Studio display settings registry](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultActivityDisplaySettingsRegistry.cs)
-- [Studio provider registration](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs)
-- [Studio tree activity picker](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs)
-- [Studio icon color handling](https://github.com/elsa-workflows/elsa-studio/blob/a067420e196245e0f5ecd755d318fa1de16364f2/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs)
-- [Core activity descriptor](https://github.com/elsa-workflows/elsa-core/blob/e59a0f172166efc24244f8fc49d8e8c33f05166b/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs)
+- [Studio display settings contract](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsProvider.cs)
+- [Studio display settings model](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows.Core/UI/Models/ActivityDisplaySettings.cs)
+- [Studio display settings registry contract](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows.Core/UI/Contracts/IActivityDisplaySettingsRegistry.cs)
+- [Studio display settings registry](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultActivityDisplaySettingsRegistry.cs)
+- [Studio provider registration](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs)
+- [Studio tree activity picker](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityPicker.razor.cs)
+- [Studio icon color handling](https://github.com/elsa-workflows/elsa-studio/blob/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules/Elsa.Studio.Workflows/ActivityPickers/Treeview/ActivityTreeItem.cs)
+- [Core activity descriptor](https://github.com/elsa-workflows/elsa-core/blob/c58fe8770ff7ba39be74b58cd4b1e6017ee5e140/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs)
 - [Extensions Agents provider example](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/agents/Elsa.Studio.Agents/UI/Providers/DefaultActivityDisplaySettingsProvider.cs)


### PR DESCRIPTION
## Summary

- add a release-backed guide for Elsa Agents workflow activities, API, persistence, and Studio administration
- document the compiled 3.8.0 contracts and explicitly separate Agents from Weaver
- refresh the slice inventory and fix stale/broken source/navigation links found during review

## Validation

- targeted Markdownlint for the new guide and SUMMARY.md
- repository-wide local-link and fenced-code checks
- exact release-source assertions for Core, Studio, and Extensions
- HTTP 200 checks for all cited release-source links
- git diff --check

Validated against Core `release/3.8.0` at `c58fe8770ff7ba39be74b58cd4b1e6017ee5e140`, Studio `release/3.8.0` at `d25f0aaeb5f14af6c5938d173aae828d87ebad5c`, and the local Extensions `release/3.8.0` snapshot at `335a26495318f6ee1528bf2723b7333c753ce9a2`.
