### PR TITLE
docs: add Proto.Actor workflow runtime guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -37,6 +37,7 @@
   * [Workflow Dispatch Outbox](guides/architecture/workflow-dispatch-outbox.md)
   * [Runtime Coordination Storage](guides/architecture/runtime-coordination-storage.md)
   * [Standalone and Modular Hosting](guides/architecture/standalone-and-modular-hosting.md)
+  * [Proto.Actor Workflow Runtime](guides/architecture/protoactor-workflow-runtime.md)
 * [Onboarding](guides/onboarding/README.md)
   * [Hosting Elsa in an Existing App](guides/onboarding/hosting-elsa-in-existing-app.md)
 * [Authentication & Authorization](guides/authentication/README.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-08-14)
+## Slice Inventory (2026-08-15)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -86,12 +86,13 @@ acceptance criterion below is already complete.
 
 ### Available next slices
 
-No named slice remains; the next run should re-inventory the documentation and
-the latest release source for a new gap.
+- `DOC-072` Studio activity port providers
+- `DOC-073` Connections extension and activity connection management
+- `DOC-074` Workflow-trigger OpenAPI exposure
 
 ### Recommended next slice
 
-No recommended slice remains until the next source-backed inventory.
+- `DOC-072` Studio activity port providers
 
 ### Newly discovered slices
 
@@ -108,30 +109,68 @@ No recommended slice remains until the next source-backed inventory.
   `Elsa.Studio.Agents`. This is distinct from the Core/Weaver guide in
   `DOC-067`; validate the compiled contracts rather than the extension README
   examples, which contain claims not present in the release source.
+- `DOC-071` ProtoActor workflow runtime and actor-cluster hosting —
+  `elsa-extensions` release `3.8.0` contains the
+  `Elsa.Workflows.Runtime.ProtoActor` and `Elsa.Actors.ProtoActor` modules.
+  The GitBook only mentions `ProtoActorWorkflowRuntime` in the distributed
+  hosting page; it does not explain `UseProtoActor`, cluster providers,
+  remote addressing, persistence, tenant propagation, or the release's
+  incomplete client methods.
+- `DOC-073` Connections extension and activity connection management —
+  `elsa-extensions` release `3.8.0` contains `Elsa.Connections.*`, including
+  connection descriptors, activity middleware, API endpoints, and in-memory
+  or EF Core stores. The GitBook has no focused guide explaining how an
+  activity declares a connection, how the runtime resolves it, or which
+  persistence and security boundaries apply.
+- `DOC-072` Studio activity port providers — `elsa-studio` release `3.8.0`
+  contains `IActivityPortProvider`, priority-based provider selection, and
+  built-in providers for dynamic outcomes, Switch, HTTP, and related
+  activities. Existing custom-activity guidance does not explain this
+  Studio-only dynamic port contract or how to author a custom provider.
+- `DOC-074` Workflow-trigger OpenAPI exposure — `elsa-extensions` release
+  `3.8.0` contains an opt-in `Elsa.Http.OpenApi` module that exports workflow
+  HTTP triggers to `/openapi.json` and `/documentation`. The workbench does
+  not enable it automatically, and the mapping/security boundary needs a
+  focused guide.
 
-### Current run plan (2026-08-14)
+### Current run plan (2026-08-15)
 
-- Select and complete `DOC-070` Runtime Agents activities and Studio
-  administration from the fresh `origin/main` worktree.
-- Add a concise cross-persona guide covering runtime activities, registration
-  and invocation, persistence, API permissions, Studio setup, and
-  operational/security limits.
+- Select and complete `DOC-071` ProtoActor workflow runtime and actor-cluster
+  hosting from the fresh `origin/main` worktree.
+- Add a concise architecture and operations guide covering the runtime
+  boundary, host registration, cluster provider and remote configuration,
+  persistence, tenant propagation, and release limitations.
 - Update navigation, coverage metadata, and this slice inventory. Validate all
   claims and examples against the exact `release/3.8.0` source refs in Core,
   Studio, and Extensions.
 
