### PR TITLE
docs: add Studio activity port provider guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -144,6 +144,7 @@
 ## Extensibility
 
 * [Custom Activities](extensibility/custom-activities.md)
+* [Activity Port Providers](guides/extensibility/activity-port-providers.md)
 * [Registering Custom Types](guides/extensibility/custom-types.md)
 * [Workflow Providers](guides/extensibility/workflow-providers.md)
 * [Activity Type Providers](guides/extensibility/activity-type-providers.md)

--- a/docs/meta/backlog.md
+++ b/docs/meta/backlog.md
@@ -4,7 +4,7 @@ This backlog is prioritized by user impact and frequency of complaints
 based on gap analysis from 161 issues across elsa-studio and
 elsa-gitbook.
 
-## Slice Inventory (2026-08-15)
+## Slice Inventory (2026-08-16)
 
 This inventory reflects the current GitBook contents before selecting the
 next automation slice. "Covered" means the repository now includes a
@@ -83,94 +83,77 @@ acceptance criterion below is already complete.
 - `DOC-068` Workflow-definition labels
 - `DOC-069` Elasticsearch persistence provider
 - `DOC-070` Runtime Agents activities and Studio administration
+- `DOC-071` Proto.Actor workflow runtime and actor-cluster hosting
+- `DOC-072` Studio activity port providers
 
 ### Available next slices
 
-- `DOC-072` Studio activity port providers
 - `DOC-073` Connections extension and activity connection management
 - `DOC-074` Workflow-trigger OpenAPI exposure
 
 ### Recommended next slice
 
-- `DOC-072` Studio activity port providers
+- `DOC-073` Connections extension and activity connection management
 
 ### Newly discovered slices
 
-- `DOC-069` Elasticsearch persistence provider — `elsa-extensions`
-  `release/3.8.0` contains `Elsa.Persistence.Elasticsearch`, including
-  `UseElasticsearch`, configurable endpoint/authentication/index naming, a
-  workflow-instance store, and an execution-log store. The source also leaves
-  important boundaries that the guide must state: not every runtime/management
-  store is replaced, several workflow-instance filters are TODO, and the
-  release source has no caller for the optional index-configuration hook.
-- `DOC-070` Runtime Agents activities and Studio administration —
-  `elsa-extensions` release `3.8.0` contains `Elsa.Agents.*` runtime activities,
-  provider registration, agent/skill APIs, persistence options, and
-  `Elsa.Studio.Agents`. This is distinct from the Core/Weaver guide in
-  `DOC-067`; validate the compiled contracts rather than the extension README
-  examples, which contain claims not present in the release source.
-- `DOC-071` ProtoActor workflow runtime and actor-cluster hosting —
-  `elsa-extensions` release `3.8.0` contains the
-  `Elsa.Workflows.Runtime.ProtoActor` and `Elsa.Actors.ProtoActor` modules.
-  The GitBook only mentions `ProtoActorWorkflowRuntime` in the distributed
-  hosting page; it does not explain `UseProtoActor`, cluster providers,
-  remote addressing, persistence, tenant propagation, or the release's
-  incomplete client methods.
 - `DOC-073` Connections extension and activity connection management —
   `elsa-extensions` release `3.8.0` contains `Elsa.Connections.*`, including
   connection descriptors, activity middleware, API endpoints, and in-memory
   or EF Core stores. The GitBook has no focused guide explaining how an
   activity declares a connection, how the runtime resolves it, or which
   persistence and security boundaries apply.
-- `DOC-072` Studio activity port providers — `elsa-studio` release `3.8.0`
-  contains `IActivityPortProvider`, priority-based provider selection, and
-  built-in providers for dynamic outcomes, Switch, HTTP, and related
-  activities. Existing custom-activity guidance does not explain this
-  Studio-only dynamic port contract or how to author a custom provider.
 - `DOC-074` Workflow-trigger OpenAPI exposure — `elsa-extensions` release
   `3.8.0` contains an opt-in `Elsa.Http.OpenApi` module that exports workflow
   HTTP triggers to `/openapi.json` and `/documentation`. The workbench does
   not enable it automatically, and the mapping/security boundary needs a
   focused guide.
 