-### Current run selection (2026-08-14)
+### Current run selection (2026-08-15)
 
-- The previous inventory completed `DOC-069`; `DOC-070` is the remaining
-  named slice.
-- Release-source review confirms the distinct `DOC-070` gap: the Extensions
-  release ships runtime agent activities, provider and skill APIs, persistence
-  options, and an optional Studio administration module, but the GitBook has
-  no dedicated guide.
-- Presentation target: a task-oriented guide that starts with the runtime
-  contract, then explains host setup, Studio usage, API entry points, and
-  explicit security and operational limits.
-- No additional distinct source-backed topic was discovered before this run.
+- The previous inventory completed `DOC-070`; release-source review found two
+  new gaps, and `DOC-071` is selected because ProtoActor changes the workflow
+  runtime and cluster topology for architects and operators.
+- The Extensions release ships `UseProtoActor` on both the module and workflow
+  runtime features, a default in-memory cluster provider, configurable remote
+  addressing, optional actor persistence, and tenant-aware actor middleware.
+  The release client still throws `NotImplementedException` for delete and
+  instance-existence operations, so the guide must state that boundary.
+- Presentation target: a decision-oriented architecture guide with a minimal
+  host setup, production configuration checklist, and explicit limitations;
+  it should distinguish ProtoActor runtime coordination from workflow data
+  persistence, distributed locking, and MassTransit dispatch.
+
+### Current run completion (2026-08-15)
+
+- Added `guides/architecture/protoactor-workflow-runtime.md`, linked it from
+  `SUMMARY.md`, the architecture overview, and distributed-hosting guidance,
+  and updated current coverage.
+- Documented the release-backed `UseProtoActor` registrations, cluster and
+  remote configuration, default providers, actor versus workflow persistence,
+  tenant propagation, Studio boundary, and the unsupported 3.8.0 client
+  operations.
+- Delegated inventory also found Studio activity port providers, generic
+  connection-backed activities, and workflow-trigger OpenAPI exposure. These
+  are recorded as `DOC-072` through `DOC-074`; `DOC-072` is recommended next.
 
 ### Current run completion (2026-08-14)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -78,7 +78,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Packages** (`getting-started/packages.md`)
 - **Prerequisites** (`getting-started/prerequisites.md`)
 
-### GUIDES (31 pages)
+### GUIDES (32 pages)
 
 - **External Application Interaction** (`guides/external-application-interaction.md`)
 - **HTTP Workflows** (`guides/http-workflows/README.md`)
@@ -90,6 +90,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Standalone and Modular Hosting** (`guides/architecture/standalone-and-modular-hosting.md`)
 - **Workflow Dispatch Outbox** (`guides/architecture/workflow-dispatch-outbox.md`)
 - **Runtime Coordination Storage** (`guides/architecture/runtime-coordination-storage.md`)
+- **Proto.Actor Workflow Runtime** (`guides/architecture/protoactor-workflow-runtime.md`)
 - **Security & Hardening** (`guides/security/README.md`)
 - **Production Hardening** (`guides/security/production-hardening.md`)
 - **HTTP Endpoint Security** (`guides/security/http-endpoint-security.md`)
@@ -241,6 +242,8 @@ Based on the current structure, the following core concepts are documented:
   persistence, and permission boundaries
 - ✅ Agents runtime activities, provider/API composition, persistence choices,
   Studio administration, and security boundaries
+- ✅ Proto.Actor workflow runtime, actor-cluster hosting, separate persistence,
+  tenant propagation, and 3.8.0 client limitations
 
 ### Expressions
 - ✅ C#, JavaScript, Python, Liquid