-### Current run plan (2026-08-15)
+### Current run plan (2026-08-16)
 
-- Select and complete `DOC-071` ProtoActor workflow runtime and actor-cluster
-  hosting from the fresh `origin/main` worktree.
-- Add a concise architecture and operations guide covering the runtime
-  boundary, host registration, cluster provider and remote configuration,
-  persistence, tenant propagation, and release limitations.
+- Select and complete `DOC-072` Studio activity port providers from the fresh
+  `origin/main` worktree.
+- Add a concise Studio and extensibility guide covering provider selection,
+  dynamic and embedded ports, custom provider registration, and release
+  limitations.
 - Update navigation, coverage metadata, and this slice inventory. Validate all
   claims and examples against the exact `release/3.8.0` source refs in Core,
   Studio, and Extensions.
 
-### Current run selection (2026-08-15)
+### Current run selection (2026-08-16)
 
-- The previous inventory completed `DOC-070`; release-source review found two
-  new gaps, and `DOC-071` is selected because ProtoActor changes the workflow
-  runtime and cluster topology for architects and operators.
-- The Extensions release ships `UseProtoActor` on both the module and workflow
-  runtime features, a default in-memory cluster provider, configurable remote
-  addressing, optional actor persistence, and tenant-aware actor middleware.
-  The release client still throws `NotImplementedException` for delete and
-  instance-existence operations, so the guide must state that boundary.
-- Presentation target: a decision-oriented architecture guide with a minimal
-  host setup, production configuration checklist, and explicit limitations;
-  it should distinguish ProtoActor runtime coordination from workflow data
-  persistence, distributed locking, and MassTransit dispatch.
+- The previous inventory completed `DOC-071`; release-source review confirms
+  `DOC-072` as the next distinct gap, followed by generic Connections and
+  workflow-trigger OpenAPI export (`DOC-073` and `DOC-074`).
+- Studio release `3.8.0` selects one `IActivityPortProvider` by support and
+  priority, ships providers for dynamic outcomes, Switch, HTTP, and related
+  activities, and exposes `AddActivityPortProvider<T>` for custom providers.
+- Presentation target: a decision-oriented guide for Studio users and custom
+  activity authors with a minimal provider example, registration placement,
+  dynamic/embedded port guidance, and explicit Studio-only boundaries.
 
-### Current run completion (2026-08-15)
+### Current run completion (2026-08-16)
 
-- Added `guides/architecture/protoactor-workflow-runtime.md`, linked it from
-  `SUMMARY.md`, the architecture overview, and distributed-hosting guidance,
-  and updated current coverage.
-- Documented the release-backed `UseProtoActor` registrations, cluster and
-  remote configuration, default providers, actor versus workflow persistence,
-  tenant propagation, Studio boundary, and the unsupported 3.8.0 client
-  operations.
-- Delegated inventory also found Studio activity port providers, generic
-  connection-backed activities, and workflow-trigger OpenAPI exposure. These
-  are recorded as `DOC-072` through `DOC-074`; `DOC-072` is recommended next.
+- Added `guides/extensibility/activity-port-providers.md`, linked it from
+  `SUMMARY.md`, custom activities, and Studio customization guidance, and
+  updated current coverage.
+- Documented the release-backed Studio contract, priority selection and
+  descriptor fallback, built-in dynamic/embedded port providers, custom
+  provider registration, and the Studio/runtime boundary.
+- Validated Core `5fd3a074c950fd539a06ef5407a7ae9d879a3afc`, Studio
+  `bee3c1605fd2c5937fed3621b2860465a2f8c448`, and Extensions
+  `335a26495318f6ee1528bf2723b7333c753ce9a2` release refs. Core and
+  Extensions contain no activity-port provider contract; the relevant
+  implementation is Studio-only.
+- Self-review fixed an over-wide built-in-provider table and a non-self-
+  contained sample; final review found no remaining high-priority factual,
+  source-grounding, navigation, link, structure, regression, or formatting
+  issues.
+- Checks passed: release-source assertions, targeted Markdownlint, repository-
+  wide local-link validation, all `SUMMARY.md` targets, balanced fences,
+  source-link HTTP checks, and staged/working-tree `git diff --check`.
+- The next available slice is `DOC-073` Connections extension and activity
+  connection management; no additional distinct topic was found this run.
 
 ### Current run completion (2026-08-14)
 

--- a/docs/meta/current-coverage.md
+++ b/docs/meta/current-coverage.md
@@ -42,9 +42,10 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Liquid** (`expressions/liquid.md`)
 - **Python** (`expressions/python.md`)
 
-### EXTENSIBILITY (6 pages)
+### EXTENSIBILITY (7 pages)
 
 - **This topic covers extending Elsa with your own custom activities.** (`extensibility/custom-activities.md`)
+- **Activity Port Providers** (`guides/extensibility/activity-port-providers.md`)
 - **Registering Custom Types** (`guides/extensibility/custom-types.md`)
 - **Add custom Polly-based resilience strategies and retry diagnostics to Elsa 3.8.0 workflows.** (`guides/extensibility/custom-resilience-strategies.md`)
 - **Workflow Providers** (`guides/extensibility/workflow-providers.md`)
@@ -144,7 +145,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Introducing Elsa Workflows 3** (`README.md`)
 - **Table of contents** (`SUMMARY.md`)
 
-### STUDIO (9 pages)
+### STUDIO (10 pages)
 
 - **This section displays the available customization options for Elsa Studio.** (`studio/design/README.md`)
 - **Activity Pickers (3.7-preview)** (`studio/design/activity-pickers-3.7-preview.md`)
@@ -154,6 +155,7 @@ The documentation currently contains a broad set of markdown pages organized int
 - **Content Visualisers (3.6-preview)** (`studio/workflow-editor/content-visualisers-3.6-preview.md`)
 - **Field Extensions** (`studio/workflow-editor/field-extensions.md`)
 - **UI Hints** (`studio/workflow-editor/ui-hints.md`)
+- **Activity Port Providers** (`guides/extensibility/activity-port-providers.md`)
 - **Custom Activity Icons** (`guides/extensibility/custom-icons.md`)
 
 ## Key Concepts Documented
@@ -184,6 +186,7 @@ Based on the current structure, the following core concepts are documented:
 - ✅ External Authentication server extension contracts and Studio custom editors
 - ✅ JavaScript IntelliSense type-definition providers
 - ✅ Custom activity icons through Studio display-settings providers
+- ✅ Studio activity port providers for dynamic outcomes and embedded activities
 - ✅ Weaver AI workspace integration, grounded context, tool governance, and
   current proposal-review boundary
 - ✅ External Authentication adapters, policies, matchers, grant sources, and Studio editor extensibility

--- a/extensibility/custom-activities.md
+++ b/extensibility/custom-activities.md
@@ -131,6 +131,10 @@ For the built-in hints and how Studio resolves them, see
 To change how a custom activity appears in Studio's picker and designer, see
 [Custom Activity Icons](../guides/extensibility/custom-icons.md).
 
+If the activity has dynamic outcomes or embedded child activities, see
+[Activity Port Providers](../guides/extensibility/activity-port-providers.md)
+for the Studio-side port contract.
+
 ## Outputs
 
 You can expose additional outputs by declaring `Output<T>` properties and