--- a/guides/architecture/README.md
+++ b/guides/architecture/README.md
@@ -185,6 +185,11 @@ Elsa supports **multitenancy** - running multiple isolated tenants in a single d
 
 For detailed multitenancy setup, see the [Multitenancy Introduction](../../multitenancy/introduction.md) guide.
 
+For actor-based workflow coordination across hosts, see the
+[Proto.Actor Workflow Runtime](protoactor-workflow-runtime.md) guide. It
+documents the additional cluster, remote transport, actor persistence, and
+release-specific client limitations.
+
 ## System Architecture (Mindmap)
 
 Here's a textual representation of Elsa's core functionality and surrounding modules:

--- a/guides/architecture/protoactor-workflow-runtime.md
+++ b/guides/architecture/protoactor-workflow-runtime.md
@@ -1,0 +1,208 @@
+---
+description: >-
+  Configure the Elsa 3.8.0 Proto.Actor workflow runtime for actor-based
+  coordination across hosts, with explicit persistence and cluster boundaries.
+---
+
+# Proto.Actor workflow runtime
+
+Elsa 3.8.0 includes an optional workflow runtime backed by Proto.Actor. It
+routes workflow-instance commands to virtual actors in a Proto.Actor cluster.
+Use it when workflow execution needs actor-based routing across multiple
+processes or hosts. It is a runtime and coordination choice; it does not
+replace Elsa's workflow-definition, workflow-instance, execution-log, or
+distributed-lock providers.
+
+The implementation is shipped by the `Elsa.Workflows.Runtime.ProtoActor` and
+`Elsa.Actors.ProtoActor` modules in
+[`elsa-extensions` release/3.8.0](https://github.com/elsa-workflows/elsa-extensions/tree/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules).
+Elsa Studio has no Proto.Actor-specific module in the same release; Studio
+continues to use the server's normal HTTP API.
+
+## Decide whether to use it
+
+Choose Proto.Actor when:
+
+- a workflow instance should have a stable cluster address derived from its
+  instance ID;
+- several Elsa hosts must route commands through a cluster; or
+- you already operate Proto.Actor infrastructure and want Elsa workflow
+  coordination to use it.
+
+Use the regular local or distributed workflow runtime when you only need the
+runtime options described in the [distributed hosting guide](../../hosting/distributed-hosting.md)
+and do not need actor-based routing. Proto.Actor adds an actor cluster,
+remote transport, and a separate actor persistence provider to the deployment.
+
+## Register the runtime
+
+Install `Elsa.Workflows.Runtime.ProtoActor` and register both parts of the
+feature:
+
+1. `runtime.UseProtoActor()` selects `ProtoActorWorkflowRuntime` as the
+   `IWorkflowRuntime` implementation.
+2. `elsa.UseProtoActor(...)` installs the actor system, cluster, virtual actor
+   provider, remote transport, and actor persistence service.
+
+```csharp
+using Elsa.Extensions;
+using Microsoft.Data.Sqlite;
+using Proto.Persistence.Sqlite;
+
+builder.Services.AddElsa(elsa =>
+{
+    elsa.UseWorkflowRuntime(runtime => runtime.UseProtoActor());
+
+    // The extension's default is an in-memory Proto.Actor provider.
+    elsa.UseProtoActor(proto =>
+    {
+        proto.PersistenceProvider = _ =>
+            new SqliteProvider(new SqliteConnectionStringBuilder(
+                "Data Source=proto-actor.db"));
+    });
+});
+```
+
+The two registrations are intentionally separate. The runtime feature sets
+the workflow runtime implementation, while the actor feature creates the
+`ActorSystem` and registers the `Cluster`. The release source shows both
+extension methods in
+[`WorkflowRuntimeFeatureExtensions.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Extensions/WorkflowRuntimeFeatureExtensions.cs)
+and
+[`ProtoActorFeature`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/actors/Elsa.Actors.ProtoActor/Features/ProtoActorFeature.cs).
+
+### Development defaults
+
+If you omit the `PersistenceProvider`, the actor feature uses
+`InMemoryProvider`. If you omit the cluster provider and remote configuration,
+it uses Proto.Actor's in-memory test provider and binds remote transport to
+localhost. Those defaults are useful for a single-process development host;
+they are not a multi-node deployment configuration. They are defined in
+[`ProtoActorFeature`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/actors/Elsa.Actors.ProtoActor/Features/ProtoActorFeature.cs).
+
+## Configure a multi-host cluster
+
+Every host that participates in the cluster needs compatible cluster and
+remote-transport settings. Set a shared cluster name, select a real cluster
+provider, and advertise an address that the other hosts can reach:
+
+```csharp
+using Proto.Cluster.Kubernetes;
+using Proto.Remote;
+using Proto.Remote.GrpcNet;
+
+elsa.UseProtoActor(proto =>
+{
+    proto.ClusterName = "elsa-cluster";
+    proto.CreateClusterProvider = _ =>
+        new KubernetesProvider(new KubernetesProviderConfig());
+    proto.ConfigureRemoteConfig = _ =>
+        RemoteConfig.BindToAllInterfaces(
+            advertisedHost: Environment.GetEnvironmentVariable(
+                "POD_IP"));
+});
+```
+
+The Kubernetes provider and the advertised host pattern are the same approach
+used by the release workbench. In Kubernetes, supply the pod IP or another
+reachable address through deployment configuration; do not advertise
+`localhost` to other pods. See the workbench's
+[`ProtoActor` setup](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/workbench/Elsa.Server.Web/Program.cs#L552-L605)
+and the module's
+[`ProtoActorFeature`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/actors/Elsa.Actors.ProtoActor/Features/ProtoActorFeature.cs#L35-L145)
+for the release-backed extension points.
+
+`ClusterName`, the cluster-provider choice, remote addressing, and actor
+persistence are infrastructure settings. Keep them aligned across hosts and
+roll out changes as a cluster configuration change, not as a workflow
+definition change.
+
+## What is coordinated
+
+The runtime creates a `ProtoActorWorkflowClient` for each workflow instance.
+The client addresses a virtual actor named from the workflow instance ID, and
+the actor loads workflow state and the workflow graph before running or
+resuming it. The actor handles create, run, create-and-run, cancel, stop,
+delete, export, and import messages in the generated
+[`WorkflowInstance` protocol](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Proto/WorkflowInstance.proto).
+
+This does not make all Elsa services actor-based. Workflow state is still
+created and saved through `IWorkflowInstanceManager`, using the workflow
+management/runtime persistence configured for the host. The actor feature's
+`PersistenceProvider` is a separate Proto.Actor persistence service. Configure
+both deliberately when you need restart durability.
+
+The runtime implementation and the workflow actor are visible in
+[`ProtoActorWorkflowRuntime.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Services/ProtoActorWorkflowRuntime.cs),
+[`ProtoActorWorkflowClient.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Services/ProtoActorWorkflowClient.cs),
+and
+[`WorkflowInstance.cs`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Actors/WorkflowInstance.cs).
+
+### Keep related infrastructure separate
+
+- **Workflow persistence** stores definitions, instances, bookmarks, and
+  execution data. Configure it through the normal Elsa management/runtime
+  persistence APIs.
+- **Actor persistence** is supplied through `ProtoActorFeature.PersistenceProvider`
+  and belongs to the Proto.Actor infrastructure.
+- **Distributed locking** remains a runtime coordination concern. Review the
+  lock-provider guidance in [Distributed Hosting](../../hosting/distributed-hosting.md)
+  when other runtime components require a shared lock.
+- **MassTransit dispatch** and **Proto.Actor distributed caching** are separate
+  transports. The release workbench can enable Proto.Actor for distributed
+  cache invalidation independently of selecting it as the workflow runtime.
+
+## Tenant propagation
+
+When an Elsa tenant is active, the Proto.Actor workflow client adds the tenant
+ID to the actor message headers. Actor middleware reads that header, resolves
+the tenant, and creates a tenant scope before processing the message. This
+keeps the actor's Elsa services aligned with the tenant that initiated the
+operation.
+
+The propagation path is implemented in
+[`ProtoActorWorkflowClient`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Services/ProtoActorWorkflowClient.cs#L66-L100)
+and
+[`TenantScopeMiddleware`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/actors/Elsa.Actors.ProtoActor/Middleware/TenantScopeMiddleware.cs).
+Configure Elsa's tenant resolution before relying on this behavior, and test
+cross-tenant requests at the API boundary.
+
+## Release limitations
+
+The 3.8.0 client wrapper is not a complete replacement for every
+`IWorkflowClient` operation:
+
+- `DeleteAsync` throws `NotImplementedException` in
+  `ProtoActorWorkflowClient`.
+- `InstanceExistsAsync` also throws `NotImplementedException` in that client.
+- The actor protocol and actor implementation contain delete and
+  instance-existence messages, but the client wrapper does not yet call them.
+
+Do not build application logic that assumes those two client methods work when
+running the 3.8.0 Proto.Actor runtime. Use the supported API path for the
+operation or choose another runtime until the release changes. This limitation
+is visible in the release
+[`ProtoActorWorkflowClient`](https://github.com/elsa-workflows/elsa-extensions/blob/335a26495318f6ee1528bf2723b7333c753ce9a2/src/modules/runtimes/Elsa.Workflows.Runtime.ProtoActor/Services/ProtoActorWorkflowClient.cs#L52-L65).
+
+There is no Proto.Actor-specific Studio setting in the 3.8.0
+[Studio release source](https://github.com/elsa-workflows/elsa-studio/tree/d25f0aaeb5f14af6c5938d173aae828d87ebad5c/src/modules).
+Studio users should connect to the server normally; operators must configure
+and observe the server cluster and both persistence layers.
+
+## Production checklist
+
+Before enabling the runtime in production, verify:
+
+- all hosts use the same cluster name and compatible Proto.Actor package/module
+  versions;
+- the cluster provider can discover every host and remote addresses are
+  reachable from every host;
+- actor persistence is not left on the default in-memory provider when actor
+  restart durability is required;
+- Elsa workflow persistence is configured independently and tested for
+  workflow-state recovery;
+- tenant resolution is enabled and tenant-scoped commands are tested; and
+- application code does not depend on the unsupported 3.8.0 client methods.
+
+For general multi-node runtime, locking, caching, and scheduling guidance,
+continue with [Distributed Hosting](../../hosting/distributed-hosting.md).

--- a/hosting/distributed-hosting.md
+++ b/hosting/distributed-hosting.md
@@ -22,6 +22,10 @@ By default, Elsa uses the `LocalWorkflowRuntime`, which is not suitable for dist
 
 Both options ensure that workflow instances are executed in a synchronized manner, preventing multiple processes from acting on the same instance concurrently.
 
+For the release-specific Proto.Actor setup, including cluster discovery,
+remote addressing, tenant propagation, separate actor persistence, and the
+3.8.0 client limitations, see the [Proto.Actor workflow runtime guide](../guides/architecture/protoactor-workflow-runtime.md).
+
 To enable the **Distributed Workflow Runtime**, configure Elsa as follows:
 
 ```csharp


### PR DESCRIPTION
## Summary
- add a release-backed guide for the optional Proto.Actor workflow runtime
- document cluster, remote transport, tenant propagation, and separate persistence boundaries
- call out the 3.8.0 client limitations and link architecture/distributed-hosting navigation

## Validation
- release/3.8.0 source assertions across Core, Studio, and Extensions
- local link, SUMMARY target, fenced-code, and git diff checks
- 13 cited release-source URLs returned HTTP 200
- no local GitBook/Markdownlint/Vale/Lychee binaries are available