--- a/guides/extensibility/activity-port-providers.md
+++ b/guides/extensibility/activity-port-providers.md
@@ -1,0 +1,263 @@
+---
+description: >-
+  Source-backed guide to Elsa Studio activity port providers in release 3.8.0,
+  including dynamic ports, embedded activities, provider selection, and custom
+  registration.
+---
+
+# Activity Port Providers
+
+Activity port providers control the ports that Elsa Studio renders around an
+activity in the workflow designer. Use them when an activity's connections or
+embedded child activities depend on its current JSON configuration rather than
+on a fixed list of ports in its activity descriptor.
+
+This is a Studio customization seam. It changes how a workflow is edited and
+how the designer reads or writes the activity JSON; it does not change the
+activity's runtime execution, outcomes, or server-side activity implementation.
+
+## When to use a provider
+
+Use an activity port provider when:
+
+- an activity exposes a variable number of flow outcomes, such as one port per
+  configured case or status code;
+- an activity contains child activities under a configuration-specific branch;
+  or
+- the ports declared by the server's activity descriptor are not enough for
+  the Studio designer.
+
+If the activity always has the same ports, declare those ports in the activity
+descriptor instead. Studio's fallback provider returns the descriptor's ports.
+
+## How Studio selects a provider
+
+The contract is `IActivityPortProvider` from the Studio Workflows Core module.
+Each provider receives a `PortProviderContext` containing:
+
+- `ActivityDescriptor`: the descriptor loaded from the Elsa backend;
+- `Activity`: the current activity as a mutable `JsonObject`.
+
+A provider implements these operations:
+
+- `Priority` determines which matching provider wins.
+- `GetSupportsActivityType` says whether the provider handles this descriptor
+  and JSON shape.
+- `GetPorts` returns the current `Port` objects shown by the designer.
+- `ResolvePort` finds the child activity currently assigned to a port.
+- `AssignPort` assigns a child activity to a port.
+- `ClearPort` removes a child activity from a port.
+
+For each activity, Studio filters providers whose support method returns
+`true`, then selects the one with the highest `Priority`. It uses that same
+provider to render ports and to navigate into, assign, or clear embedded
+activities. If no custom provider matches, the built-in
+`DefaultActivityPortProvider` handles the activity and returns the ports from
+the descriptor.
+
+The fallback provider has priority `-1000`; the normal base-class priority is
+`0`. A custom provider therefore wins over the fallback automatically. Set a
+higher priority when deliberately replacing another provider that also claims
+the activity type.
+
+## Port kinds
+
+The `Port` model distinguishes the two designer relationships most custom
+providers need:
+
+- `PortType.Flow` represents an outgoing workflow connection. The port does
+  not necessarily contain a child activity.
+- `PortType.Embedded` represents a child activity stored inside the current
+  activity, such as a `Switch` case branch.
+
+Use stable, unique port names. Studio uses the name to find the child activity
+and stores it in designer path segments, so changing a name can make existing
+embedded paths or connections difficult to reopen.
+
+## Built-in providers in release 3.8.0
+
+`AddWorkflowsModule()` registers the default provider module automatically.
+The released module adds providers for these cases:
+
+- `DynamicOutcomesPortProvider` supports an input with the
+  `dynamic-outcomes` UI hint. It returns flow ports from the configured
+  outcome expression and any fixed outcomes.
+- `SwitchPortProvider` supports `Elsa.Switch`. It returns embedded ports from
+  case labels and adds a `Default` port when one is absent.
+- `FlowSwitchPortProvider` supports `Elsa.FlowSwitch`. It returns flow ports
+  from case labels and adds a `Default` port when one is absent.
+- `HttpEndpointPortProvider` supports `Elsa.HttpEndpoint`. It returns `Done`
+  and enabled error outcomes such as request-too-large or invalid MIME type.
+- `SendHttpRequestPortProvider` supports `Elsa.SendHttpRequest`. It returns
+  embedded ports for expected status codes, unmatched status, connection
+  failure, and timeout.
+- `FlowHttpRequestPortProvider` supports `Elsa.FlowSendHttpRequest` and
+  `Elsa.DownloadHttpFile`. It returns flow ports for expected status codes and
+  the unmatched, failure, timeout, and done outcomes.
+
+The exact labels are derived from the activity JSON. For example, changing a
+`Switch` case label changes the corresponding Studio port label; enabling an
+`HttpEndpoint` error outcome adds that port.
+
+## Author a custom provider
+
+The easiest starting point is `ActivityPortProviderBase`. Override
+`GetSupportsActivityType` and `GetPorts` for flow-only ports. For embedded
+ports, also override `ResolvePort`, `AssignPort`, and `ClearPort` so the port
+maps to the activity's actual JSON shape.
+
+The following provider supports an activity whose descriptor type name is
+`Acme.Approve` and whose JSON stores embedded branches as:
+
+```json
+{
+  "type": "Acme.Approve",
+  "branches": [
+    { "label": "Approved", "activity": null },
+    { "label": "Rejected", "activity": null }
+  ]
+}
+```
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Enums;
+using Elsa.Api.Client.Resources.ActivityDescriptors.Models;
+using Elsa.Studio.Workflows.Domain.Contexts;
+using Elsa.Studio.Workflows.Domain.Providers;
+
+public sealed class ApprovalPortProvider : ActivityPortProviderBase
+{
+    public override bool GetSupportsActivityType(PortProviderContext context) =>
+        context.ActivityDescriptor.TypeName == "Acme.Approve";
+
+    public override IEnumerable<Port> GetPorts(PortProviderContext context)
+    {
+        foreach (var branch in GetBranches(context.Activity))
+        {
+            var label = GetLabel(branch);
+            if (label is null)
+                continue;
+
+            yield return new Port
+            {
+                Name = label,
+                DisplayName = label,
+                Type = PortType.Embedded
+            };
+        }
+    }
+
+    public override JsonObject? ResolvePort(
+        string portName,
+        PortProviderContext context)
+    {
+        return GetBranches(context.Activity)
+            .FirstOrDefault(branch => GetLabel(branch) == portName)?["activity"]
+            ?.AsObject();
+    }
+
+    public override void AssignPort(
+        string portName,
+        JsonObject activity,
+        PortProviderContext context)
+    {
+        var branch = GetBranches(context.Activity)
+            .FirstOrDefault(branch => GetLabel(branch) == portName);
+
+        if (branch is not null)
+            branch["activity"] = activity;
+    }
+
+    public override void ClearPort(string portName, PortProviderContext context)
+    {
+        var branch = GetBranches(context.Activity)
+            .FirstOrDefault(branch => GetLabel(branch) == portName);
+
+        if (branch is not null)
+            branch["activity"] = null;
+    }
+
+    private static IEnumerable<JsonObject> GetBranches(JsonObject activity) =>
+        (activity["branches"] as JsonArray ?? new JsonArray())
+            .OfType<JsonObject>();
+
+    private static string? GetLabel(JsonObject branch) =>
+        branch["label"]?.GetValue<string>();
+}
+```
+
+If the provider only creates flow ports and never stores child activities,
+leave the base implementation of `ResolvePort`, `AssignPort`, and `ClearPort`
+in place only if its camel-cased property mapping matches your JSON. Otherwise,
+implement those methods explicitly or return no embedded ports.
+
+### Register it in the Studio host
+
+Register the provider after `AddWorkflowsModule()` in the Studio host that
+should use it:
+
+```csharp
+builder.Services.AddWorkflowsModule();
+builder.Services.AddActivityPortProvider<ApprovalPortProvider>();
+```
+
+`AddActivityPortProvider<T>()` registers the provider as a scoped
+`IActivityPortProvider`. The provider assembly must be referenced by the host.
+Use `builder.Services` in the Server and Custom Elements hosts, or `services`
+in the WASM host. Register it in each host where the custom designer behavior
+is required.
+
+You do not need to call `AddDefaultActivityPortProviders()` in a stock host:
+`AddWorkflowsModule()` calls it and also registers the descriptor fallback.
+Call the default-provider extension directly only when composing a lower-level
+custom module instead of the released workflows module.
+
+## Design and troubleshooting checklist
+
+- Confirm the provider's `TypeName` matches the activity descriptor returned by
+  the backend, including the activity version behavior your host uses.
+- Inspect the activity JSON property names and casing. Port names are designer
+  identifiers; JSON property names are your storage contract.
+- Keep port names stable and unique within one activity.
+- Use `Flow` for ordinary outgoing connections and `Embedded` only when the
+  activity owns the child activity JSON.
+- Give a provider a higher priority if another provider claims the same
+  activity type and should remain available as a fallback.
+- Reopen the activity after changing its configuration. Providers are queried
+  from the current descriptor and JSON, so a changed case list or expected
+  status-code list can change the visible ports.
+- If Studio reports that no port provider is found, verify that the workflows
+  module is registered and that the provider assembly is loaded into the host.
+
+## Boundary with runtime behavior
+
+Activity port providers live in `elsa-studio`. They are not an Elsa Server
+activity provider, a workflow runtime extension, or a replacement for runtime
+outcome logic. The activity still needs to implement the corresponding runtime
+behavior, and its descriptor still needs to expose the metadata Studio uses to
+load the activity.
+
+This distinction matters when deploying a custom activity: installing the
+provider in Studio changes the editing experience, but every execution host
+that runs the workflow must still reference and register the activity's server
+or extension module.
+
+## Release source
+
+The contract and selection behavior are implemented in the
+[Studio `IActivityPortProvider` contract](https://github.com/elsa-workflows/elsa-studio/blob/bee3c1605fd2c5937fed3621b2860465a2f8c448/src/modules/Elsa.Studio.Workflows.Core/Domain/Contracts/IActivityPortProvider.cs),
+[provider selection service](https://github.com/elsa-workflows/elsa-studio/blob/bee3c1605fd2c5937fed3621b2860465a2f8c448/src/modules/Elsa.Studio.Workflows.Core/Domain/Services/DefaultActivityPortService.cs),
+and [registration extensions](https://github.com/elsa-workflows/elsa-studio/blob/bee3c1605fd2c5937fed3621b2860465a2f8c448/src/modules/Elsa.Studio.Workflows.Core/Extensions/ServiceCollectionExtensions.cs).
+The built-in registrations are in the
+[activity port provider module](https://github.com/elsa-workflows/elsa-studio/blob/bee3c1605fd2c5937fed3621b2860465a2f8c448/src/modules/Elsa.Studio.ActivityPortProviders/Extensions/ServiceCollectionExtensions.cs),
+and the stock workflows host composes them through
+[`AddWorkflowsModule`](https://github.com/elsa-workflows/elsa-studio/blob/bee3c1605fd2c5937fed3621b2860465a2f8c448/src/modules/Elsa.Studio.Workflows/Extensions/ServiceCollectionExtensions.cs).
+
+## Related guides
+
+- [Custom Activities](../../extensibility/custom-activities.md)
+- [Customizing Elsa Studio](../studio/customization.md)
+- [UI Hints](../../studio/workflow-editor/ui-hints.md)

--- a/guides/studio/customization.md
+++ b/guides/studio/customization.md
@@ -32,6 +32,7 @@ injection and feature modules.
 | Add panels, tabs, or editor widgets | `IWidget` or `IWidgetRegistry` | `DefaultWidgetRegistry` |
 | Change the workflow activity picker | Replace `IActivityPickerComponentProvider` | workflows module plus host override |
 | Add icons for custom activities | `IActivityDisplaySettingsProvider` | `AddActivityDisplaySettingsProvider<T>` |
+| Add activity ports | `IActivityPortProvider` | `AddActivityPortProvider<T>` |
 | Render a new input editor | Studio `IUIHintHandler` plus backend `UIHint` metadata | `AddDefaultUIHintHandlers`, `ActivityDescriber` |
 | Decorate an existing input editor | `IUIFieldExtensionHandler` | `FieldExtension.razor` |
 
@@ -175,6 +176,9 @@ The server host replaces it with
 
 If you need a different activity browsing experience, replace
 `IActivityPickerComponentProvider` in your host.
+
+For dynamic outcomes or embedded child activities, use an
+`IActivityPortProvider`; see [Activity Port Providers](../extensibility/activity-port-providers.md).
 
 ### Input Editors
 


### PR DESCRIPTION
## Summary

- document Elsa Studio's `IActivityPortProvider` contract and priority selection
- explain built-in dynamic and embedded port providers in release 3.8.0
- add a custom provider example, registration guidance, and Studio/runtime boundary
- update navigation, coverage, and the slice inventory

## Validation

- targeted Markdownlint: passed
- repository-wide local links: 0 missing
- SUMMARY targets: 0 missing
- fenced-code balance: passed
- release-source assertions and source-link HTTP checks: passed
- staged and working-tree `git diff --check`: passed

Validated against Core `5fd3a074`, Studio `bee3c160`, and Extensions `335a2649` on `release/3.8.0`.